### PR TITLE
Fix #524 スマホ表示時のヘッダーを固定表示する

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -92,10 +92,23 @@ export default {
     width: 325px;
   }
 }
+@include lessThan($small) {
+  .naviContainer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 65px;
+    width: 100%;
+    z-index: 100;
+  }
+  .mainContainer {
+    margin-top: 65px;
+  }
+}
 .open {
   overflow-x: hidden;
   overflow-y: auto;
-  height: 100vh;
+  height: 100vh !important;
 }
 .mainContainer {
   grid-column: 2/3;


### PR DESCRIPTION
## 📝 関連issue
- close #524 

## ⛏ 変更内容
- スマホ表示時のヘッダを固定表示化
- position: fixed; の追加
- 表の見出しなどが最前面に出ないようにz-indexを指定
- メニューをopenした時のheightにimportantを指定