### PR TITLE
fix: 外部リンクに`rel=noopener`属性を追加

### DIFF
--- a/components/DesktopFlowSvg.vue
+++ b/components/DesktopFlowSvg.vue
@@ -929,7 +929,7 @@
       </g>
       <g transform="translate(0 -19)">
         <g transform="translate(19 5)">
-          <a xlink:href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank">
+          <a xlink:href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">
             <text class="c" transform="translate(803 311)" style="">
               <tspan x="0" y="0">各保健所の電話番号は</tspan>
               <tspan x="0" y="22">福祉保健局HPへ</tspan>

--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -4,6 +4,7 @@
     :to="isInternalLink(link) ? link : ''"
     :href="!isInternalLink(link) ? link : ''"
     :target="!isInternalLink(link) ? '_blank' : ''"
+    :rel="!isInternalLink(link) ? 'noopener' : ''"
     router
     exact
     class="ListItem-Container"

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="whatsNewOuter" :href="url" target="_blank">
+  <a class="whatsNewOuter" :href="url" target="_blank" rel="noopener">
     <v-icon size="18" class="whatsNewOuter-Icon">
       mdi-information
     </v-icon>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -44,17 +44,17 @@
       Google Analyticsの利用規約及びプライバシーポリシーに関する説明については、Google Analyticsのサイトをご覧ください。<br />
       <ul>
         <li>
-          <a href="https://marketingplatform.google.com/about/analytics/terms/jp" target="_blank">
+          <a href="https://marketingplatform.google.com/about/analytics/terms/jp" target="_blank" rel="noopener">
             Google Analytics利用規約
           </a>
         </li>
         <li>
-          <a href="https://policies.google.com/privacy?hl=ja" target="_blank">
+          <a href="https://policies.google.com/privacy?hl=ja" target="_blank" rel="noopener">
             Googleのプライバシーポリシー
           </a>
         </li>
         <li>
-          <a href="https://support.google.com/analytics/answer/6004245" target="_blank">
+          <a href="https://support.google.com/analytics/answer/6004245" target="_blank" rel="noopener">
             Google Analyticsに関する詳細情報
           </a>
         </li>

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -60,7 +60,7 @@
             <div class="SodanHeijitsu">
               <dt class="Heijitsu">平日（日中）</dt>
               <dd>
-                <a class="Link" href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank">
+                <a class="Link" href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">
                   各保健所の電話番号は福祉保健局HPへ
                   <v-icon size="16">
                     mdi-open-in-new
@@ -110,6 +110,7 @@
       <a
         href="https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html"
         target="_blank"
+        rel="nopenner"
         class="Flow-Card-Button"
       >
         詳細を見る(東京都福祉保健局)

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -20,12 +20,12 @@ export default {
         {
           title: '1 感染予防・健康管理',
           body:
-            '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="https://tokyodouga.jp/lViN9C_BS-0.html" target="_blank">【参考】感染症予防のための正しい手洗い方法（動画）</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
+            '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="https://tokyodouga.jp/lViN9C_BS-0.html" target="_blank" rel="noopener">【参考】感染症予防のための正しい手洗い方法（動画）</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
         },
         {
           title: '2 感染症を疑う場合の対応',
           body:
-            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
+            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
         },
         {
           title: '3 その他',

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -20,17 +20,17 @@ export default {
         {
           title: '中小企業者等特別相談窓口',
           body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局 報道発表）'
+            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局 報道発表）'
         },
         {
           title: '緊急労働相談ダイヤル',
           body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html" target="_blank">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html</a><br />新型コロナウイルスに関する休暇や休業の取り扱い、職場のハラスメントなどについての相談（東京都産業労働局　報道発表）'
+            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html</a><br />新型コロナウイルスに関する休暇や休業の取り扱い、職場のハラスメントなどについての相談（東京都産業労働局　報道発表）'
         },
         {
           title: '新しいワークスタイルや企業活動の東京モデル「スムーズビズ」',
           body:
-            '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
+            '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
         }
       ]
     }


### PR DESCRIPTION
## ⛏ 変更内容
- 別タブで開く外部サイトのリンクに `rel="noopener"`属性を追加しました。

## 参考
[サイトで rel=_noopener_ を使用して外部アンカーを開く](https://developers.google.com/web/tools/lighthouse/audits/noopener)

## 📸 スクリーンショット
見た目の変更はありません。