### PR TITLE
chore: Issue Template を分割

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,5 +1,6 @@
-- [ ] バグ / Bug
-- [ ] 改善提案 / Suggestions for improvement
+---
+labels: bug
+---
 
 ## 起こっている問題 / Occurred problem
 * xxxx(できるだけ簡潔に/as concise as possible)

--- a/.github/ISSUE_TEMPLATE/IMPROVE_SUGGESTIONS.md
+++ b/.github/ISSUE_TEMPLATE/IMPROVE_SUGGESTIONS.md
@@ -1,0 +1,15 @@
+---
+labels: improve
+---
+
+## 改善詳細 / Improve details
+* xxxx(できるだけ簡潔に/as concise as possible)
+
+## スクリーンショット / Screenshot
+<!-- バグであればdeveloper toolからコンソールも合わせて添付 -->
+
+## 期待する見せ方・挙動 / Expected behavior
+* xxxx(できるだけ簡潔に/as concise as possible)
+
+## 動作環境・ブラウザ / Environment
+*


### PR DESCRIPTION
## 📝 関連issue
- close #445

## ⛏ 変更内容

- Issue Template をバグとそれ以外で分割
  - 合わせて `bug` および `improve(旧: 改善提案)` ラベルが自動付与されるように
  - label 単位で簡単に絞り込めるように

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->