### PR TITLE
[Draft] og:titleが変更されるように

### DIFF
--- a/assets/mixins/meta.js
+++ b/assets/mixins/meta.js
@@ -1,0 +1,10 @@
+export default {
+  head() {
+    return {
+      title: this.meta.title,
+      meta: [
+        { hid: 'og:title', property: 'og:title', content: this.meta.title }
+      ]
+    }
+  }
+}

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -89,16 +89,20 @@
         href="https://portal.data.metro.tokyo.lg.jp/"
         target="_blank"
         rel="noopener"
-        >東京都オープンデータカタログサイト</a
-      >より誰でも自由にダウンロードが可能です。（データは順次追加予定です）
+      >
+        東京都オープンデータカタログサイト
+      </a>
+      より誰でも自由にダウンロードが可能です。（データは順次追加予定です）
     </TextCard>
     <TextCard title="ソースコードについて">
       本サイトのソースコードはMITライセンスで公開されており、誰でも自由に利用することができます。詳しくは、<a
         href="https://github.com/tokyo-metropolitan-gov/covid19"
         target="_blank"
         rel="noopener"
-        >GitHub リポジトリ</a
-      >をご確認ください。
+      >
+        GitHub リポジトリ
+      </a>
+      をご確認ください。
     </TextCard>
 
     <TextCard title="お問い合わせ先（都のHPサイトポリシーについて）">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -115,14 +115,18 @@
 
 <script lang="ts">
 import TextCard from '@/components/TextCard.vue'
