### PR TITLE
README.mdを言語ごとに分割

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,32 +4,27 @@
 
 [![東京都 新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://stopcovid19.metro.tokyo.lg.jp/)
 
+### 日本語 | [English](./README_EN.md)
 
-## How to Contribute / 貢献の仕方
+## 貢献の仕方
 Issues にあるいろいろな修正にご協力いただけると嬉しいです。
 
 詳しくは[貢献の仕方](./.github/CONTRIBUTING.md)を御覧ください。
 
-All contributions are welcome!
-Please check [How to contribute](./.github/CONTRIBUTING_EN.md) for details.
 
-## Code of Conduct / 行動原則
-
+## 行動原則
 詳しくは[サイト構築にあたっての行動原則](./.github/CODE_OF_CONDUCT.md)を御覧ください。
 
-Please check [Code of conduct for developers](./.github/CODE_OF_CONDUCT_EN.md) for details.
-
-## License / ライセンス
+## ライセンス
 本ソフトウェアは、MITライセンスの元提供されています。
-This software is released under the MIT License.
 
-## For Developers / 開発者向け情報
+## 開発者向け情報
 
-### How to Set Up Environments / 環境構築の手順
+### 環境構築の手順
 
-- Required Node.js version: 10.19.0 or higher
+- 必要となるNode.jsのバージョン: 10.19.0以上
 
-**Use yarn / yarn を使う場合**
+**yarn を使う場合**
 ``` bash
 # install dependencies
 $ yarn install
@@ -38,26 +33,16 @@ $ yarn install
 $ yarn dev
 ```
 
-**Use docker / docker compose を使う場合**
+**docker compose を使う場合**
 ```bash
 # serve with hot reload at localhost:3000
 $ docker-compose up --build
 ```
 
-### Deployment to Staging & Production Environments / ステージング・本番環境への反映
+### ステージング・本番環境への反映
 
 `master` ブランチがアップデートされると、自動的に `production` ブランチにHTML類がbuildされます。そして、本番サイト https://stopcovid19.metro.tokyo.lg.jp/ が更新されます。
 
 `staging` ブランチがアップデートされると、自動的に `gh-pages` ブランチにHTML類がbuildされます。そして、ステージングサイト https://stg-covid19-tokyo.netlify.com/ が更新されます。
 
 `development` ブランチがアップデートされると、自動的に `dev-pages` ブランチにHTML類がbuildされます。そして、開発用サイト https://dev-covid19-tokyo.netlify.com/ が更新されます。
-
-
-When `master` branch is updated, the HTML files will be automatically built onto `production` branch,
-and then the production site (https://stopcovid19.metro.tokyo.lg.jp/) will be also updated.
-
-When `staging` branch is updated, the HTML files will be automatically built onto `gh-pages` branch,
-and then the staging site (https://stg-covid19-tokyo.netlify.com/) will be also updated.
-
-When `development` branch is updated, the HTML files will be automatically built onto `dev-pages` branch,
-and then the development site (https://dev-covid19-tokyo.netlify.com/) will be also updated.

--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,51 @@
+# Tokyo COVID-19 Task Force website
+
+![](https://github.com/tokyo-metropolitan-gov/covid19/workflows/production%20deploy/badge.svg)
+
+[![Tokyo COVID-19 Task Force website](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://stopcovid19.metro.tokyo.lg.jp/)
+
+### [日本語](./README.md) | English
+
+## How to Contribute
+
+All contributions are welcome!
+Please check [How to contribute](./.github/CONTRIBUTING_EN.md) for details.
+
+## Code of Conduct
+
+Please check [Code of conduct for developers](./.github/CODE_OF_CONDUCT_EN.md) for details.
+
+## License
+This software is released under the MIT License.
+
+## For Developers
+
+### How to Set Up Environments
+
+- Required Node.js version: 10.19.0 or higher
+
+**Use yarn**
+``` bash
+# install dependencies
+$ yarn install
+
+# serve with hot reload at localhost:3000
+$ yarn dev
+```
+
+**Use docker**
+```bash
+# serve with hot reload at localhost:3000
+$ docker-compose up --build
+```
+
+### Deployment to Staging & Production Environments
+
+When `master` branch is updated, the HTML files will be automatically built onto `production` branch,
+and then the production site (https://stopcovid19.metro.tokyo.lg.jp/) will be also updated.
+
+When `staging` branch is updated, the HTML files will be automatically built onto `gh-pages` branch,
+and then the staging site (https://stg-covid19-tokyo.netlify.com/) will be also updated.
+
+When `development` branch is updated, the HTML files will be automatically built onto `dev-pages` branch,
+and then the development site (https://dev-covid19-tokyo.netlify.com/) will be also updated.


### PR DESCRIPTION
## 📝 関連issue
- close #601 

## ⛏ 変更内容
- README.mdを日本語と英語に分割
- 各言語へのリンクを冒頭に追加

## 📸 スクリーンショット
[![Image from Gyazo](https://i.gyazo.com/2f510b3283cf514042585e9da3a4871a.gif)](https://gyazo.com/2f510b3283cf514042585e9da3a4871a)

- 参考リンク(動作確認ページ): https://github.com/yokinist/covid19/tree/devide-readme