### PR TITLE
検査実施日別状況のタイトルと単位を修正

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -131,12 +131,13 @@ export default {
       }
     },
     options() {
+      const unit = this.unit
       return {
         tooltips: {
           displayColors: false,
           callbacks: {
             label(tooltipItem) {
-              const labelText = tooltipItem.value + '人'
+              const labelText = tooltipItem.value + unit
               return labelText
             }
           }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -42,12 +42,12 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-stacked-bar-chart
-          title="検査実施日別状況"
+          title="検査実施数"
           :chart-data="inspectionsGraph"
           :date="Data.inspections_summary.date"
           :items="inspectionsItems"
           :labels="inspectionsLabels"
-          :unit="'人'"
+          :unit="'件'"
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">


### PR DESCRIPTION
## 📝 関連issue
- close #504 
- close #506 

## ⛏ 変更内容
- 検査実施日別状況のタイトルと単位を修正しました

## 📸 スクリーンショット
![スクリーンショット 2020-03-05 23 34 43](https://user-images.githubusercontent.com/14883063/75991683-28794700-5f3a-11ea-9f33-96a67a1e40d4.png)
