### PR TITLE
about ページのリンクの修正

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -87,12 +87,16 @@
     <TextCard title="データについて">
       本サイトで公表しているデータは、<a
         href="https://portal.data.metro.tokyo.lg.jp/"
+        target="_blank"
+        rel="noopener"
         >東京都オープンデータカタログサイト</a
       >より誰でも自由にダウンロードが可能です。（データは順次追加予定です）
     </TextCard>
     <TextCard title="ソースコードについて">
       本サイトのソースコードはMITライセンスで公開されており、誰でも自由に利用することができます。詳しくは、<a
         href="https://github.com/tokyo-metropolitan-gov/covid19"
+        target="_blank"
+        rel="noopener"
         >GitHub リポジトリ</a
       >をご確認ください。
     </TextCard>


### PR DESCRIPTION
#476 で追加し忘れたページリンクへ target="_blank" rel="noopener" を追加
