### PR TITLE
index.vue Vue.extend対応

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -145,6 +145,7 @@ const config: Configuration = {
     id: 'UA-159417676-1'
   },
   build: {
+    extractCSS: true,
     postcss: {
       plugins: [
         purgecss({

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -84,7 +84,9 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue'
+import { Chart } from 'chart.js'
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
 import MetroBarChart from '@/components/MetroBarChart.vue'
@@ -101,7 +103,7 @@ import News from '@/data/news.json'
 import SvgCard from '@/components/SvgCard.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
 
-export default {
+export default Vue.extend({
   components: {
     PageHeader,
     TimeBarChart,
@@ -115,11 +117,11 @@ export default {
   },
   data() {
     // 感染者数グラフ
-    const patientsGraph = formatGraph(Data.patients_summary.data)
+    const patientsGraph = formatGraph(Data.patients_summary.data as any)
     // 感染者数
     const patientsTable = formatTable(Data.patients.data)
     // 退院者グラフ
-    const dischargesGraph = formatGraph(Data.discharges_summary.data)
+    const dischargesGraph = formatGraph(Data.discharges_summary.data as any)
     // 退院者数
     const dischargesTable = formatTable(Data.discharges.data)
     // 相談件数
@@ -144,7 +146,7 @@ export default {
     //   Data.patients.data.filter(patient => patient['備考'] === '死亡')
     // )
     // 検査陽性者の状況
-    const confirmedCases = formatConfirmedCases(Data.main_summary)
+    const confirmedCases = formatConfirmedCases(Data.main_summary as any)
 
     const sumInfoOfPatients = {
       lText: patientsGraph[
@@ -152,6 +154,61 @@ export default {
       ].cumulative.toLocaleString(),
       sText: patientsGraph[patientsGraph.length - 1].label + 'の累計',
       unit: '人'
+    }
+
+    const metroGraphOption: Chart.ChartOptions = {
+      responsive: true,
+      legend: {
+        display: true
+      },
+      scales: {
+        xAxes: [
+          {
+            position: 'bottom',
+            stacked: false,
+            gridLines: {
+              display: true
+            },
+            ticks: {
+              fontSize: 10,
+              maxTicksLimit: 20,
+              fontColor: '#808080'
+            }
+          }
+        ],
+        yAxes: [
+          {
+            stacked: false,
+            gridLines: {
+              display: true
+            },
+            ticks: {
+              fontSize: 12,
+              maxTicksLimit: 10,
+              fontColor: '#808080',
+              callback(value) {
+                // 基準値を100としたときの相対値
+                return (value / 100).toFixed(2)
+              }
+            }
+          }
+        ]
+      },
+      tooltips: {
+        displayColors: false,
+        callbacks: {
+          title(tooltipItems, _) {
+            const label = tooltipItems[0].label
+            return `期間: ${label}`
+          },
+          label(tooltipItem, data) {
+            const currentData = data.datasets![tooltipItem!.datasetIndex!]
+            const percentage = `${currentData!.data![tooltipItem!.index!]}%`
+
+            return `${metroGraph.base_period}の利用者数との相対値: ${percentage}`
+          }
+        }
+      }
     }
 
     const data = {
@@ -174,60 +231,7 @@ export default {
         date: Data.lastUpdate
       },
       newsItems: News.newsItems,
-      metroGraphOption: {
-        responsive: true,
-        legend: {
-          display: true
-        },
-        scales: {
-          xAxes: [
-            {
-              position: 'bottom',
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 10,
-                maxTicksLimit: 20,
-                fontColor: '#808080'
-              }
-            }
-          ],
-          yAxes: [
-            {
-              stacked: false,
-              gridLines: {
-                display: true
-              },
-              ticks: {
-                fontSize: 12,
-                maxTicksLimit: 10,
-                fontColor: '#808080',
-                callback(value) {
-                  // 基準値を100としたときの相対値
-                  return (value / 100).toFixed(2)
-                }
-              }
-            }
-          ]
-        },
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            title(tooltipItems, _) {
-              const label = tooltipItems[0].label
-              return `期間: ${label}`
-            },
-            label(tooltipItem, data) {
-              const currentData = data.datasets[tooltipItem.datasetIndex]
-              const percentage = `${currentData.data[tooltipItem.index]}%`
-
-              return `${metroGraph.base_period}の利用者数との相対値: ${percentage}`
-            }
-          }
-        }
-      }
+      metroGraphOption
     }
     return data
   },
@@ -236,7 +240,7 @@ export default {
       title: '都内の最新感染動向'
     }
   }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -119,15 +119,15 @@ export default Vue.extend({
     // 感染者数グラフ
     const patientsGraph = formatGraph(Data.patients_summary.data as any)
     // 感染者数
-    const patientsTable = formatTable(Data.patients.data)
+    const patientsTable = formatTable(Data.patients.data as any)
     // 退院者グラフ
     const dischargesGraph = formatGraph(Data.discharges_summary.data as any)
     // 退院者数
-    const dischargesTable = formatTable(Data.discharges.data)
+    const dischargesTable = formatTable(Data.discharges.data as any)
     // 相談件数
-    const contactsGraph = formatGraph(Data.contacts.data)
+    const contactsGraph = formatGraph(Data.contacts.data as any)
     // 帰国者・接触者電話相談センター相談件数
-    const querentsGraph = formatGraph(Data.querents.data)
+    const querentsGraph = formatGraph(Data.querents.data as any)
     // 都営地下鉄の利用者数の推移
     const metroGraph = MetroData
     // 検査実施日別状況

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -86,6 +86,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import { Chart } from 'chart.js'
 import PageHeader from '@/components/PageHeader.vue'
 import TimeBarChart from '@/components/TimeBarChart.vue'
@@ -235,7 +236,7 @@ export default Vue.extend({
     }
     return data
   },
-  head() {
+  head(): MetaInfo {
     return {
       title: '都内の最新感染動向'
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
       "dom"
     ],
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "allowJs": true,
     "sourceMap": true,
     "strict": true,

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -8,10 +8,10 @@ const headers = [
 ]
 
 type DataType = {
-  リリース日: Date
+  リリース日: string
   居住地: string | null
   年代: string | null
-  性別: '男性' | '女性'
+  性別: '男性' | '女性' | string
   [key: string]: any
 }
 


### PR DESCRIPTION
**#698 かこちらか、どちらか一方のみmergeして下さい**
双方マージするとconflictします。コードとしても意味がありません。
#698 がpendingなので単独でts化出来るよう別PRを作りました。

## 📝 関連issue
- #621 refactor: コードベースを TypeScript 化する

## ⛏ 変更内容
- index.vue ts化
- Vue.extendsに対応
- tsconfig.json で resolveJsonModule しjsonの構造を直接取り出す  
  resolve結果とutils/formatXXX() との差異は（すぐには）解消できないので as any で逃げた
- chart.jsへ渡すオプション（オブジェクト）のアノテーション
- nuxt.config.ts build.extractCSS を `true` に