### PR TITLE
グラフ・表が２カラムにならない不具合を修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,7 +18,7 @@
       :btn-text="'相談の手順を見る'"
     />
     <v-row class="DataBlock">
-      <v-col xs12 sm6 md4 class="DataCard">
+      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="陽性患者数"
           :chart-data="patientsGraph"
@@ -27,7 +27,7 @@
           :unit="'人'"
         />
       </v-col>
-      <v-col xs12 sm6 md4 class="DataCard">
+      <v-col cols="12" md="6" class="DataCard">
         <data-table
           :title="'陽性患者の属性'"
           :chart-data="patientsTable"
@@ -37,7 +37,7 @@
         />
       </v-col>
 
-      <v-col xs12 sm6 md4 class="DataCard">
+      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
           :chart-data="contactsGraph"
@@ -46,7 +46,7 @@
           :unit="'件'"
         />
       </v-col>
-      <v-col xs12 sm6 md4 class="DataCard">
+      <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="帰国者・接触者電話相談センター相談件数"
           :chart-data="querentsGraph"


### PR DESCRIPTION
## 📝 関連issue
- close #264 
- close #51 
- close #267 

## ⛏ 変更内容
- v-colのattrの書き方を修正しました。現在２カラムのbreakpointは960pxにしています。

## 📸 スクリーンショット
![responsive_graph](https://user-images.githubusercontent.com/14883063/75843689-12bf3100-5e17-11ea-9db2-7e0012a2dbfd.gif)
