### PR TITLE
Feature/issue 155 whatsnew tapfield

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="whatsNewOuter">
-    <v-icon size="18">
+  <a class="whatsNewOuter" :href="url">
+    <v-icon size="18" class="whatsNewOuter-Icon">
       mdi-information
     </v-icon>
     <time class="time px-2">{{ date }}</time>
-    <a :href="url" class="link">{{ text }}</a>
-  </div>
+    <span class="link">{{ text }}</span>
+  </a>
 </template>
 
 <script>
@@ -38,11 +38,17 @@ export default {
   border-radius: 4px;
   padding: 0.7em 1em;
   @include font-size(14);
+  text-decoration: none;
+  &-Icon {
+    color: $gray-2 !important;
+  }
 }
 .link {
   @include text-link();
 }
 .time {
   flex: 0 0 auto;
+  color: $gray-1;
+  font-weight: bold;
 }
 </style>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="whatsNewOuter">
-    <v-icon size="18">mdi-information</v-icon>
+    <v-icon size="18">
+      mdi-information
+    </v-icon>
     <time class="time px-2">{{ date }}</time>
     <a :href="url" class="link">{{ text }}</a>
   </div>
@@ -8,7 +10,20 @@
 
 <script>
 export default {
-  props: ['date', 'url', 'text'],
+  props: {
+    date: {
+      type: String,
+      required: true
+    },
+    text: {
+      type: String,
+      required: true
+    },
+    url: {
+      type: String,
+      required: true
+    }
+  }
 }
 </script>
 


### PR DESCRIPTION
## issue

- close https://github.com/tokyo-metropolitan-gov/covid19/issues/155

## 変更内容

- 最新情報の表示領域全体をタップ可能にしました。
- 一部スタイルがデザインとずれていたので修正しました。

## スクリーンショット

<img width="992" alt="スクリーンショット 2020-03-02 23 03 25" src="https://user-images.githubusercontent.com/8067258/75683479-8ad40c80-5cda-11ea-8db2-db9287dba966.png">
