### PR TITLE
出典表示の変更 (Add data source name of graph)

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date" :url="url">
+  <data-view :title="title" :date="date" :url="url" :source="source">
     <template v-slot:button>
       <span />
     </template>
@@ -85,6 +85,10 @@ export default {
     url: {
       type: String,
       required: false,
+      default: ''
+    },
+    source: {
+      type: String,
       default: ''
     }
   }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -10,7 +10,11 @@
       <v-spacer />
       <slot name="infoPanel" />
     </v-toolbar>
-    <v-card-text :class="$vuetify.breakpoint.xs ? 'DataView-CardTextForXS' : 'DataView-CardText'">
+    <v-card-text
+      :class="
+        $vuetify.breakpoint.xs ? 'DataView-CardTextForXS' : 'DataView-CardText'
+      "
+    >
       <slot />
     </v-card-text>
     <v-footer class="DataView-Footer">

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -14,12 +14,16 @@
       <slot />
     </v-card-text>
     <v-footer class="DataView-Footer">
+      <span v-if="url">
+        出典:
+        <a class="OpenDataLink" :href="url" target="_blank">
+          <v-icon class="ExternalLinkIcon" size="15">
+            mdi-open-in-new
+          </v-icon>
+          {{ source }}
+        </a>
+      </span>
       <time :datetime="date">{{ date }} 更新</time>
-      <a v-if="url" class="OpenDataLink" :href="url" target="_blank">オープンデータへのリンク
-        <v-icon class="ExternalLinkIcon" size="15">
-          mdi-open-in-new
-        </v-icon>
-      </a>
     </v-footer>
   </v-card>
 </template>
@@ -32,6 +36,7 @@ export default class DataView extends Vue {
   @Prop() private title!: string
   @Prop() private date!: string
   @Prop() private url!: string
+  @Prop() private source!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
 }
 </script>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date" :url="url">
+  <data-view :title="title" :date="date" :url="url" :source="source">
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
@@ -45,6 +45,11 @@ export default {
       default: ''
     },
     url: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    source: {
       type: String,
       required: false,
       default: ''

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -28,6 +28,9 @@
           :date="Data.patients.date"
           :unit="'人'"
           :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :source="
+            '東京オープンデータカタログサイト 「東京都 新型コロナウイルス患者発表者数」'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
@@ -38,6 +41,9 @@
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
           :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :source="
+            '東京オープンデータカタログサイト 「東京都 新型コロナウイルス患者発表者数」'
+          "
         />
       </v-col>
       <v-col cols="12" md="6" class="DataCard">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -27,7 +27,9 @@
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
           :source="
             '東京オープンデータカタログサイト 「東京都 新型コロナウイルス患者発表者数」'
           "
@@ -40,7 +42,9 @@
           :chart-option="{}"
           :date="Data.patients.date"
           :info="sumInfoOfPatients"
-          :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+          :url="
+            'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+          "
           :source="
             '東京オープンデータカタログサイト 「東京都 新型コロナウイルス患者発表者数」'
           "


### PR DESCRIPTION
## 📝 関連issue
- close #533

## ⛏ 変更内容
- データの出典へのリンクが「オープンデータへのリンク」となっているものを，より明確に表示
  - そのために Vue component を修正

## 📸 スクリーンショット

### Before
![Screenshot 2020-03-06 01 50 16](https://user-images.githubusercontent.com/23148331/76004554-fcb38c80-5f4c-11ea-8f1c-d825298d9d70.png)
![Screenshot 2020-03-06 01 50 24](https://user-images.githubusercontent.com/23148331/76004558-fe7d5000-5f4c-11ea-81af-031402c481d5.png)

### After
![Screenshot 2020-03-06 01 50 33](https://user-images.githubusercontent.com/23148331/76004562-ffae7d00-5f4c-11ea-9f38-9fca93cd5b37.png)
![Screenshot 2020-03-06 01 50 36](https://user-images.githubusercontent.com/23148331/76004565-ffae7d00-5f4c-11ea-9fcd-38a576797722.png)

