### PR TITLE
docs: fix typo "fell" in CONTRIBUTING_EN.md

### DIFF
--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -25,7 +25,7 @@ may not be always accepted (especially the ones for UI)
 * If you can't have any progress for more than half a day, make sure that others can take over your work.
 * In case issues are not updated for more than one day, we may remove the assign. [Draft Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) is recommended so that everyone knows the situation.
 * For any questions related to the Issue, we should discuss in the Issue comments than Slack.
-* We also accept suggestions! Please fell free to create new issues.
+* We also accept suggestions! Please feel free to create new issues.
 
 ## Development information
 * Development site https://dev-covid19-tokyo.netlify.com/


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/673.

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- This PR replaces one character to use the correct word in English: `feel` = > `fell`.

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

![Screen Shot 2020-03-06 at 7 22 31 PM](https://user-images.githubusercontent.com/15894826/76135865-ec98bd00-5fdf-11ea-8a2d-bcd4943b61e8.png)

Rendered: https://github.com/francisfuzz/covid19/blob/ccbb586f45354eab3f740862671eab77ca21dbce/.github/CONTRIBUTING_EN.md#for-participation
