### PR TITLE
linkのcolorに!importantをつける

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -65,7 +65,7 @@ $small: 450;
 // button
 @mixin text-link {
   @include font-size(14);
-  color: $link;
+  color: $link !important;
   text-decoration: none;
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
## 📝 関連issue
- close #308 

## ⛏ 変更内容
- aタグのカラーはvuetifyの設定が優先されてしまっていたので、text-linkのmixinのcolorを `!important` にしました。

## 📸 スクリーンショット
![スクリーンショット 2020-03-04 15 02 25](https://user-images.githubusercontent.com/14883063/75849996-89fdc080-5e29-11ea-9fe1-070d7ae1a535.png)
