### PR TITLE
グラフの色の修正 (Fix color of graphs)

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -51,7 +51,7 @@ export default {
   },
   computed: {
     displayData() {
-      const colors = ['#a6e29f', '#63c765', '#008b41']
+      const colors = ['#E6AC73', '#E6E68A', '#00B849']
       return {
         labels: this.chartData.datasets.map(d => d.label),
         datasets: this.chartData.labels.map((label, i) => {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -104,7 +104,7 @@ export default {
       }
     },
     displayData() {
-      const colorArray = ['#00A040', '#00D154']
+      const colorArray = ['#00B849', '#B8E6E6']
       if (this.dataKind === 'transition') {
         return {
           labels: this.labels,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,9 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -37,7 +39,9 @@
           :chart-option="{}"
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">


### PR DESCRIPTION
## ⛏ 変更内容

見やすさ（特に色盲・色弱者向け）および全体の統一感を考慮し，以下の通り変更

- **検査実施日別状況**
  - 緑 (`#00A040`) を，周囲の他のグラフに合わせて `#00B849` に
  - 「その他（チャーター便・クルーズ便）」の色を青系の `#B8E6E6` に
- **都営地下鉄の利用者数の推移**
  - 9:30 - 10:30 の緑 (`#008b41`) を，周囲の他のグラフに合わせて `#00B849` に
  - 時間帯の違いが明確になるよう，他の2本のグラフの色を変更

## 📸 スクリーンショット

### 検査実施日別状況
**Before**
![Screenshot 2020-03-06 00 52 26](https://user-images.githubusercontent.com/23148331/75998835-c4a84b80-5f44-11ea-8bc6-7df81c5b453a.png)

**After**
![Screenshot 2020-03-06 00 50 07](https://user-images.githubusercontent.com/23148331/75998646-7c892900-5f44-11ea-8e70-1a3838cc328d.png)

### 都営地下鉄の利用者数の推移
**Before**
![Screenshot 2020-03-06 00 53 12](https://user-images.githubusercontent.com/23148331/75998912-de499300-5f44-11ea-934e-402b46d3dbee.png)

**After**
![Screenshot 2020-03-06 01 00 05](https://user-images.githubusercontent.com/23148331/75999719-ff5eb380-5f45-11ea-8ea6-7d157d871848.png)
