### PR TITLE
flowページタイトルにスタイルをあてる

### DIFF
--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -2,7 +2,7 @@
   <div class="Flow">
     <div class="Flow-Heading">
       <CovidIcon />
-      <h2>新型コロナウイルス感染症が心配なときに</h2>
+      <h2 class="Flow-Heading-Title">新型コロナウイルス感染症が心配なときに</h2>
     </div>
     <div class="Flow-Card">
       <h2>
@@ -143,11 +143,11 @@ export default {
         fill: $gray-2;
       }
     }
-    > h1 {
+    &-Title {
       @include font-size(30);
       font-weight: normal;
       color: $gray-2;
-      margin-left: 4px;
+      margin-left: 8px;
     }
   }
   &-Card {


### PR DESCRIPTION
## 📝 関連issue
- close #240 

## ⛏ 変更内容
- flowページタイトルにclassをつけて対応しました。
- アイコンとのマージンをほんのちょっとあけました。

## 📸 スクリーンショット
![スクリーンショット 2020-03-03 20 00 03](https://user-images.githubusercontent.com/14883063/75769509-a5b18a00-5d89-11ea-8342-a71dbe2a5b94.png)
