### PR TITLE
コピーライトの表記を (C) ではなく © とする

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -51,7 +51,7 @@
           </a>
         </div>
         <small class="SideNavigation-Copyright" lang="en">
-          Copyright (C) 2020 Tokyo Metropolitan Government. All Rights Reserved.
+          Copyright &copy; 2020 Tokyo Metropolitan Government. All Rights Reserved.
         </small>
       </div>
     </div>


### PR DESCRIPTION
use copyright mark

## 📝 関連issue

- close #418 

## ⛏ 変更内容
- copyrightの表記を `&copy;` に変更
