### PR TITLE
covid がVSCodeでスペルミス扱いにならないようにする

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,22 @@
+﻿{
+  "version": "0.1",
+  "language": "en",
+  "words": [
+    "asynciterable",
+    "chartjs",
+    "covid",
+    "datasets",
+    "esnext",
+    "fullhuman",
+    "interop",
+    "mixins",
+    "nullish",
+    "nuxt",
+    "nuxtjs",
+    "precomposed",
+    "purgecss",
+    "querents",
+    "tightenco",
+    "vuetify"
+  ]
+}


### PR DESCRIPTION
## ⛏ 変更内容
- VSCodeでの拡張機能 [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker) でソースコード中の英単語のスペルチェックを実施したところ、 `covid` 等の文字列がスペルミス扱いになっていました。
- Code Spell Checkerの設定ファイル `cspell.json` を作成し、そこに `covid` 等を登録し、スペルミス扱いにならないようにしました。
- 本プルリクエストを取り込むことによって、アプリケーションの動作が変わることはありません。あくまでVSCodeのスペルチェックの挙動が変わるだけです。