### PR TITLE
fix: canonical が消えていたのを修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -29,13 +29,6 @@ export default {
     ScaleLoader,
     SideNavigation
   },
-  head() {
-    return {
-      link: [
-        { rel: 'canonical', href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}` },
-      ],
-    };
-  },
   data() {
     return {
       isNaviOpen: false,
@@ -56,7 +49,13 @@ export default {
   head() {
     const { htmlAttrs } = this.$nuxtI18nSeo()
     return {
-      htmlAttrs
+      htmlAttrs,
+      link: [
+        {
+          rel: 'canonical',
+          href: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #{ISSUE_NUMBER}

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- layouts/default.vue に `head()` が 2個あり、canonical が消えていた

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
canonical 復活・htmlAttr との共存を確認
<img width="399" alt="スクリーンショット 2020-03-06 1 00 40" src="https://user-images.githubusercontent.com/8909592/75999709-fcfc5980-5f45-11ea-9d35-211af006c5fc.png">
<img width="437" alt="スクリーンショット 2020-03-06 1 00 49" src="https://user-images.githubusercontent.com/8909592/75999715-fe2d8680-5f45-11ea-9791-c6f2e807c5e3.png">
