### PR TITLE
fix: グラフで表示される数値をカンマ区切りに修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -59,12 +59,12 @@ export default {
     displayCumulativeRatio() {
       const lastDay = this.chartData.slice(-1)[0].cumulative
       const lastDayBefore = this.chartData.slice(-2)[0].cumulative
-      return this.formatDayBeforeRatio(lastDay - lastDayBefore).toLocaleString()
+      return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayTransitionRatio() {
       const lastDay = this.chartData.slice(-1)[0].transition
       const lastDayBefore = this.chartData.slice(-2)[0].transition
-      return this.formatDayBeforeRatio(lastDay - lastDayBefore).toLocaleString()
+      return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
       if (this.dataKind === 'transition') {
@@ -125,7 +125,8 @@ export default {
           displayColors: false,
           callbacks: {
             label(tooltipItem) {
-              const labelText = tooltipItem.value + unit
+              const labelText =
+                parseInt(tooltipItem.value).toLocaleString() + unit
               return labelText
             },
             title(tooltipItem, data) {
@@ -176,13 +177,14 @@ export default {
   },
   methods: {
     formatDayBeforeRatio(dayBeforeRatio) {
+      const dayBeforeRatioLocaleString = dayBeforeRatio.toLocaleString()
       switch (Math.sign(dayBeforeRatio)) {
         case 1:
-          return `+${dayBeforeRatio}`
+          return `+${dayBeforeRatioLocaleString}`
         case -1:
-          return `${dayBeforeRatio}`
+          return `${dayBeforeRatioLocaleString}`
         default:
-          return `${dayBeforeRatio}`
+          return `${dayBeforeRatioLocaleString}`
       }
     }
   }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -137,7 +137,8 @@ export default {
           displayColors: false,
           callbacks: {
             label(tooltipItem) {
-              const labelText = tooltipItem.value + unit
+              const labelText =
+                parseInt(tooltipItem.value).toLocaleString() + unit
               return labelText
             },
             title(tooltipItem, data) {


### PR DESCRIPTION
## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- グラフの前日比で表示される数値をカンマ区切りに修正
- グラフのツールチップで表示される数値をカンマ区切りに修正

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
### Before
![image](https://user-images.githubusercontent.com/41186511/75986143-e13a8880-5f30-11ea-8bc7-9620c3e54fe4.png)

### After
![image](https://user-images.githubusercontent.com/41186511/75986098-c536e700-5f30-11ea-8247-4c72a91bacba.png)
