### PR TITLE
Fix #536 TextCardのリンクデザインの統一

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -46,6 +46,7 @@ export default class TextCard extends Vue {
     a {
       word-break: break-all;
       color: $link;
+      text-decoration: none;
     }
   }
 }


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #536 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- TextCardのリンクデザインを他と統一するために、「常に下線あり」から「通常時下線なし、ホバー時下線あり」に変更。
- #536 ではparentページに関する言及だったが、TextCardを利用したもの全体に適用される。

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
![demo](https://i.gyazo.com/49297284e2af59fb9bda4f80abc2fb81.gif)