### PR TITLE
Feature/issue 274 navigation style

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -110,18 +110,18 @@ export default {
         },
         {
           title: '知事からのメッセージ',
-          link: 'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
+          link:
+            'https://www.metro.tokyo.lg.jp/tosei/governor/governor/katsudo/2020/03/03_00.html'
         },
         {
           title: '当サイトについて',
-          link: '/about',
+          link: '/about'
         },
         {
           title: '東京都公式ホームページ',
-          link:
-            'https://www.metro.tokyo.lg.jp/',
+          link: 'https://www.metro.tokyo.lg.jp/',
           divider: true
-        },
+        }
       ]
     }
   },
@@ -169,6 +169,9 @@ export default {
   }
   &-HeadingDivider {
     margin: 0px 20px 4px;
+    @include lessThan(600) {
+      display: none;
+    }
   }
   &-Divider {
     margin: 12px 0;

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -9,8 +9,10 @@
           <img src="/logo.svg" />
         </div>
         <h1 class="SideNavigation-Heading">
-          東京都
-          <br />新型コロナウイルス対策サイト
+          <span class="SideNavigation-HeadingTitle">東京都<br /></span>
+          新型コロナウイルス<br
+            class="SideNavigation-HeadingMobileBreak"
+          />対策サイト
         </h1>
       </nuxt-link>
     </div>
@@ -145,6 +147,9 @@ export default {
   &-HeadingContainer {
     padding: 1.25em 0 1.25em 1.25em;
     align-items: center;
+    @include lessThan(600) {
+      padding: 7px 0 7px 20px;
+    }
   }
   &-HeadingLink {
     @include lessThan(600) {
@@ -159,6 +164,9 @@ export default {
   &-Logo {
     margin-top: 20px;
     width: 110px;
+    @include lessThan(600) {
+      margin-top: 0;
+    }
   }
   &-Heading {
     margin-top: 8px;
@@ -166,6 +174,20 @@ export default {
     color: #898989;
     padding: 0.5em 0;
     text-decoration: none;
+    @include lessThan(600) {
+      margin-top: 0;
+    }
+  }
+  &-HeadingTitle {
+    @include lessThan($small) {
+      display: none;
+    }
+  }
+  &-HeadingMobileBreak {
+    display: none;
+    @include lessThan($small) {
+      display: inline;
+    }
   }
   &-HeadingDivider {
     margin: 0px 20px 4px;


### PR DESCRIPTION
## 📝 関連issue

- close #271
- close #273
- close #274

## ⛏ 変更内容

- モバイルビューでヘッダーに罫線が残っていたので削除しました。
- モバイルビューでヘッダーの高さがデザインとずれているので修正しました。

## 📸 スクリーンショット

### Desktop

<img width="355" alt="スクリーンショット 2020-03-04 0 27 25" src="https://user-images.githubusercontent.com/8067258/75790874-220a9400-5daf-11ea-8cb0-bd9eb97c3f78.png">

### Mobile iPhone 8 Plusサイズ

<img width="461" alt="スクリーンショット 2020-03-04 0 27 08" src="https://user-images.githubusercontent.com/8067258/75790861-1d45e000-5daf-11ea-9f36-03138e20c6eb.png">

### Mobile iPhone SEサイズ

<img width="411" alt="スクリーンショット 2020-03-04 0 27 17" src="https://user-images.githubusercontent.com/8067258/75790851-19b25900-5daf-11ea-82f2-17d91ea10e1f.png">


レビューお願いします！ 🙏 