### PR TITLE
半角スペースから全角スペースにした

### DIFF
--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -20,7 +20,7 @@ export default {
         {
           title: '中小企業者等特別相談窓口',
           body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局 報道発表）'
+            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局　報道発表）'
         },
         {
           title: '緊急労働相談ダイヤル',


### PR DESCRIPTION
## ⛏ 変更内容

全角スペースと半角スペースが混合されていたので、「多く使われている全角スペース」に寄せた

### 対象のページ
![企業の皆様・はたらく皆様へ | 東京都 新型コロナウイルス対策サイト 2020-03-05 10-12-33](https://user-images.githubusercontent.com/8898432/75938010-e9131200-5ec9-11ea-8c46-3bb64bfc35e1.png)


## 📸 スクリーンショット
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/8898432/75938010-e9131200-5ec9-11ea-8c46-3bb64bfc35e1.png" width="320"/> | <img src="https://user-images.githubusercontent.com/8898432/75938032-fc25e200-5ec9-11ea-89d3-dd2b49149db5.png" width="320"/>