### PR TITLE
Feature/issue 153 table design

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -16,8 +16,6 @@
 </template>
 
 <style lang="scss">
-@import '../assets/variables';
-
 .cardTable {
   &.v-data-table {
     th {

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -13,9 +13,38 @@
   </data-view>
 </template>
 
-<style>
-  
-  
+<style lang="scss">
+@import '../assets/variables';
+.theme--light.v-data-table {
+  th {
+    padding: 8px 10px;
+    height: auto;
+    border-bottom: 1px solid $gray-4;
+    white-space: nowrap;
+    color: $gray-2;
+    font-size: 12px;
+  }
+  tbody {
+    tr {
+      color: $gray-1;
+      td {
+        padding: 8px 10px;
+        height: auto;
+        font-size: 12px;
+      }
+      &:nth-child(odd) {
+        td {
+          background: rgba($gray-4, 0.3);
+        }
+      }
+      &:not(:last-child) {
+        td:not(.v-data-table__mobile-row) {
+          border: none;
+        }
+      }
+    }
+  }
+}
 </style>
 
 <script>

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -9,37 +9,41 @@
       :items-per-page="-1"
       :hide-default-footer="true"
       :height="200"
+      class="cardTable"
     />
   </data-view>
 </template>
 
 <style lang="scss">
 @import '../assets/variables';
-.theme--light.v-data-table {
-  th {
-    padding: 8px 10px;
-    height: auto;
-    border-bottom: 1px solid $gray-4;
-    white-space: nowrap;
-    color: $gray-2;
-    font-size: 12px;
-  }
-  tbody {
-    tr {
-      color: $gray-1;
-      td {
-        padding: 8px 10px;
-        height: auto;
-        font-size: 12px;
-      }
-      &:nth-child(odd) {
+
+.cardTable {
+  &.v-data-table {
+    th {
+      padding: 8px 10px;
+      height: auto;
+      border-bottom: 1px solid $gray-4;
+      white-space: nowrap;
+      color: $gray-2;
+      font-size: 12px;
+    }
+    tbody {
+      tr {
+        color: $gray-1;
         td {
-          background: rgba($gray-4, 0.3);
+          padding: 8px 10px;
+          height: auto;
+          font-size: 12px;
         }
-      }
-      &:not(:last-child) {
-        td:not(.v-data-table__mobile-row) {
-          border: none;
+        &:nth-child(odd) {
+          td {
+            background: rgba($gray-4, 0.3);
+          }
+        }
+        &:not(:last-child) {
+          td:not(.v-data-table__mobile-row) {
+            border: none;
+          }
         }
       }
     }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -9,6 +9,7 @@
       :items-per-page="-1"
       :hide-default-footer="true"
       :height="200"
+      :fixed-header="true"
       class="cardTable"
     />
   </data-view>


### PR DESCRIPTION
## issue
- https://github.com/tokyo-metropolitan-gov/covid19/issues/153

## 対応内容
- table cssの変更

## プレビュー

### before

<img src="https://user-images.githubusercontent.com/1301149/75689295-4baab900-5ce4-11ea-8642-0d4ea83b4299.png" width="40%">

### after
<img src=https://user-images.githubusercontent.com/1301149/75689257-3b92d980-5ce4-11ea-9bcc-7ceae1f3f7f9.png width="40%">

## 備考
[data-tables](https://vuetifyjs.com/ja/components/data-tables) のドキュメントを見ていたのですが、結局ちょっとムリヤリcssを上書きしています。
もしもう少しスマートなやり方があればご指摘ください。