### PR TITLE
（棒グラフ共通）右上に表示する数値の変更

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -10,7 +10,7 @@
       <v-spacer />
       <slot name="infoPanel" />
     </v-toolbar>
-    <v-card-text class="DataView-CardText">
+    <v-card-text :class="$vuetify.breakpoint.xs ? 'DataView-CardTextForXS' : 'DataView-CardText'">
       <slot />
     </v-card-text>
     <v-footer class="DataView-Footer"> {{ date }} 更新 </v-footer>
@@ -76,7 +76,11 @@ export default class DataView extends Vue {
   }
   &-CardText {
     margin-bottom: 46px;
-    margin-top: 20px;
+    margin-top: 35px;
+  }
+  &-CardTextForXS {
+    margin-bottom: 46px;
+    margin-top: 50px;
   }
   &-Footer {
     background-color: $white !important;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -80,7 +80,7 @@ export default class DataView extends Vue {
   }
   &-CardTextForXS {
     margin-bottom: 46px;
-    margin-top: 50px;
+    margin-top: 70px;
   }
   &-Footer {
     background-color: $white !important;

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -46,10 +46,6 @@
   &-Title {
     @include card-h2();
   }
-  &-CardText {
-    margin-bottom: 46px;
-    margin-top: 20px;
-  }
   &-Footer {
     background-color: $white !important;
     text-align: right;

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -1,8 +1,7 @@
 <template>
   <div class="DataView-DataInfo">
     <span class="DataView-DataInfo-summary">
-      {{ lText
-      }}
+      {{ lText }}
       <small class="DataView-DataInfo-summary-unit">{{ unit }}</small>
     </span>
     <br />
@@ -26,6 +25,7 @@
       }
     }
     &-date {
+      white-space: nowrap;
       display: inline-block;
       font-size: 12px;
       line-height: 12px;

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -56,13 +56,21 @@ export default {
     }
   },
   computed: {
+    displayCumulativeRatio() {
+      const lastDay = this.chartData.slice(-1)[0].cummulative
+      const lastDayBefore = this.chartData.slice(-2)[0].cummulative
+      return this.formatDayBeforeRatio(lastDay - lastDayBefore).toLocaleString()
+    },
+    displayTransitionRatio() {
+      const lastDay = this.chartData.slice(-1)[0].transition
+      const lastDayBefore = this.chartData.slice(-2)[0].transition
+      return this.formatDayBeforeRatio(lastDay - lastDayBefore).toLocaleString()
+    },
     displayInfo() {
       if (this.dataKind === 'transition') {
         return {
-          lText: `+${this.chartData[
-            this.chartData.length - 1
-          ].transition.toLocaleString()}`,
-          sText: '前日比',
+          lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
+          sText: `実績値（前日比：${this.displayTransitionRatio} ${this.unit}）`,
           unit: this.unit
         }
       }
@@ -70,7 +78,7 @@ export default {
         lText: this.chartData[
           this.chartData.length - 1
         ].cummulative.toLocaleString(),
-        sText: `${this.chartData[this.chartData.length - 1].label} の累計`,
+        sText: `${this.chartData.slice(-1)[0].label} 累計値（前日比：${this.displayCumulativeRatio} ${this.unit}）`,
         unit: this.unit
       }
     },
@@ -106,6 +114,20 @@ export default {
             borderWidth: 0
           }
         ]
+      }
+    }
+  },
+  methods: {
+    formatDayBeforeRatio(dayBeforeRatio) {
+      switch (Math.sign(dayBeforeRatio)) {
+        case 1:
+          return `+${dayBeforeRatio}`
+          break
+        case -1:
+          return `${dayBeforeRatio}`
+          break
+        default:
+          return `${dayBeforeRatio}`
       }
     }
   }


### PR DESCRIPTION
## 📝 関連issue
#334

## ⛏ 変更内容
- 関連issueのリンク先にあるフォーマットに合わせてデータを整形して表示するように変更しました。

## 📸 スクリーンショット

### before
|  推移  |  累計  |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/13265134/75889590-7e81b800-5e70-11ea-864b-c99f4c9ef2e2.png) | ![image](https://user-images.githubusercontent.com/13265134/75889622-8c373d80-5e70-11ea-8f84-347728a16244.png)  |

### after
|  推移  |  累計  |
| ---- | ---- |
|  ![image](https://user-images.githubusercontent.com/13265134/75887014-7cb5f580-5e6c-11ea-89d7-45abf7f9cce1.png)| ![image](https://user-images.githubusercontent.com/13265134/75888021-0b774200-5e6e-11ea-85ff-164800231516.png)  |