### PR TITLE
企業の皆様・はたらく皆様の表記ゆれ修正

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -70,7 +70,7 @@
     "If you have any symptoms": "新型コロナウイルス感染症が心配なときに",
     "for Families with children": "お子様をお持ちの皆様へ",
     "for Citizens": "都民の皆様へ",
-    "for Enterprises and Employees": "企業の皆様・働く皆様へ",
+    "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "東京都新型コロナイルス感染症対策本部報",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
     "Government official website": "東京都公式ホームページ",


### PR DESCRIPTION
## 📝 関連issue
- #62
- #164

## ⛏ 変更内容
ページタイトルとナビゲーションの表記が多言語対応時(#164)に揺れてたので、元(#62)の`企業の皆様・はたらく皆様`のほうに合わせました

ご確認よろしくお願いします:bow: