### PR TITLE
whatsnew add ExternalLinkIcon #528

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,13 +1,20 @@
 <template>
   <div class="WhatsNew">
     <h2 class="WhatsNew-heading">
-      <v-icon size="24" class="WhatsNew-heading-icon">mdi-information</v-icon>
+      <v-icon size="24" class="WhatsNew-heading-icon">
+        mdi-information
+      </v-icon>
       最新のお知らせ
     </h2>
     <div v-for="(item, i) in items" :key="i">
       <a class="WhatsNew-item" :href="item.url" target="_blank">
         <time class="WhatsNew-item-time px-2">{{ item.date }}</time>
-        <span class="WhatsNew-item-link">{{ item.text }}</span>
+        <span class="WhatsNew-item-link">
+          {{ item.text }}
+          <v-icon size="14" class="WhatsNew-ExternalLink-icon">
+            mdi-open-in-new
+          </v-icon>
+        </span>
       </a>
     </div>
   </div>
@@ -25,7 +32,7 @@ export default {
 </script>
 
 <style lang="scss">
-.WhatsNew{
+.WhatsNew {
   @include card-container();
   padding: 10px;
   margin-bottom: 20px;


### PR DESCRIPTION
## 📝 関連issue
- close #528 

## ⛏ 変更内容
- 別タブ表示部分にExternalLinkIconの追加

## 📸 スクリーンショット
Before
![スクリーンショット 2020-03-06 1 00 05](https://user-images.githubusercontent.com/20437499/75999658-e8b85c80-5f45-11ea-847b-7a5e6cd5c91b.png)
After
![スクリーンショット 2020-03-06 0 59 45](https://user-images.githubusercontent.com/20437499/75999676-f2da5b00-5f45-11ea-8572-220668e55b28.png)
