### PR TITLE
スマホ版メニューがスクロールしない不具合を修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -174,8 +174,6 @@ export default {
     margin: 12px 0;
   }
   &-Footer {
-    position: absolute;
-    bottom: 0;
     padding: 20px;
     background-color: $white;
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -12,7 +12,7 @@
         :isNaviOpen="isNaviOpen"
         :class="{open: isMobile && isNaviOpen}"
       />
-      <div class="mainContainer">
+      <div class="mainContainer" :class="{open: isMobile && isNaviOpen}">
         <v-container class="px-4 py-8">
           <nuxt />
         </v-container>
@@ -66,13 +66,17 @@ export default {
   flex: 0 1 200px;
 }
 .open {
+  overflow-x: hidden;
+  overflow-y: auto;
   height: 100vh;
 }
 .mainContainer {
   flex: 1 1 auto;
-  overflow-x: hidden;
-  overflow-y: auto;
-  height: 100vh;
+  @include largerThan(600) {
+    overflow-x: hidden;
+    overflow-y: auto;
+    height: 100vh;
+  }
 }
 .loader {
   height: 200px;


### PR DESCRIPTION
## 📝 関連issue
- close #219 

## ⛏ 変更内容
- メニューのコンテンツが増えたので、フッターのabsolute指定を削除しました。
