### PR TITLE
ボタンのstyleを調整

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -76,7 +76,7 @@ $small: 450;
   @if ($size == 'sm') {
     padding: 4px 8px;
   } @else {
-    padding: 8px 36px;
+    padding: 24px 36px;
   }
   @include font-size(14);
   display: inline-block;

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -80,8 +80,6 @@ export default {
     &-Button {
       @include button-text('md');
       margin: 12px auto 0;
-      height: 80px;
-      line-height: 60px;
       @include font-size(20);
       font-weight: 600;
       text-decoration: none;


### PR DESCRIPTION
## 📝 関連issue
- close #196 

## ⛏ 変更内容
- flowのページにおいて、ボタン内のテキストが折り返してもいいようにstyleを修正しました。
- button-textのmixinも調整したので、エラーページも影響受けています。

## 📸 スクリーンショット
![スクリーンショット 2020-03-03 9 33 25](https://user-images.githubusercontent.com/14883063/75731327-b08d0000-5d32-11ea-9a45-f3aa44aa5221.png)
![スクリーンショット 2020-03-03 9 33 47](https://user-images.githubusercontent.com/14883063/75731336-b84ca480-5d32-11ea-910b-7bb07fe4f00c.png)
