### PR TITLE
dockerignoreの追記

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 node_modules
+.nuxt


### PR DESCRIPTION
## ⛏ 変更内容
- .dockerignoreに.nuxtを追加

### before
```
❯ time docker-compose build --no-cache
...
docker-compose build --no-cache  1.83s user 1.24s system 3% cpu 1:18.96 total
```
### after
```
❯ time docker-compose build --no-cache
...
docker-compose build --no-cache  1.78s user 1.19s system 4% cpu 1:07.04 total
```
約10秒ほどイメージのビルド時間の短縮に成功しました。