### PR TITLE
fix: チャートとそのツールチップの, データの単位の不一致の修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-data="displayData" :options="chartOption" :height="240" />
+    <bar :chart-data="displayData" :options="displayOption" :height="240" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -33,11 +33,6 @@ export default {
       type: Array,
       required: false,
       default: () => []
-    },
-    chartOption: {
-      type: Object,
-      required: false,
-      default: () => {}
     },
     date: {
       type: String,
@@ -78,7 +73,9 @@ export default {
         lText: this.chartData[
           this.chartData.length - 1
         ].cummulative.toLocaleString(),
-        sText: `${this.chartData.slice(-1)[0].label} 累計値（前日比：${this.displayCumulativeRatio} ${this.unit}）`,
+        sText: `${this.chartData.slice(-1)[0].label} 累計値（前日比：${
+          this.displayCumulativeRatio
+        } ${this.unit}）`,
         unit: this.unit
       }
     },
@@ -115,6 +112,54 @@ export default {
           }
         ]
       }
+    },
+    displayOption() {
+      const unit = this.unit
+      return {
+        tooltips: {
+          displayColors: false,
+          callbacks: {
+            label(tooltipItem) {
+              const labelText = tooltipItem.value + unit
+              return labelText
+            }
+          }
+        },
+        responsive: true,
+        legend: {
+          display: false
+        },
+        scales: {
+          xAxes: [
+            {
+              stacked: true,
+              gridLines: {
+                display: false
+              },
+              ticks: {
+                fontSize: 10,
+                maxTicksLimit: 20,
+                fontColor: '#808080'
+              }
+            }
+          ],
+          yAxes: [
+            {
+              location: 'bottom',
+              stacked: true,
+              gridLines: {
+                display: true,
+                color: '#E5E5E5'
+              },
+              ticks: {
+                suggestedMin: 0,
+                maxTicksLimit: 8,
+                fontColor: '#808080'
+              }
+            }
+          ]
+        }
+      }
     }
   },
   methods: {
@@ -122,10 +167,8 @@ export default {
       switch (Math.sign(dayBeforeRatio)) {
         case 1:
           return `+${dayBeforeRatio}`
-          break
         case -1:
           return `${dayBeforeRatio}`
-          break
         default:
           return `${dayBeforeRatio}`
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,7 +22,6 @@
         <time-bar-chart
           title="陽性患者数"
           :chart-data="patientsGraph"
-          :chart-option="option"
           :date="Data.patients.date"
           :unit="'人'"
         />
@@ -41,7 +40,6 @@
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
           :chart-data="contactsGraph"
-          :chart-option="option"
           :date="Data.contacts.date"
           :unit="'件'"
         />
@@ -50,7 +48,6 @@
         <time-bar-chart
           title="帰国者・接触者電話相談センター相談件数"
           :chart-data="querentsGraph"
-          :chart-option="option"
           :date="Data.querents.date"
           :unit="'件'"
         />
@@ -117,51 +114,6 @@ export default {
         icon: 'mdi-chart-timeline-variant',
         title: '都内の最新感染動向',
         date: Data.lastUpdate
-      },
-      option: {
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            label(tooltipItem) {
-              const labelText = tooltipItem.value + '人'
-              return labelText
-            }
-          }
-        },
-        responsive: true,
-        legend: {
-          display: false
-        },
-        scales: {
-          xAxes: [
-            {
-              stacked: true,
-              gridLines: {
-                display: false
-              },
-              ticks: {
-                fontSize: 10,
-                maxTicksLimit: 20,
-                fontColor: '#808080'
-              }
-            }
-          ],
-          yAxes: [
-            {
-              location: 'bottom',
-              stacked: true,
-              gridLines: {
-                display: true,
-                color: '#E5E5E5'
-              },
-              ticks: {
-                suggestedMin: 0,
-                maxTicksLimit: 8,
-                fontColor: '#808080'
-              }
-            }
-          ]
-        }
       }
     }
     return data


### PR DESCRIPTION
## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- [Topページ](https://dev-covid19-tokyo.netlify.com/)のチャートテーブルのツールチップで表示される単位が, チャートの単位が`件`であるデータも全て`人`になっていた -> `props.unit`に

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
↓before↓
<img width="330" alt="スクリーンショット 2020-03-05 13 47 42" src="https://user-images.githubusercontent.com/42742053/75951241-ccd59c00-5eee-11ea-9bb5-8463e314680a.png">

↓After↓
<img width="409" alt="スクリーンショット 2020-03-05 14 37 31" src="https://user-images.githubusercontent.com/42742053/75951283-e4ad2000-5eee-11ea-8a11-5aad020cb88a.png">