+import Meta from '@/assets/mixins/meta'
 
 export default {
   components: {
     TextCard
   },
-  head() {
+  mixins: [Meta],
+  data() {
     return {
-      title: '当サイトについて'
+      meta: {
+        title: '当サイトについて'
+      }
     }
   }
 }

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -2,7 +2,9 @@
   <div class="Flow">
     <div class="Flow-Heading">
       <CovidIcon />
-      <h2 class="Flow-Heading-Title">新型コロナウイルス感染症が心配なときに</h2>
+      <h2 class="Flow-Heading-Title">
+        新型コロナウイルス感染症が心配なときに
+      </h2>
     </div>
     <div class="Flow-Card">
       <h2>
@@ -14,53 +16,103 @@
       <div class="only-sp">
         <div class="Flow-Card-Parts">
           <div class="mb-5">
-            <img src="/flow/sp/sp_flow_01_01@2x.png" alt="発症前２週間以内の出来ごとと症状／「新型コロナウイルス感染者」と濃厚接触をした方／発熱または呼吸器症状" />
+            <img
+              src="/flow/sp/sp_flow_01_01@2x.png"
+              alt="発症前２週間以内の出来ごとと症状／「新型コロナウイルス感染者」と濃厚接触をした方／発熱または呼吸器症状"
+            />
           </div>
           <div class="mx-2 mb-5">
-            <img src="/flow/sp/sp_flow_01_02@2x.png" alt="流行地域への渡航・居住歴がある方　ご本人か濃厚接触をした方／呼吸器症状かつ発熱37.5℃以上" />
+            <img
+              src="/flow/sp/sp_flow_01_02@2x.png"
+              alt="流行地域への渡航・居住歴がある方 ご本人か濃厚接触をした方／呼吸器症状かつ発熱37.5℃以上"
+            />
           </div>
           <div>
-            <a href="#consult"><img src="/flow/sp/sp_flow_01_02_03_nav@2x.png" alt="新型コロナ受診相談窓口へ" /></a>
+            <a href="#consult">
+              <img
+                src="/flow/sp/sp_flow_01_02_03_nav@2x.png"
+                alt="新型コロナ受診相談窓口へ"
+              />
+            </a>
           </div>
         </div>
         <div class="Flow-Card-Parts">
           <div class="mx-2 mb-5">
-            <img src="/flow/sp/sp_flow_02@2x.png" alt="一般の方／風邪のような症状・発熱37.5℃以上・強いだるさ・息苦しさ／４日以上続いている" />
+            <img
+              src="/flow/sp/sp_flow_02@2x.png"
+              alt="一般の方／風邪のような症状・発熱37.5℃以上・強いだるさ・息苦しさ／４日以上続いている"
+            />
           </div>
           <div>
-            <a href="#consult"><img src="/flow/sp/sp_flow_01_02_03_nav@2x.png" alt="新型コロナ受診相談窓口へ" /></a>
+            <a href="#consult">
+              <img
+                src="/flow/sp/sp_flow_01_02_03_nav@2x.png"
+                alt="新型コロナ受診相談窓口へ"
+              />
+            </a>
           </div>
         </div>
         <div class="Flow-Card-Parts">
           <div class="mx-2 mb-5">
-            <img src="/flow/sp/sp_flow_03@2x.png" alt="ご高齢な方・基礎疾患のある方・妊娠中の方／風邪のような症状・発熱37.5℃以上・強いだるさ・息苦しさ／２日以上続いている" />
+            <img
+              src="/flow/sp/sp_flow_03@2x.png"
+              alt="ご高齢な方・基礎疾患のある方・妊娠中の方／風邪のような症状・発熱37.5℃以上・強いだるさ・息苦しさ／２日以上続いている"
+            />
           </div>
           <div>
-            <a href="#consult"><img src="/flow/sp/sp_flow_01_02_03_nav@2x.png" alt="新型コロナ受診相談窓口へ" /></a>
+            <a href="#consult">
+              <img
+                src="/flow/sp/sp_flow_01_02_03_nav@2x.png"
+                alt="新型コロナ受診相談窓口へ"
+              />
+            </a>
           </div>
         </div>
         <div class="Flow-Card-Parts">
           <div class="mx-2 mb-5">
-            <img src="/flow/sp/sp_flow_04@2x.png" alt="不安に思う方／微熱・軽い咳・感染の不安／新型コロナコールセンター　午前９時から午後９時（土日祝含む）" />
+            <img
+              src="/flow/sp/sp_flow_04@2x.png"
+              alt="不安に思う方／微熱・軽い咳・感染の不安／新型コロナコールセンター 午前９時から午後９時（土日祝含む）"
+            />
           </div>
           <div class="TelLink">
-            <a href="tel:0570550571"><img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571" /></a>
+            <a href="tel:0570550571"
+              ><img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571"
+            /></a>
           </div>
           <div class="mt-4">
-            <a href="#consult"><img src="/flow/sp/sp_flow_04_nav@2x.png" alt="専門的な助言が必要な場合"></a>
+            <a href="#consult">
+              <img
+                src="/flow/sp/sp_flow_04_nav@2x.png"
+                alt="専門的な助言が必要な場合"
+              />
+            </a>
           </div>
         </div>
-        <div class="Flow-Card-Parts Flat" id="consult">
-          <h3 class="SodanHeader Title">新型コロナ受診相談窓口</h3>
-          <p class="SodanHeader">帰国者・接触者電話相談センター</p>
+        <div id="consult" class="Flow-Card-Parts Flat">
+          <h3 class="SodanHeader Title">
+            新型コロナ受診相談窓口
+          </h3>
+          <p class="SodanHeader">
+            帰国者・接触者電話相談センター
+          </p>
           <div class="SodanHeader">
-            <div class="SodanChip">24時間対応</div>
+            <div class="SodanChip">
+              24時間対応
+            </div>
           </div>
           <dl>
             <div class="SodanHeijitsu">
-              <dt class="Heijitsu">平日（日中）</dt>
+              <dt class="Heijitsu">
+                平日（日中）
+              </dt>
               <dd>
-                <a class="Link" href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">
+                <a
+                  class="Link"
+                  href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
+                  target="_blank"
+                  rel="noopener"
+                >
                   各保健所の電話番号は福祉保健局HPへ
                   <v-icon size="16">
                     mdi-open-in-new
@@ -69,41 +121,80 @@
               </dd>
             </div>
             <div class="SodanYakan">
-              <dt class="Yakan">平日（夜間）<br /><span class="SodanTime">午後５時から翌朝午前９時</span><br />土日祝 終日</dt>
-              <dd class="TelLink"><a href="tel:0353204592"><img src="/flow/sp/sp_flow_tel_03@2x.png" alt="03-5320-4592" /></a></dd>
+              <dt class="Yakan">
+                平日（夜間）
+                <br />
+                <span class="SodanTime">午後５時から翌朝午前９時</span>
+                <br />
+                土日祝 終日
+              </dt>
+              <dd class="TelLink">
+                <a href="tel:0353204592">
+                  <img
+                    src="/flow/sp/sp_flow_tel_03@2x.png"
+                    alt="03-5320-4592"
+                  />
+                </a>
+              </dd>
             </div>
           </dl>
         </div>
         <div class="Flow-Card-Parts">
           <div class="mx-2 mb-5">
-            <img src="/flow/sp/sp_flow_06_01@2x.png" alt="新型コロナ受診相談窓口による相談結果／新型コロナ外来受診が必要と判断された場合／新型コロナ外来（帰国者・接触者外来）医師による判断" />
+            <img
+              src="/flow/sp/sp_flow_06_01@2x.png"
+              alt="新型コロナ受診相談窓口による相談結果／新型コロナ外来受診が必要と判断された場合／新型コロナ外来（帰国者・接触者外来）医師による判断"
+            />
           </div>
           <div class="Col2Btn">
             <div class="mx-1 mb-5">
-              <a href="#not_required"><img src="/flow/sp/sp_flow_06_nav_01@2x.png" alt="検査の必要なし" /></a>
+              <a href="#not_required">
+                <img
+                  src="/flow/sp/sp_flow_06_nav_01@2x.png"
+                  alt="検査の必要なし"
+                />
+              </a>
             </div>
             <div class="mx-1 mb-5">
-              <a href="#pcr"><img src="/flow/sp/sp_flow_06_nav_02@2x.png" alt="検査の必要あり" /></a>
+              <a href="#pcr">
+                <img
+                  src="/flow/sp/sp_flow_06_nav_02@2x.png"
+                  alt="検査の必要あり"
+                />
+              </a>
             </div>
           </div>
-          <div class="mx-2 mb-5" id="pcr">
-            <img src="/flow/sp/sp_flow_06_02@2x.png" alt="PCR検査　東京都健康安全研究センター等" />
+          <div id="pcr" class="mx-2 mb-5">
+            <img
+              src="/flow/sp/sp_flow_06_02@2x.png"
+              alt="PCR検査 東京都健康安全研究センター等"
+            />
           </div>
           <div class="Col2Btn">
             <div class="mx-1 mb-5">
-              <a href="#not_required"><img src="/flow/sp/sp_flow_06_nav_03@2x.png" alt="陰性" /></a>
+              <a href="#not_required">
+                <img src="/flow/sp/sp_flow_06_nav_03@2x.png" alt="陰性" />
+              </a>
             </div>
             <div class="mx-1 mb-5">
-              <a href="#hospitalized"><img src="/flow/sp/sp_flow_06_nav_04@2x.png" alt="陽性" /></a>
+              <a href="#hospitalized">
+                <img src="/flow/sp/sp_flow_06_nav_04@2x.png" alt="陽性" />
+              </a>
             </div>
           </div>
-          <div class="mx-2" id="not_required">
-            <img src="/flow/sp/sp_flow_06_03@2x.png" alt="新型コロナ外来受診が不要と判断された場合／自宅で安静に過ごす・一般の医療機関を受診／症状が良くならない場合は新型コロナ受診相談窓口に相談" />
+          <div id="not_required" class="mx-2">
+            <img
+              src="/flow/sp/sp_flow_06_03@2x.png"
+              alt="新型コロナ外来受診が不要と判断された場合／自宅で安静に過ごす・一般の医療機関を受診／症状が良くならない場合は新型コロナ受診相談窓口に相談"
+            />
           </div>
         </div>
-        <div class="Flow-Card-Parts" id="hospitalized">
+        <div id="hospitalized" class="Flow-Card-Parts">
           <div class="Smaller">
-            <img src="/flow/sp/sp_flow_06@2x.png" alt="入院となります／感染症指定医療機関等" />
+            <img
+              src="/flow/sp/sp_flow_06@2x.png"
+              alt="入院となります／感染症指定医療機関等"
+            />
           </div>
         </div>
       </div>
@@ -126,7 +217,7 @@
 import CovidIcon from '@/static/covid.svg'
 import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
 export default {
-  components: { CovidIcon, DesktopFlowSvg},
+  components: { CovidIcon, DesktopFlowSvg },
   head() {
     return {
       title: '新型コロナウイルス感染症が心配なときに'

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -76,9 +76,9 @@
             />
           </div>
           <div class="TelLink">
-            <a href="tel:0570550571"
-              ><img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571"
-            /></a>
+            <a href="tel:0570550571">
+              <img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571" />
+            </a>
           </div>
           <div class="mt-4">
             <a href="#consult">

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -216,11 +216,15 @@
 <script>
 import CovidIcon from '@/static/covid.svg'
 import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
+import Meta from '@/assets/mixins/meta'
 export default {
   components: { CovidIcon, DesktopFlowSvg },
-  head() {
+  mixins: [Meta],
+  data() {
     return {
-      title: '新型コロナウイルス感染症が心配なときに'
+      meta: {
+        title: '新型コロナウイルス感染症が心配なときに'
+      }
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,7 +26,9 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -36,7 +38,9 @@
           :chart-option="{}"
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -121,8 +125,14 @@ export default {
     // 都営地下鉄の利用者数の推移
     const metroGraph = MetroData
     // 検査実施日別状況
-    const inspectionsGraph = [Data.inspections_summary.data['都内'], Data.inspections_summary.data['その他']]
-    const inspectionsItems = ['都内発生（疑い例・接触者調査）', 'その他（チャーター便・クルーズ便）']
+    const inspectionsGraph = [
+      Data.inspections_summary.data['都内'],
+      Data.inspections_summary.data['その他']
+    ]
+    const inspectionsItems = [
+      '都内発生（疑い例・接触者調査）',
+      'その他（チャーター便・クルーズ便）'
+    ]
     const inspectionsLabels = Data.inspections_summary.labels
     // 死亡者数
     // #MEMO: 今後使う可能性あるので一時コメントアウト

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -97,6 +97,7 @@ import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
 import News from '@/data/news.json'
 import SvgCard from '@/components/SvgCard.vue'
+import Meta from '@/assets/mixins/meta'
 
 export default {
   components: {
@@ -109,6 +110,7 @@ export default {
     DataTable,
     SvgCard
   },
+  mixins: [Meta],
   data() {
     // 感染者数グラフ
     const patientsGraph = formatGraph(Data.patients_summary.data)
@@ -265,14 +267,12 @@ export default {
             }
           }
         }
+      },
+      meta: {
+        title: '都内の最新感染動向'
       }
     }
     return data
-  },
-  head() {
-    return {
-      title: '都内の最新感染動向'
-    }
   }
 }
 </script>

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -10,10 +10,12 @@
 </template>
 <script lang="ts">
 import TextCard from '@/components/TextCard.vue'
+import Meta from '@/assets/mixins/meta'
 export default {
   components: {
     TextCard
   },
+  mixins: [Meta],
   data() {
     return {
       items: [
@@ -31,12 +33,10 @@ export default {
           title: '3 その他',
           body: '〇  詳細は、各学校からのお知らせ等をご確認ください。'
         }
-      ]
-    }
-  },
-  head() {
-    return {
-      title: 'お子様をお持ちの皆様へ'
+      ],
+      meta: {
+        title: 'お子様をお持ちの皆様へ'
+      }
     }
   }
 }

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -10,10 +10,12 @@
 </template>
 <script lang="ts">
 import TextCard from '@/components/TextCard.vue'
+import Meta from '@/assets/mixins/meta'
 export default {
   components: {
     TextCard
   },
+  mixins: [Meta],
   data() {
     return {
       items: [
@@ -32,12 +34,10 @@ export default {
           body:
             '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
         }
-      ]
-    }
-  },
-  head() {
-    return {
-      title: '企業の皆様・はたらく皆様へ'
+      ],
+      meta: {
+        title: '企業の皆様・はたらく皆様へ'
+      }
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue
- close #435

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- `og:title` を変更するためのmixinを追加
- `data()`でmixinに`og:title`の中身を渡す
- #515 からcherry-pickしてます

## Notes
- 参考サイト
  - https://qiita.com/amishiro/items/b7260116b282d2cf2756
  - https://qiita.com/amishiro/items/77e3c2546fa63cc69a62
- Facebookの実装が一番楽に出来るのでとりあえずそれにしています。`og:title`にサイト名を含める場合は`titleTemplate`使わない方が良さそう（上記サイト参照）
