### PR TITLE
棒グラフカードのスタイル修正

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -55,6 +55,6 @@ $shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
 @mixin card-container {
   background-color: $white;
   box-shadow: $shadow;
-  border: 0.5px solid $gray-4;
+  border: 0.5px solid $gray-4 !important;
   border-radius: 4px;
 }

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -30,6 +30,7 @@ export default {
 
 <style lang="scss">
 .DataSelector {
+  margin-top: 2px;
   border: 1px solid $gray-4;
   background-color: $white;
   &-Button {

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -1,9 +1,13 @@
 <template>
-  <v-btn-toggle :value="value" @change="$emit('input', $event)">
-    <v-btn :value="'transition'">
+  <v-btn-toggle
+    :value="value"
+    class="DataSelector"
+    @change="$emit('input', $event)"
+  >
+    <v-btn v-ripple="false" :value="'transition'" class="DataSelector-Button">
       推移
     </v-btn>
-    <v-btn :value="'cummulative'">
+    <v-btn v-ripple="false" :value="'cummulative'" class="DataSelector-Button">
       累積
     </v-btn>
   </v-btn-toggle>
@@ -17,3 +21,27 @@ export default {
   props: ['value']
 }
 </script>
+
+<style lang="scss">
+.DataSelector {
+  border: 1px solid $gray-4;
+  background-color: $white;
+  &-Button {
+    border: none !important;
+    margin: 2px;
+    border-radius: 4px !important;
+    height: 24px !important;
+    font-size: 12px !important;
+    color: $gray-1 !important;
+    background-color: $white !important;
+    &::before {
+      background-color: inherit;
+    }
+  }
+
+  & .v-btn--active {
+    background-color: $gray-2 !important;
+    color: $white !important;
+  }
+}
+</style>

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -4,10 +4,10 @@
     class="DataSelector"
     @change="$emit('input', $event)"
   >
-    <v-btn v-ripple="false" :value="'transition'" class="DataSelector-Button">
+    <v-btn v-ripple="false" value="transition" class="DataSelector-Button">
       推移
     </v-btn>
-    <v-btn v-ripple="false" :value="'cummulative'" class="DataSelector-Button">
+    <v-btn v-ripple="false" value="cummulative" class="DataSelector-Button">
       累積
     </v-btn>
   </v-btn-toggle>
@@ -18,7 +18,13 @@
 <script>
 export default {
   name: 'DataSelector',
-  props: ['value']
+  props: {
+    value: {
+      type: String,
+      required: false,
+      default: ''
+    }
+  }
 }
 </script>
 

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,11 +1,12 @@
 <template>
   <v-card class="DataView">
     <v-toolbar flat class="DataView-Header">
-      <v-toolbar-title class="DataView-Title">
-        {{ title }}
-      </v-toolbar-title>
-      <v-spacer />
-      <slot name="button" />
+      <div class="DataView-TitleContainer">
+        <v-toolbar-title class="DataView-Title">
+          {{ title }}
+        </v-toolbar-title>
+        <slot name="button" />
+      </div>
     </v-toolbar>
     <v-card-text>
       <slot />
@@ -51,6 +52,10 @@ export default class DataView extends Vue {
   @include card-container();
   &-Header {
     background-color: transparent !important;
+    height: auto !important;
+  }
+  &-TitleContainer {
+    padding: 14px 0 8px;
   }
   &-Title {
     @include card-h2();
@@ -63,5 +68,8 @@ export default class DataView extends Vue {
     @include font-size(12);
     color: $gray-3 !important;
   }
+}
+.v-toolbar__content {
+  height: auto !important;
 }
 </style>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -10,7 +10,7 @@
     <v-card-text>
       <slot />
     </v-card-text>
-    <v-footer class="CardFooter">
+    <v-footer class="DataView-Footer">
       {{ lastUpdateDate | datetimeFormatter }} 更新
     </v-footer>
   </v-card>
@@ -54,6 +54,14 @@ export default class DataView extends Vue {
   }
   &-Title {
     @include card-h2();
+  }
+  &-Footer {
+    background-color: $white !important;
+    text-align: right;
+    margin: 2px 4px 12px;
+    flex-direction: row-reverse;
+    @include font-size(12);
+    color: $gray-3 !important;
   }
 }
 </style>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-card>
-    <v-toolbar flat class="CardHeader">
-      <v-toolbar-title class="CardTitle">
+  <v-card class="DataView">
+    <v-toolbar flat class="DataView-Header">
+      <v-toolbar-title class="DataView-Title">
         {{ title }}
       </v-toolbar-title>
       <v-spacer />
@@ -45,3 +45,15 @@ export default class DataView extends Vue {
   @Prop() private lastUpdateDate!: Date
 }
 </script>
+
+<style lang="scss">
+.DataView {
+  @include card-container();
+  &-Header {
+    background-color: transparent !important;
+  }
+  &-Title {
+    @include card-h2();
+  }
+}
+</style>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-data="displayData" :options="chartOption" />
+    <bar :chart-data="displayData" :options="chartOption" :height="240" />
   </data-view>
 </template>
 

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -16,9 +16,21 @@ import DataSelector from '@/components/DataSelector.vue'
 export default {
   components: { DataView, DataSelector },
   props: {
-    title: String,
-    chartData: Array,
-    chartOption: Object
+    title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    chartData: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    chartOption: {
+      type: Object,
+      required: false,
+      default: () => {}
+    }
   },
   data() {
     return {
@@ -38,8 +50,8 @@ export default {
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: 'green',
-              borderWidth: 1
+              backgroundColor: '#00B849',
+              borderWidth: 0
             }
           ]
         }
@@ -54,8 +66,8 @@ export default {
             data: this.chartData.map(d => {
               return d.cummulative
             }),
-            backgroundColor: 'green',
-            borderWidth: 1
+            backgroundColor: '#00B849',
+            borderWidth: 0
           }
         ]
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,9 +27,9 @@
       </v-col>
       <v-col xs12 sm6 md4>
         <time-bar-chart
-          :title="'コールセンター相談件数'"
+          title="コールセンター相談件数"
           :chart-data="contacts"
-          :chart-option="{}"
+          :chart-option="option"
         />
       </v-col>
       <v-col xs12 sm6 md4>
@@ -118,6 +118,42 @@ export default {
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
         title: '最新感染動向'
+      },
+      option: {
+        responsive: true,
+        legend: {
+          display: false
+        },
+        scales: {
+          xAxes: [
+            {
+              stacked: true,
+              gridLines: {
+                display: false
+              },
+              ticks: {
+                fontSize: 10,
+                maxTicksLimit: 20,
+                fontColor: '#808080'
+              }
+            }
+          ],
+          yAxes: [
+            {
+              location: 'bottom',
+              stacked: true,
+              gridLines: {
+                display: true,
+                color: '#E5E5E5'
+              },
+              ticks: {
+                suggestedMin: 0,
+                maxTicksLimit: 8,
+                fontColor: '#808080'
+              }
+            }
+          ]
+        }
       }
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -44,8 +44,8 @@
 </template>
 
 <script>
-import PageHeader from '@/components/PageHeader.vue'
 import moment from 'moment'
+import PageHeader from '@/components/PageHeader.vue'
 import NumberDisplay from '@/components/NumberDisplay.vue'
 import { SHEET_URL } from '@/constants.js'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -62,14 +62,6 @@ export default {
     WhatsNew,
     StaticInfo,
     DataTable
-  },
-  data() {
-    return {
-      headerItem: {
-        icon: 'mdi-chart-timeline-variant',
-        title: '最新感染動向'
-      },
-    }
   },
   async asyncData({ $axios }) {
     const res =
@@ -120,6 +112,14 @@ export default {
       contacts
     }
     return data
+  },
+  data() {
+    return {
+      headerItem: {
+        icon: 'mdi-chart-timeline-variant',
+        title: '最新感染動向'
+      }
+    }
   }
 }
 </script>


### PR DESCRIPTION
## issue

- close https://github.com/tokyo-metropolitan-gov/covid19/issues/96

## 変更内容

- 棒グラフのデザインを適用しました。
- 棒グラフカードのスタイルを修正しました。

## スクリーンショット

<img width="462" alt="スクリーンショット 2020-03-02 1 54 54" src="https://user-images.githubusercontent.com/8067258/75629862-25741300-5c29-11ea-87af-b00ada1becb9.png">

レビューお願いします！ 🙏 