### PR TITLE
fix: 特定の横幅でサイドメニューが表示を圧迫していた問題を修正

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -21,7 +21,7 @@ $shadow: 0px 0px 2px rgba(0, 0, 0, 0.15);
 $huge: 1440;
 $large: 1170;
 $medium: 768;
-$small: 450;
+$small: 600;
 
 // ==================
 // media-query


### PR DESCRIPTION
## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- サイドメニューが出現する横幅を 450px -> 600px に変更

## 📸 スクリーンショット
Before
![image](https://user-images.githubusercontent.com/12265602/75887573-56dd2080-5e6d-11ea-9300-d815f867257e.png)

↓ After ↓
![image](https://user-images.githubusercontent.com/12265602/75887499-3c0aac00-5e6d-11ea-8436-0058c672300d.png)
