### PR TITLE
nuxt-i18nのformatFallbackMessages設定を修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -100,10 +100,10 @@ module.exports = {
             iso: 'en-US'
           }
         ],
-        formatFallbackMessages: true,
         defaultLocale: 'ja',
         vueI18n: {
-          fallbackLocale: 'ja'
+          fallbackLocale: 'ja',
+          formatFallbackMessages: true
         },
         vueI18nLoader: true
       }


### PR DESCRIPTION
## 📝 関連issue
なし

## ⛏ 変更内容
- nuxt-i18nのオプションで、`formatFallbackMessages`をオブジェクトのルートから`vueI18n`下に移動

## 📸 スクリーンショット
いまのところNamed formattingを使用しているところはないようなので、vue-i18nのドキュメントにある例をもとに`SideNavigation.vue`の一部を以下のように書き換えて動作確認しました。

```html
        <h1 class="SideNavigation-Heading">
          <span class="SideNavigation-HeadingTitle">
            {{ $t('Hello {name}', { name: 'ムニエル' }) }}<br />
          </span>
          {{ $t('The weather today is {condition}!', { condition: 'sunny' }) }}
        </h1>
```

```json
{
  "ja": {
    "Hello {name}": "こんにちは、{name}さん"
  },
  "en": {
  }
}
```

|Before|After|
|---|---|
|<img width="218" alt="スクリーンショット 2020-03-05 6 52 49" src="https://user-images.githubusercontent.com/20086673/75926489-f6ba9e80-5ead-11ea-97f4-3b101ad6f41c.png">|<img width="218" alt="スクリーンショット 2020-03-05 6 39 08" src="https://user-images.githubusercontent.com/20086673/75925633-5adc6300-5eac-11ea-9e85-7002378abce9.png">|

## 参考リンク
- [Fallback localization | Vue I18n](https://kazupon.github.io/vue-i18n/guide/fallback.html#fallback-interpolation)