### PR TITLE
グラフの右上に任意の文字列を追加できるようにしました。

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,7 +1,7 @@
 <template>
-  <data-view :title="title" :date="date">
+  <data-view :title="title" :date="date" :info="info">
     <template v-slot:button>
-      {{ `${chartData.datasets.length} 人` }}
+      <span />
     </template>
     <v-data-table
       :headers="chartData.headers"
@@ -65,8 +65,13 @@ export default {
       default: () => {}
     },
     date: {
-      type:String,
+      type: String,
       default: ''
+    },
+    info: {
+        type: Object,
+        required: false,
+        default: () => {}
     }
   }
 }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -7,6 +7,15 @@
         </v-toolbar-title>
         <slot name="button" />
       </div>
+      <v-spacer />
+      <div v-if="info" class="DataView-DataInfo">
+        <span class="DataView-DataInfo-summary">
+
+          {{info.lText}}<small class="DataView-DataInfo-summary-unit">{{info.unit}}</small>
+        </span>
+        <br />
+        <small class="DataView-DataView-DataInfo-date">{{info.sText}}</small>
+      </div>
     </v-toolbar>
     <v-card-text class="DataView-CardText">
       <slot />
@@ -22,10 +31,29 @@ import { Component, Prop, Vue } from 'vue-property-decorator'
 export default class DataView extends Vue {
   @Prop() private title!: string
   @Prop() private date!: string
+  @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
 }
 </script>
 
 <style lang="scss">
+.DataView {
+  &-DataInfo {
+    &-summary {
+      font-family: Hiragino Sans;
+      font-style: normal;
+      font-size: 30px;
+      line-height: 30px;
+      &-unit {
+        font-size: 0.6em;
+      }
+    }
+    &-date {
+      font-size: 12px;
+      line-height: 12px;
+      color: #808080;
+    }
+  }
+}
 .DataView {
   @include card-container();
   height: 100%;
@@ -41,6 +69,7 @@ export default class DataView extends Vue {
   }
   &-CardText {
     margin-bottom: 46px;
+    margin-top: 20px;
   }
   &-Footer {
     background-color: $white !important;
@@ -52,6 +81,6 @@ export default class DataView extends Vue {
   }
 }
 .v-toolbar__content {
-  height: auto !important;
+  height: 80px !important;
 }
 </style>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date">
+  <data-view :title="title" :date="date" :info="info">
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
@@ -35,6 +35,11 @@ export default {
       type: String,
       required: true,
       default: ''
+    },
+    info: {
+      type: Object,
+      required: false,
+      default: () => {}
     }
   },
   data() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -24,6 +24,7 @@
           :chart-data="patientsGraph"
           :chart-option="option"
           :date="Data.lastUpdate"
+          :info="diffInfoOfPatients"
         />
       </v-col>
       <v-col xs12 sm6 md4 class="DataCard">
@@ -32,6 +33,7 @@
           :chart-data="patientsTable"
           :chart-option="{}"
           :date="Data.lastUpdate"
+          :info="sumInfoOfPatients"
         />
       </v-col>
 
@@ -81,6 +83,20 @@ export default {
       Data.patients.data.filter(patient => patient['備考'] === '死亡')
     )
 
+    const diffInfoOfPatients = {
+      lText:
+        '+' +
+        (patientsGraph[patientsGraph.length - 1].cummulative -
+          patientsGraph[patientsGraph.length - 2].cummulative),
+      sText: '前日比',
+      unit: '人'
+    }
+    const sumInfoOfPatients = {
+      lText: patientsGraph[patientsGraph.length-1].cummulative,
+      sText: patientsGraph[patientsGraph.length-1].label +'の累計',
+      unit: '人'
+    }
+
     const data = {
       Data,
       patientsTable,
@@ -88,6 +104,8 @@ export default {
       dischargesTable,
       dischargesGraph,
       contactsGraph,
+      diffInfoOfPatients,
+      sumInfoOfPatients,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',
         title: '都内の最新感染動向',


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #138 
- close #139 
- close #223 


## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- グラフ、データテーブルの右上に任意の文字を追加できるようにしました
- 前日比、累積を表示するようにしました
- 日付は簡単に取れたんですが曜日に変換するのが大変そうなのでとりあえず曜日なしです

## 📸 スクリーンショット

![スクリーンショット 2020-03-03 18 09 43](https://user-images.githubusercontent.com/13947046/75760503-bad2ec80-5d7a-11ea-842c-ea799119be58.png)
![スクリーンショット 2020-03-03 18 09 30](https://user-images.githubusercontent.com/13947046/75760622-e524aa00-5d7a-11ea-93f6-d670e7cf30f1.png)
