### PR TITLE
Google Analytics の文言の平仄合わせ

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -39,6 +39,7 @@
     <TextCard title="GoogleAnalytics の利用について">
       当サイトでは、サービス向上やWebサイトの改善のためにGoogle Inc.の提供するアクセス分析のツールであるGoogle Analyticsを利用した計測を行っております。<br />
       Google Analyticsは、当サイトが発行するクッキー(Cookie)を利用して、個人を特定する情報を含まずにWebサイトの利用データ（アクセス状況、トラフィック、閲覧環境など）を収集しております。クッキー(Cookie)の利用に関してはGoogleのプライバシーポリシーと規約に基づいております。<br />
+    <TextCard title="Google Analytics の利用について">
       取得したデータはWebサイト利用状況の分析、サイト運営者へのレポートの作成、その他のサービスの提供に関わる目的に限り、これを使用します。<br />
       <br />
       Google Analyticsの利用規約及びプライバシーポリシーに関する説明については、Google Analyticsのサイトをご覧ください。<br />


### PR DESCRIPTION
## 📝 関連issue
なし

## ⛏ 変更内容
- Google Analyticsの表記が揺れていたので統一しました。
  - grep したところ、 `Google Analytics` が多かったので半角スペースが含まれていな箇所の修正を行いました。

### 変更前
```
git grep "GoogleAnalytics"
pages/about.vue:    <TextCard title="GoogleAnalytics の利用について">

git grep "Google Analytics"
pages/about.vue:      <TextCard title="Google Analytics の利用について">
pages/about.vue:              Google Analytics利用規約
pages/about.vue:              Google Analyticsに関する詳細情報
```
### 変更後
```
git grep "GoogleAnalytics"
```

## 📸 スクリーンショット
| before | after |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/37993873/75938910-45773100-5ecc-11ea-9b81-d47a0ead02d7.png) | ![image](https://user-images.githubusercontent.com/37993873/75938864-1f519100-5ecc-11ea-960c-c85576a4c765.png) |