### PR TITLE
#498 fix nav title

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -30,7 +30,6 @@
         <v-container
           v-for="(item, i) in items"
           :key="i"
-          :class="isClass(item)"
           class="SideNavigation-ListItemContainer"
           @click="closeNavi"
         >
@@ -156,9 +155,6 @@ export default {
           divider: true
         }
       ]
-    },
-    isClass() {
-      return item => (item.title.charAt(0) === '【' ? 'kerningLeft' : '')
     }
   },
   methods: {
@@ -272,8 +268,5 @@ export default {
   .sp-none {
     display: none;
   }
-}
-.kerningLeft {
-  text-indent: -0.5em;
 }
 </style>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -80,7 +80,7 @@
     "for Citizens": "都民の皆様へ",
     "for Enterprises and Employees": "企業の皆様・はたらく皆様へ",
     "Official statements from Task Force": "東京都新型コロナウイルス感染症対策本部報",
-    "Cancelled public events": "【東京都主催等】中止または延期するイベント・説明会等",
+    "Cancelled public events": "東京都主催等 中止又は延期するイベント等",
     "Government official website": "東京都公式ホームページ",
     "Message from Governor Koike": "知事からのメッセージ",
     "About us": "当サイトについて"


### PR DESCRIPTION
## 📝 関連issue
- close #498 

## ⛏ 変更内容
- 左のナビゲーションのリンクタイトルを下記の通り変更
  - `【東京都主催等】中止又は延期するイベント・説明会等` -> `東京都主催等　中止又は延期するイベント等`
- カーニング用につかっていた処理及びスタイル, クラスを削除

## 📸 スクリーンショット
|before|after|
|-|-|
|[![Image from Gyazo](https://i.gyazo.com/e1d8efb3b9bf20f83f6e9e71ba559b72.png)](https://gyazo.com/e1d8efb3b9bf20f83f6e9e71ba559b72)|[![Image from Gyazo](https://i.gyazo.com/b196fa220cc059d2defeb3eded57abba.png)](https://gyazo.com/b196fa220cc059d2defeb3eded57abba)|