### PR TITLE
東京都のLINEアカウントのURL修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -43,7 +43,7 @@
       </v-list>
       <div class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
-          <a href="https://line.me/R/ti/p/%40822sysfc#~">
+          <a href="https://line.me/R/ti/p/%40822sysfc">
             <img src="/line.png" alt="LINE" />
           </a>
           <a href="https://twitter.com/tokyo_bousai">


### PR DESCRIPTION
LINEアカウントのURLの末尾に余分な記号があったせいで、LINE公式アプリの友達追加画面にうまくリダイレクトされないことがありました。
発生条件は不明ですが、AndroidのChromeで再現しました。
このPRはその修正のために不要な文字を消します。

Note: 修正後の `https://line.me/R/ti/p/@822sysfc` というURLは[東京都のページ](https://www.metro.tokyo.lg.jp/tosei/koho/sns/line/index.html)のQRコードから読み取れる正しいURLです。

## ⛏ 変更内容
- 東京都のLINEアカウントのURLの修正
