### PR TITLE
fix menu item overflow

### DIFF
--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -178,6 +178,6 @@ svg.isActive {
   font-size: 0.75rem;
 }
 .mobile {
-  font-size: 1.25rem;
+  font-size: 0.85rem;
 }
 </style>


### PR DESCRIPTION
## 📝 関連issue

- close #192 

## ⛏ 変更内容
モバイル時のメニューフォントサイズを小さくした。幅375で最長のメニューがちょうど見えるくらいに調整

## 📸 スクリーンショット
![image](https://user-images.githubusercontent.com/3675691/75759189-81997d00-5d78-11ea-9680-5be482f0c9d0.png)
