### PR TITLE
[wip]グラフの横スクロール

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -20,6 +20,9 @@
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+if (process.browser) {
+  require('chartjs-plugin-zoom')
+}
 
 export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
@@ -121,6 +124,19 @@ export default {
     displayOption() {
       const unit = this.unit
       return {
+        plugins: {
+          zoom: {
+            pan: {
+              enabled: true,
+              mode: 'x',
+              speed: 1
+            },
+            zoom: {
+              enabled: true,
+              mode: ''
+            }
+          }
+        },
         tooltips: {
           displayColors: false,
           callbacks: {
@@ -149,6 +165,9 @@ export default {
                 display: false
               },
               ticks: {
+                min: this.chartData[Math.max(0, this.chartData.length - 14)]
+                  .label,
+                max: this.chartData[this.chartData.length - 1].label,
                 fontSize: 10,
                 maxTicksLimit: 20,
                 fontColor: '#808080'

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -133,6 +133,19 @@ export default {
     options() {
       const unit = this.unit
       return {
+        plugins: {
+          zoom: {
+            pan: {
+              enabled: true,
+              mode: 'x',
+              speed: 1
+            },
+            zoom: {
+              enabled: true,
+              mode: ''
+            }
+          }
+        },
         tooltips: {
           displayColors: false,
           callbacks: {
@@ -161,6 +174,8 @@ export default {
                 display: false
               },
               ticks: {
+                min: this.labels[Math.max(0, this.labels.length - 14)],
+                max: this.labels[this.labels.length - 1],
                 fontSize: 10,
                 maxTicksLimit: 20,
                 fontColor: '#808080'

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nuxtjs/dotenv": "^1.4.0",
     "@nuxtjs/pwa": "^3.0.0-0",
     "chart.js": "^2.9.3",
+    "chartjs-plugin-zoom": "^0.7.5",
     "cross-env": "^5.2.0",
     "dayjs": "^1.8.21",
     "express": "^4.16.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2880,6 +2880,13 @@ chartjs-color@^2.1.0:
     chartjs-color-string "^0.6.0"
     color-convert "^1.9.3"
 
+chartjs-plugin-zoom@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-zoom/-/chartjs-plugin-zoom-0.7.5.tgz#83ffd143b1807604d8ecabae1091b9c5abf91b84"
+  integrity sha512-OGVQXlw5meOD7ac+CBNO7yKg4Tk06eBb5LUIgpK/qgv7SjVB/89pWMQY3pxWnzCMI8FsoV3iTKQ2ZCOvh4+q6w==
+  dependencies:
+    hammerjs "^2.0.8"
+
 check-types@^8.0.3:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
@@ -5093,6 +5100,11 @@ hable@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/hable/-/hable-2.3.2.tgz#7867ffec0b67e63136937613d9a0bc646ac9d7fe"
   integrity sha512-qJ9WoXl/15LNlG1KeAuBjCNGStUb+MCQ5biPxOmwRyESH8CSWwZB4xEnzCduuQ3I/mlgui28t8/oMAGT1Rpb2g==
+
+hammerjs@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
+  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
 har-schema@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## 📝 関連issue
- #316 棒グラフチャートのbar幅固定+グラフ内横スクロール

## ⛏ 変更内容
- 全グラフ、x軸の要素数が14を超える場合は横スクロールで表示
- デフォルト状態では最新のデータが表示されている  
  （右端が表示されているので左に向かってスクロールしていく）

## 備考（懸念事項）
- 表示件数上限、横幅問わず14日固定で問題ないか？  
  （chart.js及びプラグインの仕様で横幅に応じて表示数を変えるのが難しかったです）
- スクロール可能な旨が分かりづらい
  （デザイン面で良いアイデアがあれば実装できるかもしれません。又はどなたかがデザイン引き継いで頂いても構いません。）


## 📸 スクリーンショット

![320px-新型コロナ受信相談窓口相談件数](https://user-images.githubusercontent.com/4785040/76096564-a7898080-6009-11ea-9975-af363b3b1a42.png)
![320px-新型コロナコールセンター相談件数](https://user-images.githubusercontent.com/4785040/76096567-a9ebda80-6009-11ea-950c-98e241511cb0.png)
![320px-検査実施数](https://user-images.githubusercontent.com/4785040/76096571-aa847100-6009-11ea-9372-80e7c3c9cd8b.png)
![320px-陽性患者数](https://user-images.githubusercontent.com/4785040/76096573-ab1d0780-6009-11ea-889c-8c9627c6da2e.png)

