### PR TITLE
fix broken link on README for Contribution

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 * `#covid19` チャンネルにご参加ください。
 
 ## 参加にあたって
-* 開発に参加する前に、[Principle/行動規範](CODE_OF_CONDUCT) をご一読ください。
+* 開発に参加する前に、[Principle/行動規範](CODE_OF_CONDUCT.md) をご一読ください。
 * コミュニケーションにあたっては、Code for Japan の [行動規範](https://github.com/codeforjapan/codeofconduct) もご確認ください。
 * 自分ができそうな Issue に誰もアサインされていない場合、どんどん自分をアサインして進めてください！
 * [good first issue ラベルのついたもの](https://github.com/tokyo-metropolitan-gov/covid19/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)は初心者におすすめです

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 * `#covid19` チャンネルにご参加ください。
 
 ## 参加にあたって
-* 開発に参加する前に、[Principle/行動規範](Principle/行動規範) をご一読ください。
+* 開発に参加する前に、[Principle/行動規範](CODE_OF_CONDUCT) をご一読ください。
 * コミュニケーションにあたっては、Code for Japan の [行動規範](https://github.com/codeforjapan/codeofconduct) もご確認ください。
 * 自分ができそうな Issue に誰もアサインされていない場合、どんどん自分をアサインして進めてください！
 * [good first issue ラベルのついたもの](https://github.com/tokyo-metropolitan-gov/covid19/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)は初心者におすすめです

--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -15,7 +15,7 @@ This page shows how you can contribute to the development of this site.
 * Join `#covid19` Channel
 
 ## For participation
-* Please read [Principle / Code of Conduct](CODE_OF_CONDUCT_EN) before participating in developments.
+* Please read [Principle / Code of Conduct](CODE_OF_CONDUCT_EN.md) before participating in developments.
 * For communications, please also check Code of Japan's [Code of Conduct](https://github.com/codeforjapan/codeofconduct).
 * If you find some issues that you can do, please assign yourself!
 * [good first issue label](https://github.com/tokyo-metropolitan-gov/covid19/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) is recommended for beginners

--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -15,7 +15,7 @@ This page shows how you can contribute to the development of this site.
 * Join `#covid19` Channel
 
 ## For participation
-* Please read [Principle / Code of Conduct](Principle%5BEnglish%5D) before participating in developments.
+* Please read [Principle / Code of Conduct](CODE_OF_CONDUCT_EN) before participating in developments.
 * For communications, please also check Code of Japan's [Code of Conduct](https://github.com/codeforjapan/codeofconduct).
 * If you find some issues that you can do, please assign yourself!
 * [good first issue label](https://github.com/tokyo-metropolitan-gov/covid19/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) is recommended for beginners


### PR DESCRIPTION
## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- fixed broken link for Code of Conduct on the Contributing README on both Japanese and English versions