### PR TITLE
#514 スマホ表示での最新のお知らせの左の余白を削除する

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -66,7 +66,7 @@ export default {
     flex: 0 1 auto;
     @include text-link();
     @include lessThan($medium) {
-      padding-left: 15px;
+      padding-left: 8px;
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue
- close #514

## ⛏ 変更内容
padding調整

## 📸 スクリーンショット
<img width="364" alt="スクリーンショット 2020-03-05 23 57 56" src="https://user-images.githubusercontent.com/1410018/75993647-2664b780-5f3d-11ea-80e3-f2c4a8b3c364.png">
