### PR TITLE
fix margin & delete unused style

### DIFF
--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="header ma-4">
+  <div class="header mb-3">
     <h2 class="pageTitle">
       <v-icon size="40" class="mr-2">
         {{ icon }}

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,7 +13,7 @@
         :class="{open: isMobile && isNaviOpen}"
       />
       <div class="mainContainer">
-        <v-container class="pa-0">
+        <v-container class="px-4 py-8">
           <nuxt />
         </v-container>
       </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -69,7 +69,6 @@ export default {
 
 <style lang="scss">
 .About {
-  background-color: $gray-5;
   &-Heading {
     @include font-size(30);
     font-weight: normal;

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -36,9 +36,7 @@ export default {
 
 <style lang="scss">
 .Flow {
-  padding: 20px;
   margin-bottom: 20px;
-  background-color: $gray-5;
   &-Heading {
     display: flex;
     align-items: center;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -5,22 +5,18 @@
       :title="headerItem.title"
       :date="headerItem.date"
     />
-    <div class="InfoBanner">
-      <whats-new
-        class="mb-4"
-        date="2020年2月29日"
-        url="#"
-        text="新型コロナウイルスに関連した患者の発生について（第37報）"
-      />
-    </div>
-    <div class="InfoBanner">
-      <StaticInfo
-        class="mb-4"
-        :url="'/flow'"
-        :text="'自分や家族の症状に不安や心配があればまずは電話相談をどうぞ'"
-        :btn-text="'相談の手順を見る'"
-      />
-    </div>
+    <whats-new
+      class="mb-4"
+      date="2020年2月29日"
+      url="#"
+      text="新型コロナウイルスに関連した患者の発生について（第37報）"
+    />
+    <StaticInfo
+      class="mb-4"
+      :url="'/flow'"
+      :text="'自分や家族の症状に不安や心配があればまずは電話相談をどうぞ'"
+      :btn-text="'相談の手順を見る'"
+    />
     <v-row class="DataBlock">
       <v-col xs12 sm6 md4 class="DataCard">
         <time-bar-chart
@@ -46,7 +42,7 @@
           :date="Data.discharges.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
+      <v-col xs12 sm6 md4 class="DataCard">
         <data-table
           :title="'退院者の属性'"
           :chart-data="dischargesTable"
@@ -54,7 +50,7 @@
           :date="Data.discharges.date"
         />
       </v-col>
-      <v-col xs12 sm6 md4>
+      <v-col xs12 sm6 md4 class="DataCard">
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
           :chart-data="contactsGraph"
@@ -156,15 +152,10 @@ export default {
 
 <style lang="scss" scoped>
 .MainPage {
-  padding: 0 10px;
-  .InfoBanner {
-    padding: 10px;
-  }
   .DataBlock {
-    margin: 20px 0;
+    margin: 20px -12px;
     .DataCard {
       margin-bottom: 20px;
-      padding: 0 10px;
     }
   }
 }

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -38,7 +38,6 @@ export default {
 </script>
 <style lang="scss">
 .Parent {
-  background-color: $gray-5;
   &-Heading {
     @include font-size(30);
     font-weight: normal;

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -39,7 +39,6 @@ export default {
 </script>
 <style lang="scss">
 .Worker {
-  background-color: $gray-5;
   &-Heading {
     @include font-size(30);
     font-weight: normal;


### PR DESCRIPTION
## 📝 関連issue
close #187 
close #191 

## ⛏ 変更内容
- 各ページで設定されていたメインコンテンツのpaddingを、default.vueで統一しました。
- ページタイトルのマージンを合わせました。
- 各ページのbackground-colorの設定は不要なので削除しました。
