### PR TITLE
fix: 都営地下鉄の利用者数グラフの縦軸の数値を読みやすくする

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -117,8 +117,14 @@ export default {
     // 都営地下鉄の利用者数の推移
     const metroGraph = MetroData
     // 検査実施日別状況
-    const inspectionsGraph = [Data.inspections_summary.data['都内'], Data.inspections_summary.data['その他']]
-    const inspectionsItems = ['都内発生（疑い例・接触者調査）', 'その他（チャーター便・クルーズ便）']
+    const inspectionsGraph = [
+      Data.inspections_summary.data['都内'],
+      Data.inspections_summary.data['その他']
+    ]
+    const inspectionsItems = [
+      '都内発生（疑い例・接触者調査）',
+      'その他（チャーター便・クルーズ便）'
+    ]
     const inspectionsLabels = Data.inspections_summary.labels
     // 死亡者数
     // #MEMO: 今後使う可能性あるので一時コメントアウト
@@ -225,7 +231,7 @@ export default {
                 display: true
               },
               ticks: {
-                fontSize: 10,
+                fontSize: 12,
                 maxTicksLimit: 10,
                 fontColor: '#808080',
                 callback(value) {


### PR DESCRIPTION
## 📝 関連issue
- close #470

## ⛏ 変更内容

- 可読性を担保するために「都営地下鉄の利用者数の推移」グラフの Y軸の `font-size` を大きくしました

## 📸 スクリーンショット
### before
![スクリーンショット 2020-03-05 19 22 47](https://user-images.githubusercontent.com/5207601/75972765-513c1500-5f17-11ea-86af-77ae3ea7a35d.png)

### after
![スクリーンショット 2020-03-05 19 22 23](https://user-images.githubusercontent.com/5207601/75972773-54370580-5f17-11ea-8f0c-9367c4a634c4.png)
