### PR TITLE
グラフに注釈を追加

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -17,7 +17,7 @@
     margin-top: 10px;
     margin-bottom: 0 !important;
     font-size: 12px;
-    color: #808080;
+    color: $gray-3;
   }
 }
 </style>

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,5 +1,11 @@
 <template>
   <data-view class="SvgCard" :title="title" :date="date">
+    <template v-slot:button>
+      <p class="Graph-Desc">
+        （注）都内において疑い例または患者の濃厚接触者として検査を行ったものについて掲載<br />
+        （チャーター機帰国者、クルーズ船乗客等は含まれていない。）
+      </p>
+    </template>
     <slot />
   </data-view>
 </template>
@@ -8,6 +14,12 @@
 .SvgCard {
   ::v-deep svg {
     width: 100%;
+  }
+  .Graph-Desc {
+    margin-top: 10px;
+    margin-bottom: 0;
+    font-size: 12px;
+    color: $gray-3;
   }
 }
 </style>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,6 +1,9 @@
 <template>
   <data-view :title="title" :date="date">
     <template v-slot:button>
+      <p class="Graph-Desc">
+        （注）同一の対象者について複数の検体を調査する場合あり
+      </p>
       <data-selector v-model="dataKind" />
     </template>
     <bar :chart-data="displayData" :options="options" :height="240" />
@@ -182,3 +185,11 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.Graph-Desc {
+  margin: 10px 0;
+  font-size: 12px;
+  color: $gray-3;
+}
+</style>


### PR DESCRIPTION
## 📝 関連issue
- close #584 

## ⛏ 変更内容
- 「検査陽性者の状況」「検査実施数」に注釈を追加しました。
- ついでに地下鉄利用者数のstyle、sassのvariableに置き換えました。

## 📸 スクリーンショット
![スクリーンショット 2020-03-06 12 09 03](https://user-images.githubusercontent.com/14883063/76046696-f13f8000-5fa3-11ea-9b0c-ec9577dafd58.png)
![スクリーンショット 2020-03-06 12 09 28](https://user-images.githubusercontent.com/14883063/76046704-f7356100-5fa3-11ea-9413-92976d19157c.png)
