### PR TITLE
「帰国者・接触者電話相談センター相談件数」タイトルを修正

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -61,7 +61,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
-          title="帰国者・接触者電話相談センター相談件数"
+          title="新型コロナ受診相談窓口相談件数"
           :chart-data="querentsGraph"
           :date="Data.querents.date"
           :unit="'件'"


### PR DESCRIPTION
## 📝 関連issue
- close #508 

## ⛏ 変更内容
- 「帰国者・接触者電話相談センター相談件数」を「新型コロナ受診相談窓口相談件数」に修正しました。

## 📸 スクリーンショット
![スクリーンショット 2020-03-05 23 40 09](https://user-images.githubusercontent.com/14883063/75992418-47c4a400-5f3b-11ea-809f-fced286f8298.png)
