### PR TITLE
DataTable用のデータのsort処理を改善

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -11,13 +11,19 @@
       :height="200"
       :fixed-header="true"
       :mobile-breakpoint="0"
+      :sort-desc="true"
+      sort-by="time"
       class="cardTable"
-    />
+    >
+      <template v-slot:item.time="{ item }">
+        <span>{{ formatDate(item) }}</span>
+      </template>
+    </v-data-table>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
-        :lText=info.lText
-        :sText=info.sText
-        :unit=info.unit
+        :lText="info.lText"
+        :sText="info.sText"
+        :unit="info.unit"
       />
     </template>
   </data-view>
@@ -59,6 +65,7 @@
 </style>
 
 <script>
+import moment from 'moment'
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 
@@ -81,6 +88,12 @@ export default {
       type: Object,
       required: false,
       default: () => {}
+    }
+  },
+  methods: {
+    formatDate({ date, time }) {
+      if (isNaN(time)) return '不明'
+      return moment(date).format('MM/DD')
     }
   }
 }

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -1,14 +1,12 @@
-import moment from 'moment'
-
 const headers = [
-  { text: '日付', value: '日付' },
-  { text: '居住地', value: '居住地' },
-  { text: '年代', value: '年代' },
-  { text: '性別', value: '性別' }
+  { text: '日付', value: 'time' },
+  { text: '居住地', value: 'residence' },
+  { text: '年代', value: 'age' },
+  { text: '性別', value: 'gender' }
 ]
 
 type DataType = {
-  リリース日: Date
+  リリース日: string
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性'
@@ -16,31 +14,26 @@ type DataType = {
 }
 
 type TableDataType = {
-  日付: string
-  居住地: DataType['居住地']
-  年代: DataType['年代']
-  性別: DataType['性別'] | '不明'
-}
-
-type TableDateType = {
-  headers: typeof headers
-  datasets: TableDataType[]
+  date: Date,
+  time: number,
+  residence: DataType['居住地']
+  age: DataType['年代']
+  gender: DataType['性別'] | '不明'
 }
 
 export default (data: DataType[]) => {
-  const tableDate: TableDateType = {
-    headers,
-    datasets: []
-  }
-  data.forEach(d => {
-    const TableRow: TableDataType = {
-      日付: moment(d['リリース日']).format('MM/DD') ?? '不明',
-      居住地: d['居住地'] ?? '不明',
-      年代: d['年代'] ?? '不明',
-      性別: d['性別'] ?? '不明'
+  const datasets: TableDataType[] = data.map(item => {
+    const date = new Date(item['リリース日'])
+    return {
+      date,
+      time: date.getTime(),
+      residence: item['居住地'] ?? '不明',
+      age: item['年代'] ?? '不明',
+      gender: item['性別'] ?? '不明'
     }
-    tableDate.datasets.push(TableRow)
   })
-  tableDate.datasets.sort((a, b) => (a === b ? 0 : a < b ? 1 : -1))
-  return tableDate
+  return {
+    headers,
+    datasets
+  }
 }


### PR DESCRIPTION
## 📝 関連issue

- #395

## ⛏ 変更内容

- fomatTable関数で日付情報を文字列化する代わりに、DateとDate.getTime()を追加
- objectのkeyが日本語だと扱いづらいので英語化
- DataTableのデフォルトソート設定にtimeの降順を設定
- カラムのtemplateでDateを文字列フォーマット化

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->