### PR TITLE
「陽性患者数」のグラフ & データの更新日時の文言の高さに「陽性患者の属性」側を揃える

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -8,7 +8,7 @@
       :items="chartData.datasets"
       :items-per-page="-1"
       :hide-default-footer="true"
-      :height="200"
+      :height="314"
       :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"


### PR DESCRIPTION
## 📝 関連issue
p-r #342

## ⛏ 変更内容
- 陽性患者の属性テーブルの height を `200px` から `314px` に変更(`314` はグラフの高さを元に)
  - 陽性患者数のグラフ & データの更新日時の文言の高さを揃える
  - 1度に画面に表示される件数を増やす

## 📸 スクリーンショット
- Google Chrome

![image](https://user-images.githubusercontent.com/24786802/75874491-24bfc480-5e55-11ea-88b0-69b1c3e08202.png)

- Safari

![image](https://user-images.githubusercontent.com/24786802/75874514-33a67700-5e55-11ea-944c-2059e999e39a.png)

