### PR TITLE
Featue/issue 166 fix text

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -73,7 +73,7 @@ export default {
       items: [
         {
           icon: 'mdi-chart-timeline-variant',
-          title: '都内の最新動向',
+          title: '都内の最新感染動向',
           link: '/'
         },
         {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -42,14 +42,6 @@
           :date="Data.contacts.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
-        <data-table
-          :title="'死亡者データ'"
-          :chart-data="fatalities"
-          :chart-option="{}"
-          :date="Data.patients.date"
-        />
-      </v-col>
     </v-row>
   </div>
 </template>
@@ -133,36 +125,12 @@ export default {
     patients.datasets.sort(function(a, b) {
       return a === b ? 0 : a < b ? 1 : -1
     })
-    // 死亡者数
-    const fatalities = {
-      headers: [
-        { text: '日付', value: '日付' },
-        { text: '居住地', value: '居住地' },
-        { text: '年代', value: '年代' },
-        { text: '性別', value: '性別' }
-      ],
-      datasets: []
-    }
-    Data.patients.data
-      .filter(patient => patient['備考'] === '死亡')
-      .forEach(d =>
-        fatalities.datasets.push({
-          日付: moment(d['リリース日']).format('MM/DD'),
-          居住地: d['居住地'],
-          年代: d['年代'],
-          性別: d['性別']
-        })
-      )
-    fatalities.datasets.sort(function(a, b) {
-      return a === b ? 0 : a < b ? 1 : -1
-    })
 
     const data = {
       Data,
       patients,
       patientsDataset,
       contacts,
-      fatalities,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
         title: '都内の最新感染動向',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
     <StaticInfo
       class="mb-4"
       :url="'/flow'"
-      :text="'自分の症状に不安や心配があればまずは電話相談をどうぞ'"
+      :text="'自分や家族の症状に不安や心配があればまずは電話相談をどうぞ'"
       :btn-text="'相談の手順を見る'"
     />
     <v-row>
@@ -36,7 +36,7 @@
       </v-col>
       <v-col xs12 sm6 md4>
         <time-bar-chart
-          title="コールセンター相談件数"
+          title="新型コロナコールセンター相談件数"
           :chart-data="contacts"
           :chart-option="option"
           :date="Data.contacts.date"
@@ -165,7 +165,7 @@ export default {
       fatalities,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
-        title: '最新感染動向',
+        title: '都内の最新感染動向',
         date: Data.lastUpdate
       },
       option: {


### PR DESCRIPTION
# issue
- https://github.com/tokyo-metropolitan-gov/covid19/issues/166

# 修正内容
- テキスト修正
  - `コールセンター相談件数` → `新型コロナコールセンター相談件数`
  - `自分の症状に不安や心配があればまずは電話相談をどうぞ` → `自分や家族の症状に不安や心配があればまずは電話相談をどうぞ`
  - `最新感染動向` → `都内の最新感染動向`
- 死亡者数表の削除