### PR TITLE
hover時にチラチラする現象を修正

### DIFF
--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -100,7 +100,7 @@ export default class ListItem extends Vue {
     &:hover {
       color: transparent !important;
       & .ListItem-Text {
-        font-weight: 600;
+        font-weight: bold;
       }
       & .ListItem-Icon {
         color: $gray-1 !important;


### PR DESCRIPTION
close #118 

`font-weight` が数値だったのを `bold` に修正したら解消されました。
