### PR TITLE
fix: カード周りのmargin/padding 修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="DataView">
+  <v-card class="DataView pa-1">
     <v-toolbar flat>
       <div class="DataView-TitleContainer">
         <v-toolbar-title>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,7 +13,7 @@
         :class="{open: isMobile && isNaviOpen}"
       />
       <div class="mainContainer">
-        <v-container class="px-4">
+        <v-container class="pa-0">
           <nuxt />
         </v-container>
       </div>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -12,8 +12,8 @@
         :isNaviOpen="isNaviOpen"
         :class="{open: isMobile && isNaviOpen}"
       />
-      <div class="mainContainer px-4">
-        <v-container>
+      <div class="mainContainer">
+        <v-container class="px-4">
           <nuxt />
         </v-container>
       </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,24 +1,26 @@
 <template>
-  <div>
+  <div class="MainPage">
     <page-header
       :icon="headerItem.icon"
       :title="headerItem.title"
       :date="headerItem.date"
     />
-    <whats-new
-      class="mb-4"
-      date="2020年2月29日"
-      url="#"
-      text="新型コロナウイルスに関連した患者の発生について（第37報）"
-    />
-    <StaticInfo
-      class="mb-4"
-      :url="'/flow'"
-      :text="'自分の症状に不安や心配があればまずは電話相談をどうぞ'"
-      :btn-text="'相談の手順を見る'"
-    />
-    <v-row class="ma-0">
-      <v-col xs12 sm6 md4 class="pa-0 pb-5">
+    <div class="InfoBanner">
+      <whats-new
+        date="2020年2月29日"
+        url="#"
+        text="新型コロナウイルスに関連した患者の発生について（第37報）"
+      />
+    </div>
+    <div class="InfoBanner">
+      <StaticInfo
+        :url="'/flow'"
+        :text="'自分の症状に不安や心配があればまずは電話相談をどうぞ'"
+        :btn-text="'相談の手順を見る'"
+      />
+    </div>
+    <v-row class="DataBlock">
+      <v-col xs12 sm6 md4 class="DataCard">
         <time-bar-chart
           title="陽性患者数"
           :chart-data="patientsDataset"
@@ -26,7 +28,7 @@
           :date="Data.patients.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4 class="pa-0 pb-5">
+      <v-col xs12 sm6 md4 class="DataCard">
         <data-table
           :title="'陽性患者の属性'"
           :chart-data="patients"
@@ -34,7 +36,7 @@
           :date="Data.patients.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4 class="pa-0 pb-5">
+      <v-col xs12 sm6 md4 class="DataCard">
         <time-bar-chart
           title="コールセンター相談件数"
           :chart-data="contacts"
@@ -42,7 +44,7 @@
           :date="Data.contacts.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4 class="pa-0 pb-5">
+      <v-col xs12 sm6 md4 class="DataCard">
         <data-table
           :title="'死亡者データ'"
           :chart-data="fatalities"
@@ -209,3 +211,19 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.MainPage {
+  padding: 0 10px;
+  .InfoBanner {
+    padding: 10px;
+  }
+  .DataBlock {
+    margin: 20px 0;
+    .DataCard {
+      margin-bottom: 20px;
+      padding: 0 10px;
+    }
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -17,8 +17,8 @@
       :text="'自分の症状に不安や心配があればまずは電話相談をどうぞ'"
       :btn-text="'相談の手順を見る'"
     />
-    <v-row>
-      <v-col xs12 sm6 md4>
+    <v-row class="ma-0">
+      <v-col xs12 sm6 md4 class="pa-0 pb-5">
         <time-bar-chart
           title="陽性患者数"
           :chart-data="patientsDataset"
@@ -26,7 +26,7 @@
           :date="Data.patients.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
+      <v-col xs12 sm6 md4 class="pa-0 pb-5">
         <data-table
           :title="'陽性患者の属性'"
           :chart-data="patients"
@@ -34,7 +34,7 @@
           :date="Data.patients.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
+      <v-col xs12 sm6 md4 class="pa-0 pb-5">
         <time-bar-chart
           title="コールセンター相談件数"
           :chart-data="contacts"
@@ -42,7 +42,7 @@
           :date="Data.contacts.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
+      <v-col xs12 sm6 md4 class="pa-0 pb-5">
         <data-table
           :title="'死亡者データ'"
           :chart-data="fatalities"


### PR DESCRIPTION
Fixed: #159 

## 概要
カード周りのmargin/paddingを修正しました。

## やったこと
- カードのpadding/margin修正 2b911d7 9c4ba87
Figmaを見たところ、それぞれmarginが10の倍数になっているようだったので、
端とカードの余白をそれぞれ20pxに、他もFigmaに合わせて10pxの倍数に修正しました。

- DataViewのpaddingを追加 9e609f8
Dataviewのカードでborderが消えていたので修正
<img src="https://user-images.githubusercontent.com/28728602/75693592-80217380-5cea-11ea-8feb-109a0a911fbb.png" width="250">

## 備考
初PRのため不備等多いかと思いますがよろしくお願いします 🙏 
Vuetifyなので4pxの倍数にするか迷いましたが、Figmaに合わせて10pxの倍数にしています。