### PR TITLE
Git ステージ時の ESLint の発火対象の拡大(.ts, .vue サポート)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+.nuxt/
+dist/
+node_modules/
+static/

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "nuxt-ts build",
     "start": "cross-env NODE_ENV=production nuxt-ts start",
     "generate": "nuxt-ts generate",
-    "test": "echo 'skip tests (there is no test)'"
+    "test": "echo 'skip tests (there is no test)'",
+    "lint": "eslint './**/*.{js,ts,vue}' --fix"
   },
   "lint-staged": {
     "*.{js,ts,scss,css,vue}": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "echo 'skip tests (there is no test)'"
   },
   "lint-staged": {
-    "*.js": [
+    "*.{js,ts,scss,css,vue}": [
       "eslint --fix",
       "git add"
     ]


### PR DESCRIPTION
## 📝 関連issue

- #375

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- lint-staged 時に .ts ファイルや .vue ファイルでも ESLint が動作するように
  - 現状でも Lint が効いていない部分があり、落ち着いたあとに修正時の障害となりえるため
  - 新規追加分は健全であることを担保する
- GitHub Actions への追加は Lint がすべて通る状態になってからおこなう

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->