### PR TITLE
[i18n] DataSelector.vue 内の文字列をi18n化

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -6,13 +6,46 @@
     @change="$emit('input', $event)"
   >
     <v-btn v-ripple="false" value="transition" class="DataSelector-Button">
-      日別
+      {{ $t('日別') }}
     </v-btn>
     <v-btn v-ripple="false" value="cumulative" class="DataSelector-Button">
-      累計
+      {{ $t('累計') }}
     </v-btn>
   </v-btn-toggle>
 </template>
+
+<i18n>
+{
+  "ja": {
+    "日別": "日別",
+    "累計": "累計"
+  },
+  "en": {
+    "日別": "daily",
+    "累計": "total"
+  },
+  "zh-cn": {
+    "日別": "每日",
+    "累計": "累计"
+  },
+  "zh-tw": {
+    "日別": "每日",
+    "累計": "累計"
+  },
+  "ko": {
+    "日別": "날짜별",
+    "累計": "총 집계"
+  },
+  "pt-BR": {
+    "日別": "diário",
+    "累計": "total"
+  },
+  "ja-basic": {
+    "日別": "いちにちごと",
+    "累計": "ぜんぶで"
+  }
+}
+</i18n>
 
 <style lang="scss">
 .DataSelector {


### PR DESCRIPTION
## 📝 関連issue
- close #686

## ⛏ 変更内容
https://docs.google.com/spreadsheets/d/1aksSfWIXE_L3rFYFjHz9xtVhh0n7ealMQ0eEz8GGPlw/edit#gid=0 を参照し，DataSelector.vue 内の文字列をi18n化
