### PR TITLE
ESLintのエラーをコメントしてくれるGitHub Actionsの追加

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   eslint:
-    name: runner / eslint
+    name: check_eslint_error
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,20 @@
+name: production deploy
+
+on:
+  pull_request:
+    branches:
+      - development
+
+jobs:
+  eslint:
+    name: runner / eslint
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Run eslint with reviewdog
+        uses: reviewdog/action-eslint@v1.0.0
+          with:
+            github_token: ${{ secrets.github_token }}
+            reporter: github-pr-review
+            eslint_flags: './**/*.{js,ts,vue}'

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,4 +1,4 @@
-name: production deploy
+name: reviewdog
 
 on:
   pull_request:
@@ -11,10 +11,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      
-      - name: Run eslint with reviewdog
-        uses: reviewdog/action-eslint@v1.0.0
-          with:
-            github_token: ${{ secrets.github_token }}
-            reporter: github-pr-review
-            eslint_flags: './**/*.{js,ts,vue}'
+      - name: eslint review
+        uses: reviewdog/action-eslint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          eslint_flags: './**/*.{vue,ts,js}'


### PR DESCRIPTION
## 📝 関連issue
-  #594, #615 

## ⛏ 変更内容
- [x] `development` ブランチに送られるPRのみにESLintチェックを走らせるGitHub Actionsを追加
  - ステージング, 本番環境に関してはノータッチ
- [x] ESLintを実行しエラーがあったらコメントしてくれるようにした
- [x] Netlifyのビルドではeslintは無視するようにする -> @mikkame さんに確認が必要

## 変更背景
- 現状: Netlifyで `nuxt-ts generate` 前にlintを走らせ失敗したらビルドも失敗させている
- 問題:
  - どこでエラーが起きていたか確認しづらい
  - deploy logが汚い
  - ビルドに時間かかる

## 📸 スクリーンショット
以下、fork先で確認済

[失敗例-lintにひっかかる時](https://github.com/yokinist/covid19/pull/1/commits/960717f00f1a3d4978e7753cb08bd9846bd00d66)
[![Image from Gyazo](https://i.gyazo.com/eb835ee7cefd4e20ee9f272c1745fbcc.png)](https://gyazo.com/eb835ee7cefd4e20ee9f272c1745fbcc)

[成功例-lintをパスする時](https://github.com/yokinist/covid19/pull/1/commits/939ae30c7bf91ffc902af3bd1305806de16b33d6)
[![Image from Gyazo](https://i.gyazo.com/5c2ed92c10fea51d40a834da02e8d5e6.png)](https://gyazo.com/5c2ed92c10fea51d40a834da02e8d5e6)

↓早速、こうなっているはず
[![Image from Gyazo](https://i.gyazo.com/bdb63c3805719cf7ee3e224869d5cfb3.png)](https://gyazo.com/bdb63c3805719cf7ee3e224869d5cfb3)