### PR TITLE
Fix side nav style for huge size device

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -229,4 +229,9 @@ export default {
   z-index: 100;
   background-color: #fff;
 }
+@include largerThan($huge) {
+  .SideNavigation {
+    min-width: 325px;
+  }
+}
 </style>


### PR DESCRIPTION
## ⛏ 変更内容
- 大きい画面幅のときにサイトナビゲーションの横幅を可変から固定幅に

## 📸 スクリーンショット
|before|after|
|-|-|
|[![Image from Gyazo](https://i.gyazo.com/5971c6be9c80f674f81f31ee6375d256.gif)](https://gyazo.com/5971c6be9c80f674f81f31ee6375d256)|[![Image from Gyazo](https://i.gyazo.com/90dca909c655f88ad437e61a22203d0d.gif)](https://gyazo.com/90dca909c655f88ad437e61a22203d0d)|
