### PR TITLE
fixed issue #189

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 東京都公式 新型コロナウイルス対策サイト
+# 東京都 新型コロナウイルス感染症対策本部
 
-![東京都公式 新型コロナウイルス対策サイト](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)
+![東京都 新型コロナウイルス感染症対策本部](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)
 
 
 ## How to Contribute / 貢献の仕方

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -9,8 +9,8 @@
           <img src="/logo.svg" />
         </div>
         <h1 class="SideNavigation-Heading">
-          東京都公式
-          <br />新型コロナウイルス対策サイト
+          東京都
+          <br />新型コロナウイルス感染症対策本部
         </h1>
       </nuxt-link>
     </div>
@@ -102,6 +102,11 @@ export default {
           title: '公式発表',
           link:
             'https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html'
+        },
+        {
+          title: '【東京都主催等】中止又は延期するイベント・説明会等',
+          link:
+            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
         },
         {
           title: '東京都公式ホームページ',

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,20 +8,20 @@ module.exports = {
       prefix: 'og: http://ogp.me/ns#'
     },
     titleTemplate: '%s - ' + process.env.npm_package_name,
-    title: '東京都公式 新型コロナウイルス対策サイト',
+    title: '東京都 新型コロナウイルス感染症対策本部',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       {
         hid: 'description',
         name: 'description',
-        content: '東京都公式 新型コロナウイルス対策サイト'
+        content: '東京都 新型コロナウイルス感染症対策本部'
       },
-      { hid: 'og:site_name', property: 'og:site_name', content: '東京都公式 新型コロナウイルス対策サイト' },
+      { hid: 'og:site_name', property: 'og:site_name', content: '東京都 新型コロナウイルス感染症対策本部' },
       { hid: 'og:type', property: 'og:type', content: 'website' },
       { hid: 'og:url', property: 'og:url', content: 'https://stopcovid19.metro.tokyo.lg.jp' },
-      { hid: 'og:title', property: 'og:title', content: '東京都公式 新型コロナウイルス対策サイト' },
-      { hid: 'og:description', property: 'og:description', content: '東京都公式 新型コロナウイルス対策サイト' },
+      { hid: 'og:title', property: 'og:title', content: '東京都 新型コロナウイルス感染症対策本部' },
+      { hid: 'og:description', property: 'og:description', content: '東京都 新型コロナウイルス感染症対策本部' },
       { hid: 'og:image', property: 'og:image', content: 'https://stopcovid19.metro.tokyo.lg.jp/ogp.png' },
     ],
     link: [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "covid19",
   "version": "1.0.0",
-  "description": "東京都公式 新型コロナウイルス対策サイト",
+  "description": "東京都 新型コロナウイルス感染症対策本部",
   "author": "東京都",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## 📝 関連issue
- close #189 

## ⛏ 変更内容
- パッケージ内の文字を統一（東京都公式 新型コロナウイルス対策サイト → 東京都 新型コロナウイルス感染症対策本部）
- 中止又は延期するイベントへのリンク追加
※ 関さんからコメントもらっている「公式発表を削除するかどうか」については未対応な形で一旦PR出します