### PR TITLE
メインコンテンツのoverflowを削除・サイドナビをfixedに

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -180,6 +180,7 @@ export default {
 <style lang="scss" scoped>
 .SideNavigation {
   position: relative;
+  height: 100%;
   background: #fff;
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
   &-HeadingContainer {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -180,7 +180,6 @@ export default {
 <style lang="scss" scoped>
 .SideNavigation {
   position: relative;
-  flex: 0 0 220px;
   background: #fff;
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
   &-HeadingContainer {
@@ -262,7 +261,7 @@ export default {
     display: block;
     margin-top: 10px;
     font-size: 8px;
-    line-height: 11px;
+    line-height: 1.2;
     color: $gray-1;
     font-weight: bold;
   }
@@ -276,11 +275,6 @@ export default {
     width: 100%;
     z-index: 100;
     background-color: #fff;
-  }
-}
-@include largerThan($huge) {
-  .SideNavigation {
-    min-width: 325px;
   }
 }
 @include lessThan($small) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,12 +5,14 @@
       <scale-loader color="#00A040" />
     </div>
     <div class="appContainer" v-else>
-      <SideNavigation
-        @openNavi="showNavi"
-        @closeNavi="hideNavi"
-        :isNaviOpen="isNaviOpen"
-        :class="{open: isNaviOpen}"
-      />
+      <div class="naviContainer">
+        <SideNavigation
+          @openNavi="showNavi"
+          @closeNavi="hideNavi"
+          :isNaviOpen="isNaviOpen"
+          :class="{open: isNaviOpen}"
+        />
+      </div>
       <div class="mainContainer" :class="{open: isNaviOpen}">
         <v-container class="px-4 py-8">
           <nuxt />
@@ -53,12 +55,29 @@ export default {
   background-color: inherit !important;
 }
 .appContainer {
+  position: relative;
   @include largerThan($small) {
-    display: flex;
+    display: grid;
+    grid-template-columns: 240px auto;
+  }
+  @include largerThan($huge) {
+    grid-template-columns: 325px auto;
   }
 }
-.navi {
-  flex: 0 1 200px;
+@include largerThan($small) {
+  .naviContainer {
+    grid-column: 1/2;
+    position: fixed;
+    top: 0;
+    overflow-y: auto;
+    width: 240px;
+    height: 100vh;
+  }
+}
+@include largerThan($huge) {
+  .naviContainer {
+    width: 325px;
+  }
 }
 .open {
   overflow-x: hidden;
@@ -66,12 +85,8 @@ export default {
   height: 100vh;
 }
 .mainContainer {
-  flex: 1 1 auto;
-  @include largerThan($small) {
-    overflow-x: hidden;
-    overflow-y: auto;
-    height: 100vh;
-  }
+  grid-column: 2/3;
+  overflow: hidden;
   @include lessThan($small) {
     .container {
       padding-top: 16px !important;


### PR DESCRIPTION
## 📝 関連issue
- close #261 
- close #343 

## ⛏ 変更内容
- mainContainerから `overflow:scroll` を削除しました。
- サイドナビゲーションを `position:fixed` としました（デスクトップサイズ時）。

## 📸 スクリーンショット
![fixed-sidenavi](https://user-images.githubusercontent.com/14883063/75874642-841dd480-5e55-11ea-82dd-35115c717561.gif)
