### PR TITLE
Fix typo of Licence section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ All contributions are welcome!
 Please check [How to contribute](https://github.com/tokyo-metropolitan-gov/covid19/wiki/How-to-contribute) for details.
 
 ## License / ライセンス
-本ソフトウェアは、MITライセンスの元提供されています。
-This software is released under the MIT License,
+本ソフトウェアは、MITライセンスの元提供されています。 
+This software is released under the MIT License.
 
 ## For Developers / 開発者向け情報
 


### PR DESCRIPTION
## ⛏ 変更内容
- `README.md`内のLicenceのTypoを修正