### PR TITLE
chore: Raise the minimum version of nuxt to 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "chart.js": "^2.9.3",
     "cross-env": "^5.2.0",
     "express": "^4.16.4",
-    "nuxt": "^2.0.0",
+    "nuxt": "^2.9.0",
     "nuxt-i18n": "^6.6.0",
     "vue-chartjs": "^3.5.0",
     "vue-property-decorator": "^8.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7520,7 +7520,7 @@ nuxt-svg-loader@^1.2.0:
     consola "^2.3.2"
     svg-to-vue-component "^0.3.1"
 
-nuxt@^2.0.0:
+nuxt@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/nuxt/-/nuxt-2.11.0.tgz#654664fe1a95af2014fd55c38ba2c732bfa5edc5"
   integrity sha512-Y7lastjYWIOppja0FaWozPfkvlmJ8uZSqWx0VbK7l5djbHls5jgUGag0iu6GsNNwCFTKpoAtptNHiWOsyMxStA==


### PR DESCRIPTION
## 📝 関連issue

- close #525

## ⛏ 変更内容

- nuxtの最小バージョンを2.9.0にした。