### PR TITLE
都営地下鉄利用者数推移のホバー時ハイライトをボーダーのみに変更

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -51,15 +51,19 @@ export default {
   },
   computed: {
     displayData() {
-      const colors = ['#a6e29f', '#63c765', '#008b41']
+      const barColors = ['#a6e29f', '#63c765', '#008b41']
+      const borderColors = ['#5DC94F', '#40B342', '#00BC58']
       return {
         labels: this.chartData.datasets.map(d => d.label),
         datasets: this.chartData.labels.map((label, i) => {
           return {
             label,
             data: this.chartData.datasets.map(d => d.data[i]),
-            backgroundColor: colors[i],
-            borderWidth: 0
+            backgroundColor: barColors[i],
+            borderWidth: 0,
+            hoverBackgroundColor: barColors[i],
+            hoverBorderColor: borderColors[i],
+            hoverBorderWidth: 2
           }
         })
       }


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- #592 

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- グラフのホバー時に凡例と色がずれないよう、全体をハイライトせずボーダーに色が付くだけに変更

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
**変更前**
![image](https://user-images.githubusercontent.com/61839368/76066486-0b438780-5fd1-11ea-8d74-9b7b92a02798.png)
**変更後**
![image](https://user-images.githubusercontent.com/61839368/76066564-34641800-5fd1-11ea-9d19-3919a557bbba.png)
