### PR TITLE
[After #617] Deploy PreviewだけにESLintのエラーでビルド失敗させるように変更

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn run test
-      - run: yarn run generate --fail-on-page-error
+      - run: yarn run generate:deploy --fail-on-page-error
 
       - name: archive dist
         uses: actions/upload-artifact@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn run test
-      - run: yarn run generate --fail-on-page-error
+      - run: yarn run generate:deploy --fail-on-page-error
 
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn run test
-      - run: yarn run generate --fail-on-page-error
+      - run: yarn run generate:deploy --fail-on-page-error
       - run: "echo \"User-agent: *\nDisallow *\" > ./dist/robots.txt"
 
       - name: deploy

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn run test
-      - run: yarn run generate
+      - run: yarn run generate:deploy
       - run: pip install selenium
       - run: (python -m http.server --directory ./dist 8000 &)  ; python ./ui-test/screenshot.py
       - name: Upload screenshot

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: yarn install --frozen-lockfile
       - run: yarn run test
-      - run: yarn run generate --fail-on-page-error
+      - run: yarn run generate:deploy --fail-on-page-error
       - run: "echo \"User-agent: *\nDisallow *\" > ./dist/robots.txt"
 
       - name: deploy

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "cross-env NODE_ENV=development nuxt-ts",
     "build": "nuxt-ts build",
     "start": "cross-env NODE_ENV=production nuxt-ts start",
-    "generate": "nuxt-ts generate",
+    "generate:deploy": "nuxt-ts generate",
+    "generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "lint-and-generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "test": "echo 'skip tests (there is no test)'",
     "lint": "eslint './**/*.{js,ts,vue}' --fix"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "dev": "cross-env NODE_ENV=development nuxt-ts",
     "build": "nuxt-ts build",
     "start": "cross-env NODE_ENV=production nuxt-ts start",
-    "generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
+    "generate": "nuxt-ts generate",
+    "lint-and-generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "test": "echo 'skip tests (there is no test)'",
     "lint": "eslint './**/*.{js,ts,vue}' --fix"
   },

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -16,18 +16,21 @@ export default {
   },
   data() {
     return {
-      items: [ 
+      items: [
         {
           title: '新型コロナウイルス感染症対応緊急融資',
-          body: '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html</a><br />新型コロナウイルス感染症により事業活動に影響を受けている中小企業等を対象とした緊急融資制度です。'    
+          body:
+            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html</a><br />新型コロナウイルス感染症により事業活動に影響を受けている中小企業等を対象とした緊急融資制度です。'
         },
         {
           title: '新型コロナウイルスによる経営課題に関する専門家派遣',
-          body: '<a href="https://www.tokyo-kosha.or.jp/topics/2003/0001.html" target="_blank" rel="noopener">https://www.tokyo-kosha.or.jp/topics/2003/0001.html</a><br />新型コロナウイルス感染症により経営面の影響を受けている中小企業を対象に、中小企業診断士等の専門家を無料で派遣し、経営改善等に向けたアドバイスを実施します。'    
+          body:
+            '<a href="https://www.tokyo-kosha.or.jp/topics/2003/0001.html" target="_blank" rel="noopener">https://www.tokyo-kosha.or.jp/topics/2003/0001.html</a><br />新型コロナウイルス感染症により経営面の影響を受けている中小企業を対象に、中小企業診断士等の専門家を無料で派遣し、経営改善等に向けたアドバイスを実施します。'
         },
         {
           title: '事業継続緊急対策（テレワーク）助成金',
-          body: '<a href="https://www.shigotozaidan.or.jp/koyo-kankyo/" target="_blank" rel="noopener">https://www.shigotozaidan.or.jp/koyo-kankyo/</a><br />都内中堅・中小企業に対し、テレワークの導入に必要な機器やソフトウェア等の経費を助成します。'    
+          body:
+            '<a href="https://www.shigotozaidan.or.jp/koyo-kankyo/" target="_blank" rel="noopener">https://www.shigotozaidan.or.jp/koyo-kankyo/</a><br />都内中堅・中小企業に対し、テレワークの導入に必要な機器やソフトウェア等の経費を助成します。'
         },
         {
           title: '中小企業者等特別相談窓口',
@@ -43,7 +46,7 @@ export default {
           title: '新しいワークスタイルや企業活動の東京モデル「スムーズビズ」',
           body:
             '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
-        },
+        }
       ]
     }
   },


### PR DESCRIPTION
## 📝 関連issue
- close #615

## ⛏ 変更内容
- NetlifyのDeploy PreviewだけにESLintのエラーでビルド失敗させるように変更
### やったこと
- [x] eslintも含まれてしまっている `yarn generate` を分割
- [x] actionsで走らせるのを `nuxt-ts generate` にあてられているスクリプトに変更

## 変更理由
- #597 マージ以前につくられたPRにESLintのエラーがある場合、取り込んだ際に本番のビルドでこけてしまう可能性があるため
## 備考
- ビルド時が通らなかったので #617 の変更を引き継いでいます
- #617 マージ後に取り込みをお願いします🙏