### PR TITLE
Tools: tool/convert.php で生成される日付文字列形式を慣習的なものに

### DIFF
--- a/tool/convert.php
+++ b/tool/convert.php
@@ -217,7 +217,7 @@ foreach ($data as $arr) {
     $timestamp = Carbon::parse($arr['date'])->format('YmdHis');
     if ($lastTime <= $timestamp) {
       $lastTime = $timestamp;
-      $lastUpdate = Carbon::parse($arr['date'])->addDay()->format('Y/n/d 8:00');
+      $lastUpdate = Carbon::parse($arr['date'])->addDay()->format('Y/m/d 8:00');
     }
 }
 $data['lastUpdate'] = $lastUpdate;

--- a/tool/convert.php
+++ b/tool/convert.php
@@ -7,7 +7,8 @@ use Carbon\Carbon;
 function formatDate(string $date) :string
 {
     if (preg_match('#(\d+/\d+/\d+)/ (\d+:\d+)#', $date, $maches)) {
-      return $maches[1].' '.$maches[2];
+      $carbon = Carbon::parse($maches[1].' '.$maches[2]);
+      return $carbon->format('Y/m/d H:i');
     } else {
       throw new Exception('Can not parse date:'.$date);
     }


### PR DESCRIPTION
## 📝 関連issue
- PR #405

## ⛏ 変更内容
- サイトで使用されるデータの自動生成において、`2020/3/05`のようなゼロ無し月からゼロ付き月へ変更

## Note
元データが無かったので疑似データでテスト済みです