### PR TITLE
グラフのツールチップのみを月日表記に変更

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -83,7 +83,7 @@ export default {
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
-            return d.label.replace(/(\w+)\/(\w+)/, '$1月$2月')
+            return d.label.replace(/(\w+)\/(\w+)/, '$1月$2日')
           }),
           datasets: [
             {
@@ -99,7 +99,7 @@ export default {
       }
       return {
         labels: this.chartData.map(d => {
-          return d.label.replace(/(\w+)\/(\w+)/, '$1月$2月')
+          return d.label.replace(/(\w+)\/(\w+)/, '$1月$2日')
         }),
         datasets: [
           {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -83,7 +83,7 @@ export default {
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
-            return d.label
+            return d.label.replace(/(\w+)\/(\w+)/, '$1月$2月')
           }),
           datasets: [
             {
@@ -99,7 +99,7 @@ export default {
       }
       return {
         labels: this.chartData.map(d => {
-          return d.label
+          return d.label.replace(/(\w+)\/(\w+)/, '$1月$2月')
         }),
         datasets: [
           {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -83,7 +83,7 @@ export default {
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
-            return d.label.replace(/(\w+)\/(\w+)/, '$1月$2日')
+            return d.label
           }),
           datasets: [
             {
@@ -99,7 +99,7 @@ export default {
       }
       return {
         labels: this.chartData.map(d => {
-          return d.label.replace(/(\w+)\/(\w+)/, '$1月$2日')
+          return d.label
         }),
         datasets: [
           {
@@ -122,6 +122,12 @@ export default {
             label(tooltipItem) {
               const labelText = tooltipItem.value + unit
               return labelText
+            },
+            title(tooltipItem, data) {
+              return data.labels[tooltipItem[0].index].replace(
+                /(\w+)\/(\w+)/,
+                '$1月$2日'
+              )
             }
           }
         },

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -107,7 +107,7 @@ export default {
       const colorArray = ['#00A040', '#00D154']
       if (this.dataKind === 'transition') {
         return {
-          labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2日')),
+          labels: this.labels,
           datasets: this.chartData.map((item, index) => {
             return {
               label: this.items[index],
@@ -119,7 +119,7 @@ export default {
         }
       }
       return {
-        labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2日')),
+        labels: this.labels,
         datasets: this.chartData.map((item, index) => {
           return {
             label: this.items[index],
@@ -138,6 +138,12 @@ export default {
             label(tooltipItem) {
               const labelText = tooltipItem.value + '人'
               return labelText
+            },
+            title(tooltipItem, data) {
+              return data.labels[tooltipItem[0].index].replace(
+                /(\w+)\/(\w+)/,
+                '$1月$2日'
+              )
             }
           }
         },

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -20,33 +20,33 @@ import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 
 function cumulative(array) {
-  const cumulativeArray = [];
-  let patSum = 0;
+  const cumulativeArray = []
+  let patSum = 0
   array.forEach(d => {
-    patSum += d;
-    cumulativeArray.push(patSum);
-  });
-  return cumulativeArray;
+    patSum += d
+    cumulativeArray.push(patSum)
+  })
+  return cumulativeArray
 }
 
 function sum(array) {
   return array.reduce((acc, cur) => {
-    return acc + cur;
+    return acc + cur
   })
 }
 
 function pickLastNumber(chartDataArray) {
   return chartDataArray.map(array => {
-    return array[array.length - 1];
+    return array[array.length - 1]
   })
 }
 
 function cumulativeSum(chartDataArray) {
   return chartDataArray.map(array => {
     return array.reduce((acc, cur) => {
-      return acc + cur;
+      return acc + cur
     })
-  });
+  })
 }
 
 export default {
@@ -81,7 +81,7 @@ export default {
       type: String,
       required: false,
       default: ''
-    },
+    }
   },
   data() {
     return {
@@ -104,10 +104,10 @@ export default {
       }
     },
     displayData() {
-      const colorArray = ['#00A040', '#00D154'];
+      const colorArray = ['#00A040', '#00D154']
       if (this.dataKind === 'transition') {
         return {
-          labels: this.labels,
+          labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2月')),
           datasets: this.chartData.map((item, index) => {
             return {
               label: this.items[index],
@@ -119,7 +119,7 @@ export default {
         }
       }
       return {
-        labels: this.labels,
+        labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2月')),
         datasets: this.chartData.map((item, index) => {
           return {
             label: this.items[index],

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -107,7 +107,7 @@ export default {
       const colorArray = ['#00A040', '#00D154']
       if (this.dataKind === 'transition') {
         return {
-          labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2月')),
+          labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2日')),
           datasets: this.chartData.map((item, index) => {
             return {
               label: this.items[index],
@@ -119,7 +119,7 @@ export default {
         }
       }
       return {
-        labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2月')),
+        labels: this.labels.map(v => v.replace(/(\w+)\/(\w+)/, '$1月$2日')),
         datasets: this.chartData.map((item, index) => {
           return {
             label: this.items[index],


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- #194

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- tooltipsのm/d から m月d日へ変更するためにlabelの値をm月d日のフォーマットに変更
- pre-commitで;が除かれてた(なのでこちらの変更点は実質`.replace(/(\w+)\/(\w+)/, '$1月$2月')`の部分になります)

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<img width="609" alt="スクリーンショット 2020-03-05 19 15 07" src="https://user-images.githubusercontent.com/135112/75971834-af67f880-5f15-11ea-8a35-b721685e61ee.png">
