### PR TITLE
外部リンクに rel="noopener" を追加

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -15,7 +15,7 @@
     </v-card-text>
     <v-footer class="DataView-Footer">
       <time :datetime="date">{{ date }} 更新</time>
-      <a v-if="url" class="OpenDataLink" :href="url" target="_blank">オープンデータへのリンク
+      <a v-if="url" class="OpenDataLink" :href="url" target="_blank" rel="noopener">オープンデータへのリンク
         <v-icon class="ExternalLinkIcon" size="15">
           mdi-open-in-new
         </v-icon>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -5,7 +5,7 @@
       最新のお知らせ
     </h2>
     <div v-for="(item, i) in items" :key="i">
-      <a class="WhatsNew-item" :href="item.url" target="_blank">
+      <a class="WhatsNew-item" :href="item.url" target="_blank" rel="noopener">
         <time class="WhatsNew-item-time px-2">{{ item.date }}</time>
         <span class="WhatsNew-item-link">{{ item.text }}</span>
       </a>


### PR DESCRIPTION
## 📝 関連issue
- #476 
- #389

## ⛏ 変更内容
外部リンクに `rel="noopener"` が入っていないものがあったので追加しました。