### PR TITLE
SideNavigation内の画像にaltを設定する

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -9,7 +9,7 @@
       </v-icon>
       <nuxt-link to="/" class="SideNavigation-HeadingLink">
         <div class="SideNavigation-Logo">
-          <img src="/logo.svg" />
+          <img src="/logo.svg" :alt="$t('Tokyo')" />
         </div>
         <h1 class="SideNavigation-Heading">
           <span class="SideNavigation-HeadingTitle">
@@ -44,10 +44,10 @@
       <div class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
           <a href="https://line.me/R/ti/p/%40822sysfc#~">
-            <img src="/line.png" />
+            <img src="/line.png" alt="LINE" />
           </a>
           <a href="https://twitter.com/tokyo_bousai">
-            <img src="/twitter.png" />
+            <img src="/twitter.png" alt="Twitter" />
           </a>
         </div>
         <small class="SideNavigation-Copyright" lang="en">


### PR DESCRIPTION
## 📝 関連issue
- close #{ISSUE_NUMBER}

## ⛏ 変更内容
SideNavigation内のimgタグにaltの設定。
Lighthouseにて警告がでていたため。

## 📸 スクリーンショット
![alt](https://user-images.githubusercontent.com/27715262/75889800-caccf800-5e70-11ea-8ace-8bcf992ce6cf.png)