### PR TITLE
[要検算] 検査実施日別状況のグラフを追加

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,0 +1,182 @@
+<template>
+  <data-view :title="title" :date="date">
+    <template v-slot:button>
+      <data-selector v-model="dataKind" />
+    </template>
+    <bar :chart-data="displayData" :options="options" :height="240" />
+    <template v-slot:infoPanel>
+      <data-view-basic-info-panel
+        :l-text="displayInfo.lText"
+        :s-text="displayInfo.sText"
+        :unit="displayInfo.unit"
+      />
+    </template>
+  </data-view>
+</template>
+
+<script>
+import DataView from '@/components/DataView.vue'
+import DataSelector from '@/components/DataSelector.vue'
+import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+
+function cumulative(array) {
+  const cumulativeArray = [];
+  let patSum = 0;
+  array.forEach(d => {
+    patSum += d;
+    cumulativeArray.push(patSum);
+  });
+  return cumulativeArray;
+}
+
+function sum(array) {
+  return array.reduce((acc, cur) => {
+    return acc + cur;
+  })
+}
+
+function pickLastNumber(chartDataArray) {
+  return chartDataArray.map(array => {
+    return array[array.length - 1];
+  })
+}
+
+function cumulativeSum(chartDataArray) {
+  return chartDataArray.map(array => {
+    return array.reduce((acc, cur) => {
+      return acc + cur;
+    })
+  });
+}
+
+export default {
+  components: { DataView, DataSelector, DataViewBasicInfoPanel },
+  props: {
+    title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    chartData: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    date: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    items: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    labels: {
+      type: Array,
+      required: false,
+      default: () => []
+    },
+    unit: {
+      type: String,
+      required: false,
+      default: ''
+    },
+  },
+  data() {
+    return {
+      dataKind: 'transition'
+    }
+  },
+  computed: {
+    displayInfo() {
+      if (this.dataKind === 'transition') {
+        return {
+          lText: sum(pickLastNumber(this.chartData)).toLocaleString(),
+          sText: `${this.labels[this.labels.length - 1]} の合計`,
+          unit: this.unit
+        }
+      }
+      return {
+        lText: sum(cumulativeSum(this.chartData)).toLocaleString(),
+        sText: `${this.labels[this.labels.length - 1]} の全体累計`,
+        unit: this.unit
+      }
+    },
+    displayData() {
+      const colorArray = ['#00A040', '#00D154'];
+      if (this.dataKind === 'transition') {
+        return {
+          labels: this.labels,
+          datasets: this.chartData.map((item, index) => {
+            return {
+              label: this.items[index],
+              data: item,
+              backgroundColor: colorArray[index],
+              borderWidth: 0
+            }
+          })
+        }
+      }
+      return {
+        labels: this.labels,
+        datasets: this.chartData.map((item, index) => {
+          return {
+            label: this.items[index],
+            data: cumulative(item),
+            backgroundColor: colorArray[index],
+            borderWidth: 0
+          }
+        })
+      }
+    },
+    options() {
+      return {
+        tooltips: {
+          displayColors: false,
+          callbacks: {
+            label(tooltipItem) {
+              const labelText = tooltipItem.value + '人'
+              return labelText
+            }
+          }
+        },
+        responsive: true,
+        legend: {
+          display: true
+        },
+        scales: {
+          xAxes: [
+            {
+              stacked: true,
+              gridLines: {
+                display: false
+              },
+              ticks: {
+                fontSize: 10,
+                maxTicksLimit: 20,
+                fontColor: '#808080'
+              }
+            }
+          ],
+          yAxes: [
+            {
+              location: 'bottom',
+              stacked: true,
+              gridLines: {
+                display: true,
+                color: '#E5E5E5'
+              },
+              ticks: {
+                suggestedMin: 0,
+                maxTicksLimit: 8,
+                fontColor: '#808080'
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+</script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,7 +43,16 @@
           :info="sumInfoOfPatients"
         />
       </v-col>
-
+      <v-col cols="12" md="6" class="DataCard">
+        <time-stacked-bar-chart
+          title="検査実施日別状況"
+          :chart-data="inspectionsGraph"
+          :date="Data.inspections_summary.date"
+          :items="inspectionsItems"
+          :labels="inspectionsLabels"
+          :unit="'人'"
+        />
+      </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
@@ -69,6 +78,7 @@
 <script>
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
+import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
 import Data from '@/data/data.json'
@@ -81,6 +91,7 @@ export default {
   components: {
     PageHeader,
     TimeBarChart,
+    TimeStackedBarChart,
     WhatsNew,
     StaticInfo,
     DataTable,
@@ -99,6 +110,10 @@ export default {
     const contactsGraph = formatGraph(Data.contacts.data)
     // 帰国者・接触者電話相談センター相談件数
     const querentsGraph = formatGraph(Data.querents.data)
+    // 検査実施日別状況
+    const inspectionsGraph = [Data.inspections_summary.data['都内'], Data.inspections_summary.data['その他']]
+    const inspectionsItems = ['都内発生（疑い例・接触者調査）', 'その他（チャーター便・クルーズ便）']
+    const inspectionsLabels = Data.inspections_summary.labels
     // 死亡者数
     // #MEMO: 今後使う可能性あるので一時コメントアウト
     // const fatalitiesTable = formatTable(
@@ -121,6 +136,9 @@ export default {
       dischargesGraph,
       contactsGraph,
       querentsGraph,
+      inspectionsGraph,
+      inspectionsItems,
+      inspectionsLabels,
       sumInfoOfPatients,
       headerItem: {
         icon: 'mdi-chart-timeline-variant',


### PR DESCRIPTION
## 📝 関連issue
- close #355 

## ⛏ 変更内容
- 検査実施日別状況のグラフを追加しました。
- サイトトップのグラフの並び順を修正しました。

chartのoption値がindex.vueとTimeStackedBarChart.vueとで冗長になってしまいましたが（legendの値が違う・tooltipも変更予定）、しばらくそのままにしておいてください（何かいい方法があればissueを立ててください）。

## 📸 スクリーンショット
![スクリーンショット 2020-03-05 15 14 12](https://user-images.githubusercontent.com/14883063/75955254-d06e2080-5ef8-11ea-9a32-2c900665fd0d.png)
![スクリーンショット 2020-03-05 15 17 08](https://user-images.githubusercontent.com/14883063/75955266-d5cb6b00-5ef8-11ea-8c4c-113932f4d3a4.png)
