### PR TITLE
Fix prop type of `href` and `to`

### DIFF
--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -1,7 +1,7 @@
 <template>
   <v-list-item
-    :to="isInternalLink(link) && link"
-    :href="!isInternalLink(link) && link"
+    :to="isInternalLink(link) ? link : ''"
+    :href="!isInternalLink(link) ? link : ''"
     router
     exact
   >


### PR DESCRIPTION
Fix prop type warning: `Invalid prop: type check failed for prop "href". Expected String, Object, got Boolean with value false.`