### PR TITLE
【typo修正】「東京都新型コロナイルス感染症対策本部報」を「東京都新型コロナウイルス感染症対策本部報」に変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -71,7 +71,7 @@
     "for Families with children": "お子様をお持ちの皆様へ",
     "for Citizens": "都民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
-    "Official statements from Task Force": "東京都新型コロナイルス感染症対策本部報",
+    "Official statements from Task Force": "東京都新型コロナウイルス感染症対策本部報",
     "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
     "Government official website": "東京都公式ホームページ",
     "Message from Governor Koike": "知事からのメッセージ",


### PR DESCRIPTION
## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
-  サイドビューのtypo修正
- "東京都新型コロナイルス感染症対策本部報"を"東京都新型コロナウイルス感染症対策本部報"に変更

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
![image](https://user-images.githubusercontent.com/45462830/75955217-bd5b5080-5ef8-11ea-9f9b-b06ae8378593.png)
