### PR TITLE
サイドバーの【がずれる件についての修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -25,6 +25,7 @@
         <v-container
           v-for="(item, i) in items"
           :key="i"
+          :class="isClass(item)"
           class="SideNavigation-ListItemContainer"
           @click="closeNavi"
         >
@@ -121,6 +122,11 @@ export default {
         }
       ]
     }
+  },
+  computed: {
+    isClass() {
+      return item => item.title.charAt(0) === '【' ? 'kerningLeft' : ''
+    },
   },
   methods: {
     openNavi() {
@@ -249,5 +255,8 @@ export default {
   .sp-none {
     display: none;
   }
+}
+.kerningLeft {
+  text-indent: -.5em;
 }
 </style>


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
・オフトピ気味ですが、【東京都主催等】の部分がきれいに左揃えできてなくてちょっと気持ち悪くないです？
-->
- close #{ISSUE_NUMBER}

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- #222 でこの順番という指示がでているため順番は変えていません
- 「【」付きのtextのみ-0.5emされるように揃えました。sidebarのみの反映なので、他にもあればcomputed{内部にjsを追加し「【」付きで始まる際のみclassを追加しての調整

## 📸 スクリーンショット
<img width="207" alt="スクリーンショット 2020-03-04 19 38 37" src="https://user-images.githubusercontent.com/27335198/75871864-8b8eaf00-5e50-11ea-9cee-95e35b66ba47.png">
<img width="370" alt="スクリーンショット 2020-03-04 19 38 49" src="https://user-images.githubusercontent.com/27335198/75871867-8cbfdc00-5e50-11ea-97d6-a9b9efafcc4a.png">
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->