### PR TITLE
スペルミスと思われる個所 `maches` を `matches` に修正

### DIFF
--- a/tool/convert.php
+++ b/tool/convert.php
@@ -19,8 +19,8 @@ function makeDateArray($begin) : Collection{
 }
 function formatDate(string $date) :string
 {
-    if (preg_match('#(\d+/\d+/\d+)/ (\d+:\d+)#', $date, $maches)) {
-      $carbon = Carbon::parse($maches[1].' '.$maches[2]);
+    if (preg_match('#(\d+/\d+/\d+)/ (\d+:\d+)#', $date, $matches)) {
+      $carbon = Carbon::parse($matches[1].' '.$matches[2]);
       return $carbon->format('Y/m/d H:i');
     } else {
       throw new Exception('Can not parse date:'.$date);


### PR DESCRIPTION
## ⛏ 変更内容
- スペルミスと思われる個所を修正しました。
- 変更前 : `maches`
- 変更後 : `matches`