### PR TITLE
[#418] コピーライトの記法を(C)から©へ変更した

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -51,7 +51,7 @@
           </a>
         </div>
         <small class="SideNavigation-Copyright" lang="en">
-          Copyright (C) 2020 Tokyo Metropolitan Government. All Rights Reserved.
+          Copyright © 2020 Tokyo Metropolitan Government. All Rights Reserved
         </small>
       </div>
     </div>
@@ -150,8 +150,8 @@ export default {
       ]
     },
     isClass() {
-      return item => item.title.charAt(0) === '【' ? 'kerningLeft' : ''
-    },
+      return item => (item.title.charAt(0) === '【' ? 'kerningLeft' : '')
+    }
   },
   methods: {
     openNavi() {


### PR DESCRIPTION
## 📝 関連issue
close #418 

## ⛏ 変更内容
- コピーライトの記法を(C)から©へ変更した

## 📸 スクリーンショット
<img width="496" alt="スクリーンショット 2020-03-05 8 55 07" src="https://user-images.githubusercontent.com/5590142/75934122-0d1d2600-5ebf-11ea-9c13-7d04ca08e862.png">
