### PR TITLE
[DNM]data/*.json の型付け

### DIFF
--- a/data/json.ts
+++ b/data/json.ts
@@ -1,0 +1,150 @@
+/* eslint-disable camelcase */
+
+export namespace Json {
+  // data.json
+  export type data = {
+    contacts: {
+      date: string
+      data: data.contact[]
+    }
+    querents: {
+      date: string
+      data: data.querent[]
+    }
+    patients: {
+      date: string
+      data: data.patient[]
+    }
+    patients_summary: {
+      date: string
+      data: data.summary[]
+    }
+    discharges_summary: {
+      date: string
+      data: data.summary[]
+    }
+    discharges: {
+      date: string
+      data: data.discharge[]
+    }
+    inspections: {
+      date: string
+      data: data.inspection[]
+    }
+    inspections_summary: {
+      date: string
+      data: { [area: string]: number[] }
+      labels: string[]
+    }
+    better_patients_summary: {
+      date: string
+      data: {
+        [attribute: string]: {
+          [datetime: string]: number
+        }
+      }
+    }
+    lastUpdate: string
+    main_summary: data.main_summary
+  }
+  export namespace data {
+    export type contact = {
+      日付: string
+      曜日: string
+      '9-13時': number | null
+      '13-17時': number | null
+      '17-21時': number | null
+      date: string
+      w: number
+      short_date: string
+      小計: number
+    }
+    export type querent = {
+      日付: string
+      曜日: string
+      '9-17時': string | null
+      '17-翌9時': string | null
+      date: string
+      w: number
+      short_date: string
+      小計: number
+    }
+    export type patient = {
+      No: number
+      リリース日: string
+      曜日: number
+      居住地: string
+      年代: string
+      性別: '男性' | '女性'
+      属性: string
+      備考: string | null
+      補足: string | null
+      退院: string
+      date: string
+      w: number
+      short_date: string
+    }
+    export type summary = {
+      日付: string
+      小計: number
+    }
+    export type discharge = {
+      No: number
+      リリース日: string
+      曜日: number
+      居住地: string
+      年代: string
+      性別: '男性' | '女性'
+      属性: string
+      備考: string | null
+      補足: string | null
+      退院: string
+      date: string
+      w: number
+      short_date: string
+    }
+    export type inspection = {
+      判明日: string
+      検査検体数: string
+      疑い例検査: string
+      接触者調査: string
+      陰性確認: string
+      '（小計①）': string
+      チャーター便: string
+      クルーズ船: string
+      陰性確認2: string
+      '（小計②）': string
+    }
+    export type main_summary = {
+      attr: string
+      value: number
+      children?: main_summary[]
+    }
+  }
+
+  // metro.json
+  export type metro = {
+    date: string
+    datasets: metro.data[]
+    labels: string[]
+    base_period: string
+  }
+  export namespace metro {
+    export type data = {
+      label: string
+      data: number[]
+    }
+  }
+
+  // news.json
+  export type news = {
+    newsItems: news.item[]
+  }
+  export namespace news {
+    export type item = {
+      date: string
+      url: string
+      text: string
+    }
+  }
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -85,6 +85,7 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue'
 import { Chart } from 'chart.js'
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -104,7 +105,7 @@ const News: Json.news = require('@/data/news.json')
 const Data: Json.data = require('@/data/data.json')
 const MetroData: Json.metro = require('@/data/metro.json')
 
-export default {
+export default Vue.extend({
   components: {
     PageHeader,
     TimeBarChart,
@@ -240,7 +241,7 @@ export default {
       title: '都内の最新感染動向'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -84,22 +84,25 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import { Chart } from 'chart.js'
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
 import MetroBarChart from '@/components/MetroBarChart.vue'
 import TimeStackedBarChart from '@/components/TimeStackedBarChart.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
-import Data from '@/data/data.json'
-import MetroData from '@/data/metro.json'
 import DataTable from '@/components/DataTable.vue'
 import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
-import News from '@/data/news.json'
 import SvgCard from '@/components/SvgCard.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
+
+import { Json } from '@/data/json'
+const News: Json.news = require('@/data/news.json')
+const Data: Json.data = require('@/data/data.json')
+const MetroData: Json.metro = require('@/data/metro.json')
 
 export default {
   components: {
@@ -154,6 +157,60 @@ export default {
       unit: '人'
     }
 
+    const metroGraphOption: Chart.ChartOptions = {
+      responsive: true,
+      legend: {
+        display: true
+      },
+      scales: {
+        xAxes: [
+          {
+            position: 'bottom',
+            stacked: false,
+            gridLines: {
+              display: true
+            },
+            ticks: {
+              fontSize: 10,
+              maxTicksLimit: 20,
+              fontColor: '#808080'
+            }
+          }
+        ],
+        yAxes: [
+          {
+            stacked: false,
+            gridLines: {
+              display: true
+            },
+            ticks: {
+              fontSize: 12,
+              maxTicksLimit: 10,
+              fontColor: '#808080',
+              callback(value) {
+                // 基準値を100としたときの相対値
+                return (value / 100).toFixed(2)
+              }
+            }
+          }
+        ]
+      },
+      tooltips: {
+        displayColors: false,
+        callbacks: {
+          title(tooltipItems, _) {
+            const label = tooltipItems[0].label
+            return `期間: ${label}`
+          },
+          label(tooltipItem, data) {
+            const currentData = data.datasets![tooltipItem!.datasetIndex!]
+            const percentage = `${currentData!.data![tooltipItem!.index!]}%`
+            return `${metroGraph.base_period}の利用者数との相対値: ${percentage}`
+          }
+        }
+      }
+    }
+
     const data = {
       Data,
       patientsTable,
@@ -174,60 +231,7 @@ export default {
         date: Data.lastUpdate
       },
       newsItems: News.newsItems,
-      metroGraphOption: {
-        responsive: true,
-        legend: {
-          display: true
-        },
-        scales: {
-          xAxes: [
-            {
-              position: 'bottom',
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 10,
-                maxTicksLimit: 20,
-                fontColor: '#808080'
-              }
-            }
-          ],
-          yAxes: [
-            {
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 12,
-                maxTicksLimit: 10,
-                fontColor: '#808080',
-                callback(value) {
-                  // 基準値を100としたときの相対値
-                  return (value / 100).toFixed(2)
-                }
-              }
-            }
-          ]
-        },
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            title(tooltipItems, _) {
-              const label = tooltipItems[0].label
-              return `期間: ${label}`
-            },
-            label(tooltipItem, data) {
-              const currentData = data.datasets[tooltipItem.datasetIndex]
-              const percentage = `${currentData.data[tooltipItem.index]}%`
-
-              return `${metroGraph.base_period}の利用者数との相対値: ${percentage}`
-            }
-          }
-        }
-      }
+      metroGraphOption
     }
     return data
   },

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -1,57 +1,21 @@
-type DataType = {
-  attr: '検査実施人数'
-  value: number
-  children: [
-    {
-      attr: '陽性患者数'
-      value: number
-      children: [
-        {
-          attr: '入院中'
-          value: number
-          children: [
-            {
-              attr: '軽症・中等症'
-              value: number
-            },
-            {
-              attr: '重症'
-              value: number
-            }
-          ]
-        },
-        {
-          attr: '退院'
-          value: number
-        },
-        {
-          attr: '死亡'
-          value: number
-        }
-      ]
-    }
-  ]
-}
+/* eslint-disable camelcase */
+
+import { Json } from '@/data/json'
+type DataType = Json.data.main_summary
 
 type ConfirmedCasesType = {
-  検査実施人数: number
-  陽性物数: number
-  入院中: number
-  軽症中等症: number
-  重症: number
-  死亡: number
-  退院: number
+  [attribute: string]: number
 }
 
 export default (data: DataType) => {
   const formattedData: ConfirmedCasesType = {
     検査実施人数: data.value,
-    陽性物数: data.children[0].value,
-    入院中: data.children[0].children[0].value,
-    軽症中等症: data.children[0].children[0].children[0].value,
-    重症: data.children[0].children[0].children[1].value,
-    死亡: data.children[0].children[2].value,
-    退院: data.children[0].children[1].value
+    陽性物数: data.children![0].value,
+    入院中: data.children![0].children![0].value,
+    軽症中等症: data.children![0].children![0].children![0].value,
+    重症: data.children![0].children![0].children![1].value,
+    死亡: data.children![0].children![2].value,
+    退院: data.children![0].children![1].value
   }
   return formattedData
 }

--- a/utils/formatGraph.ts
+++ b/utils/formatGraph.ts
@@ -1,7 +1,6 @@
-type DataType = {
-  日付: Date
-  小計: number
-}
+import { Json } from '@/data/json'
+
+type DataType = Json.data.summary
 
 type GraphDataType = {
   label: string

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -8,7 +8,7 @@ const headers = [
 ]
 
 type DataType = {
-  リリース日: Date
+  リリース日: string
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性'


### PR DESCRIPTION
**#725 かこちらか、どちらか一方のみmergeして下さい**
双方マージするとconflictします。コードとしても意味がありません。
jsonの変更と型付けに時間がかかるようであれば #725 単独で、
すぐに対応できるようであればこちらをマージすると良いと思います。

## 📝 関連issue
- #621 refactor: コードベースを TypeScript 化する

## ⛏ 変更内容
- `data/*.json` の型定義

## 利用例
```ts
import { Json } from '@/data/json';
const News: Json.news = require('@/data/news.json')
const Data: Json.data = require('@/data/data.json')
const MetroData: Json.metro = require('@/data/metro.json')
```

```ts
import { Json } from '@/data/json'
type DataType = Json.data.main_summary
```

## 懸念事項・TODO

別途 `*.vue` ファイルのts化が進行中。
そちらの進行のためスピード重視で対応したので冗長な定義がある。
別途リファクタリングしたい。