### PR TITLE
言語切り替えボタンを仮実装

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -11,3 +11,9 @@ img {
   height: auto;
   vertical-align: bottom;
 }
+
+.clearfix {
+  content: "";
+  display: block;
+  clear: both;
+}

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -13,7 +13,9 @@ img {
 }
 
 .clearfix {
-  content: "";
-  display: block;
-  clear: both;
+  &:after {
+    content: "";
+    display: block;
+    clear: both;
+  }
 }

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="SelectLanguages mb-3 clearfix">
+    <div class="SelectLanguages__inner">
+      <nuxt-link
+        v-for="locale in availableLocales"
+        :key="locale.code"
+        :to="switchLocalePath(locale.code)"
+        class="SelectLanguage"
+      >
+        {{ locale.name }}
+      </nuxt-link>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    availableLocales() {
+      return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale)
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.SelectLanguages {
+  font-size: 12px;
+  .SelectLanguages__inner {
+    float: right;
+    .SelectLanguage {
+      + .SelectLanguage {
+        margin-left: 5px;
+        padding-left: 5px;
+      }
+    }
+  }
+}
+</style>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -106,18 +106,18 @@ export default {
         {
           icon: 'mdi-chart-timeline-variant',
           title: this.$t('The latest updates'),
-          link: '/'
+          link: this.localePath('/')
         },
         {
           icon: 'covid',
           title: this.$t('If you have any symptoms'),
-          link: '/flow',
+          link: this.localePath('/flow'),
           divider: true
         },
         {
           icon: 'parent',
           title: this.$t('for Families with children'),
-          link: '/parent'
+          link: this.localePath('/parent')
         },
         {
           icon: 'mdi-account-multiple',
@@ -127,7 +127,7 @@ export default {
         {
           icon: 'mdi-domain',
           title: this.$t('for Enterprises and Employees'),
-          link: '/worker',
+          link: this.localePath('/worker'),
           divider: true
         },
         {
@@ -147,7 +147,7 @@ export default {
         },
         {
           title: this.$t('About us'),
-          link: '/about'
+          link: this.localePath('/about')
         },
         {
           title: this.$t('Government official website'),

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -95,6 +95,30 @@ const config: Configuration = {
           {
             code: 'ja',
             iso: 'ja-JP'
+          },
+          {
+            code: 'en',
+            iso: 'en-US'
+          },
+          {
+            code: 'zh-CN',
+            iso: 'zh-CN'
+          },
+          {
+            code: 'zh-TW',
+            iso: 'zh-TW'
+          },
+          {
+            code: 'ko',
+            iso: 'ko-KR'
+          },
+          {
+            code: 'ja-basicjpn',
+            iso: 'ja-basicjpn'
+          },
+          {
+            code: 'pt-BR',
+            iso: 'pt-BR'
           }
         ],
         defaultLocale: 'ja',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -90,35 +90,46 @@ const config: Configuration = {
     [
       'nuxt-i18n',
       {
-        strategy: 'no_prefix',
+        strategy: 'prefix_except_default',
+        detectBrowserLanguage: {
+          useCookie: true,
+          cookieKey: 'i18n_redirected'
+        },
         locales: [
           {
             code: 'ja',
+            name: '日本語',
             iso: 'ja-JP'
           },
           {
             code: 'en',
+            name: 'English',
             iso: 'en-US'
           },
           {
-            code: 'zh-CN',
+            code: 'zh-cn',
+            name: '簡体字',
             iso: 'zh-CN'
           },
           {
-            code: 'zh-TW',
+            code: 'zh-tw',
+            name: '繁体字',
             iso: 'zh-TW'
           },
           {
             code: 'ko',
+            name: '한국어',
             iso: 'ko-KR'
           },
           {
-            code: 'ja-basicjpn',
-            iso: 'ja-basicjpn'
+            code: 'pt-BR',
+            name: 'Portuguese',
+            iso: 'pt-BR'
           },
           {
-            code: 'pt-BR',
-            iso: 'pt-BR'
+            code: 'ja-basic',
+            name: 'やさしい にほんご',
+            iso: 'ja-JP'
           }
         ],
         defaultLocale: 'ja',

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="About">
+    <language-selector />
     <h2 class="About-Heading">
       当サイトについて
     </h2>
@@ -89,16 +90,14 @@
         href="https://portal.data.metro.tokyo.lg.jp/"
         target="_blank"
         rel="noopener"
-        >東京都オープンデータカタログサイト</a
-      >より誰でも自由にダウンロードが可能です。（データは順次追加予定です）
+      >東京都オープンデータカタログサイト</a>より誰でも自由にダウンロードが可能です。（データは順次追加予定です）
     </TextCard>
     <TextCard title="ソースコードについて">
       本サイトのソースコードはMITライセンスで公開されており、誰でも自由に利用することができます。詳しくは、<a
         href="https://github.com/tokyo-metropolitan-gov/covid19"
         target="_blank"
         rel="noopener"
-        >GitHub リポジトリ</a
-      >をご確認ください。
+      >GitHub リポジトリ</a>をご確認ください。
     </TextCard>
 
     <TextCard title="お問い合わせ先（都のHPサイトポリシーについて）">
@@ -110,10 +109,12 @@
 </template>
 
 <script lang="ts">
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import TextCard from '@/components/TextCard.vue'
 
 export default {
   components: {
+    LanguageSelector,
     TextCard
   },
   head() {

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="Flow">
+    <language-selector />
     <div class="Flow-Heading">
       <CovidIcon />
       <h2 class="Flow-Heading-Title">
@@ -214,10 +215,11 @@
 </template>
 
 <script>
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import CovidIcon from '@/static/covid.svg'
 import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
 export default {
-  components: { CovidIcon, DesktopFlowSvg },
+  components: { LanguageSelector, CovidIcon, DesktopFlowSvg },
   head() {
     return {
       title: '新型コロナウイルス感染症が心配なときに'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,20 +1,10 @@
 <template>
   <div class="MainPage">
-    <div class="SelectLanguages mb-3">
-      <nuxt-link
-        v-for="locale in availableLocales"
-        :key="locale.code"
-        :to="switchLocalePath(locale.code)"
-        class="SelectLanguage"
-      >
-        {{ locale.name }}
-      </nuxt-link>
-    </div>
+    <language-selector />
     <page-header
       :icon="headerItem.icon"
       :title="headerItem.title"
       :date="headerItem.date"
-      class="clearfix"
     />
     <whats-new class="mb-4" :items="newsItems" />
     <static-info
@@ -96,6 +86,7 @@
 </template>
 
 <script>
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
 import MetroBarChart from '@/components/MetroBarChart.vue'
@@ -114,6 +105,7 @@ import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
 
 export default {
   components: {
+    LanguageSelector,
     PageHeader,
     TimeBarChart,
     MetroBarChart,
@@ -242,11 +234,6 @@ export default {
     }
     return data
   },
-  computed: {
-    availableLocales() {
-      return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale)
-    }
-  },
   head() {
     return {
       title: '都内の最新感染動向'
@@ -257,16 +244,6 @@ export default {
 
 <style lang="scss" scoped>
 .MainPage {
-  .SelectLanguages {
-    font-size: 12px;
-    float: right;
-    .SelectLanguage {
-      + .SelectLanguage {
-        margin-left: 5px;
-        padding-left: 5px;
-      }
-    }
-  }
   .DataBlock {
     margin: 20px -12px;
     .DataCard {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,9 +1,20 @@
 <template>
   <div class="MainPage">
+    <div class="SelectLanguages mb-3">
+      <nuxt-link
+        v-for="locale in availableLocales"
+        :key="locale.code"
+        :to="switchLocalePath(locale.code)"
+        class="SelectLanguage"
+      >
+        {{ locale.name }}
+      </nuxt-link>
+    </div>
     <page-header
       :icon="headerItem.icon"
       :title="headerItem.title"
       :date="headerItem.date"
+      class="clearfix"
     />
     <whats-new class="mb-4" :items="newsItems" />
     <static-info
@@ -231,6 +242,11 @@ export default {
     }
     return data
   },
+  computed: {
+    availableLocales() {
+      return this.$i18n.locales.filter(i => i.code !== this.$i18n.locale)
+    }
+  },
   head() {
     return {
       title: '都内の最新感染動向'
@@ -241,6 +257,16 @@ export default {
 
 <style lang="scss" scoped>
 .MainPage {
+  .SelectLanguages {
+    font-size: 12px;
+    float: right;
+    .SelectLanguage {
+      + .SelectLanguage {
+        margin-left: 5px;
+        padding-left: 5px;
+      }
+    }
+  }
   .DataBlock {
     margin: 20px -12px;
     .DataCard {

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="Parent">
+    <language-selector />
     <h2 class="Parent-Heading">
       臨時休校中の新型コロナウイルス感染症対応についてのお願い
     </h2>
@@ -9,9 +10,12 @@
   </div>
 </template>
 <script lang="ts">
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import TextCard from '@/components/TextCard.vue'
+
 export default {
   components: {
+    LanguageSelector,
     TextCard
   },
   data() {
@@ -41,6 +45,7 @@ export default {
   }
 }
 </script>
+
 <style lang="scss">
 .Parent {
   &-Heading {

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="Worker">
+    <language-selector />
     <h2 class="Worker-Heading">
       企業の皆様・はたらく皆様へ
     </h2>
@@ -8,10 +9,14 @@
     </div>
   </div>
 </template>
+
 <script lang="ts">
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import TextCard from '@/components/TextCard.vue'
+
 export default {
   components: {
+    LanguageSelector,
     TextCard
   },
   data() {
@@ -57,6 +62,7 @@ export default {
   }
 }
 </script>
+
 <style lang="scss">
 .Worker {
   &-Heading {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     },
     "types": [
       "@types/node",
-      "@nuxt/types"
+      "@nuxt/types",
+      "nuxt-i18n"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## 📝 関連issue
- related #681

## ⛏ 変更内容
- `nuxt.config.ts`に言語設定を追加
  - 「やさしい日本語」の言語コードがISOに無かったので`ja-basic`とする
- (追記) 言語変更ボタンを追加 by @nard-tech 