### PR TITLE
【改善】TypeScript(Vue.extend)の利用/ pages配下

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -36,15 +36,24 @@
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator'
+import Vue from 'vue'
 
-@Component
-export default class DataView extends Vue {
-  @Prop() private title!: string
-  @Prop() private date!: string
-  @Prop() private url!: string
-  @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
-}
+export default Vue.extend({
+  props: {
+    title: {
+      type: String,
+      default: ''
+    },
+    date: {
+      type: String,
+      default: ''
+    },
+    url: {
+      type: String,
+      default: ''
+    }
+  }
+})
 </script>
 
 <style lang="scss">

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -111,17 +111,14 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
-
-type LocalHead = {
-  title: string
-}
 
 export default Vue.extend({
   components: {
     TextCard
   },
-  head: (): LocalHead => ({
+  head: (): MetaInfo => ({
     title: '当サイトについて'
   })
 })

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -110,18 +110,21 @@
 </template>
 
 <script lang="ts">
+import Vue from 'vue'
 import TextCard from '@/components/TextCard.vue'
 
-export default {
+type LocalHead = {
+  title: string
+}
+
+export default Vue.extend({
   components: {
     TextCard
   },
-  head() {
-    return {
-      title: '当サイトについて'
-    }
-  }
-}
+  head: (): LocalHead => ({
+    title: '当サイトについて'
+  })
+})
 </script>
 
 <style lang="scss">

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -76,9 +76,9 @@
             />
           </div>
           <div class="TelLink">
-            <a href="tel:0570550571"
-              ><img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571"
-            /></a>
+            <a href="tel:0570550571">
+              <img src="/flow/sp/sp_flow_tel_01@2x.png" alt="0570-550571" />
+            </a>
           </div>
           <div class="mt-4">
             <a href="#consult">
@@ -213,17 +213,21 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue'
 import CovidIcon from '@/static/covid.svg'
 import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
-export default {
-  components: { CovidIcon, DesktopFlowSvg },
-  head() {
-    return {
-      title: '新型コロナウイルス感染症が心配なときに'
-    }
-  }
+
+type LocalHead = {
+  title: string
 }
+
+export default Vue.extend({
+  components: { CovidIcon, DesktopFlowSvg },
+  head: (): LocalHead => ({
+    title: '新型コロナウイルス感染症が心配なときに'
+  })
+})
 </script>
 
 <style lang="scss">

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -215,16 +215,13 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import CovidIcon from '@/static/covid.svg'
 import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
 
-type LocalHead = {
-  title: string
-}
-
 export default Vue.extend({
   components: { CovidIcon, DesktopFlowSvg },
-  head: (): LocalHead => ({
+  head: (): MetaInfo => ({
     title: '新型コロナウイルス感染症が心配なときに'
   })
 })

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -8,39 +8,44 @@
     </div>
   </div>
 </template>
+
 <script lang="ts">
+import Vue from 'vue'
 import TextCard from '@/components/TextCard.vue'
-export default {
+import { ItemsData } from '@/types/Items.d.ts'
+
+type LocalHead = {
+  title: string
+}
+
+export default Vue.extend({
   components: {
     TextCard
   },
-  data() {
-    return {
-      items: [
-        {
-          title: '1 感染予防・健康管理',
-          body:
-            '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="https://tokyodouga.jp/lViN9C_BS-0.html" target="_blank" rel="noopener">【参考】感染症予防のための正しい手洗い方法（動画）</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
-        },
-        {
-          title: '2 感染症を疑う場合の対応',
-          body:
-            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
-        },
-        {
-          title: '3 その他',
-          body: '〇  詳細は、各学校からのお知らせ等をご確認ください。'
-        }
-      ]
-    }
-  },
-  head() {
-    return {
-      title: 'お子様をお持ちの皆様へ'
-    }
-  }
-}
+  data: (): ItemsData => ({
+    items: [
+      {
+        title: '1 感染予防・健康管理',
+        body:
+          '〇　不特定多数の人の集まる場所等への外出を避け、基本的に自宅で過ごしてください。<br />〇　手洗い、咳エチケット等により、感染予防に努めてください。<br />　<a href="https://tokyodouga.jp/lViN9C_BS-0.html" target="_blank" rel="noopener">【参考】感染症予防のための正しい手洗い方法（動画）</a> <br />〇　規則正しい生活を心がけ、日常の健康管理に十分気を付けてください。'
+      },
+      {
+        title: '2 感染症を疑う場合の対応',
+        body:
+          '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
+      },
+      {
+        title: '3 その他',
+        body: '〇  詳細は、各学校からのお知らせ等をご確認ください。'
+      }
+    ]
+  }),
+  head: (): LocalHead => ({
+    title: 'お子様をお持ちの皆様へ'
+  })
+})
 </script>
+
 <style lang="scss">
 .Parent {
   &-Heading {

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -11,12 +11,9 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
 import { ItemsData } from '@/types/Items.d.ts'
-
-type LocalHead = {
-  title: string
-}
 
 export default Vue.extend({
   components: {
@@ -40,7 +37,7 @@ export default Vue.extend({
       }
     ]
   }),
-  head: (): LocalHead => ({
+  head: (): MetaInfo => ({
     title: 'お子様をお持ちの皆様へ'
   })
 })

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -13,7 +13,15 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
-import { ItemData } from '@/types/Items.d.ts'
+
+type ItemData = {
+  items: Item[]
+}
+
+type Item = {
+  title: string
+  body: string
+}
 
 export default Vue.extend({
   components: {

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -13,13 +13,13 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
-import { ItemsData } from '@/types/Items.d.ts'
+import { ItemData } from '@/types/Items.d.ts'
 
 export default Vue.extend({
   components: {
     TextCard
   },
-  data: (): ItemsData => ({
+  data: (): ItemData => ({
     items: [
       {
         title: '1 感染予防・健康管理',

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -12,13 +12,13 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
-import { ItemsData } from '@/types/Items.d.ts'
+import { ItemData } from '@/types/Items.d.ts'
 
 export default Vue.extend({
   components: {
     TextCard
   },
-  data: (): ItemsData => ({
+  data: (): ItemData => ({
     items: [
       {
         title: '新型コロナウイルス感染症対応緊急融資',

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -10,12 +10,9 @@
 </template>
 <script lang="ts">
 import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
 import { ItemsData } from '@/types/Items.d.ts'
-
-type LocalHead = {
-  title: string
-}
 
 export default Vue.extend({
   components: {
@@ -55,7 +52,7 @@ export default Vue.extend({
       }
     ]
   }),
-  head: (): LocalHead => ({
+  head: (): MetaInfo => ({
     title: '企業の皆様・はたらく皆様へ'
   })
 })

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -9,53 +9,56 @@
   </div>
 </template>
 <script lang="ts">
+import Vue from 'vue'
 import TextCard from '@/components/TextCard.vue'
-export default {
+import { ItemsData } from '@/types/Items.d.ts'
+
+type LocalHead = {
+  title: string
+}
+
+export default Vue.extend({
   components: {
     TextCard
   },
-  data() {
-    return {
-      items: [
-        {
-          title: '新型コロナウイルス感染症対応緊急融資',
-          body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html</a><br />新型コロナウイルス感染症により事業活動に影響を受けている中小企業等を対象とした緊急融資制度です。'
-        },
-        {
-          title: '新型コロナウイルスによる経営課題に関する専門家派遣',
-          body:
-            '<a href="https://www.tokyo-kosha.or.jp/topics/2003/0001.html" target="_blank" rel="noopener">https://www.tokyo-kosha.or.jp/topics/2003/0001.html</a><br />新型コロナウイルス感染症により経営面の影響を受けている中小企業を対象に、中小企業診断士等の専門家を無料で派遣し、経営改善等に向けたアドバイスを実施します。'
-        },
-        {
-          title: '事業継続緊急対策（テレワーク）助成金',
-          body:
-            '<a href="https://www.shigotozaidan.or.jp/koyo-kankyo/" target="_blank" rel="noopener">https://www.shigotozaidan.or.jp/koyo-kankyo/</a><br />都内中堅・中小企業に対し、テレワークの導入に必要な機器やソフトウェア等の経費を助成します。'
-        },
-        {
-          title: '中小企業者等特別相談窓口',
-          body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局　報道発表）'
-        },
-        {
-          title: '緊急労働相談ダイヤル',
-          body:
-            '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html</a><br />新型コロナウイルスに関する休暇や休業の取り扱い、職場のハラスメントなどについての相談（東京都産業労働局　報道発表）'
-        },
-        {
-          title: '新しいワークスタイルや企業活動の東京モデル「スムーズビズ」',
-          body:
-            '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
-        }
-      ]
-    }
-  },
-  head() {
-    return {
-      title: '企業の皆様・はたらく皆様へ'
-    }
-  }
-}
+  data: (): ItemsData => ({
+    items: [
+      {
+        title: '新型コロナウイルス感染症対応緊急融資',
+        body:
+          '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/03/05/26.html</a><br />新型コロナウイルス感染症により事業活動に影響を受けている中小企業等を対象とした緊急融資制度です。'
+      },
+      {
+        title: '新型コロナウイルスによる経営課題に関する専門家派遣',
+        body:
+          '<a href="https://www.tokyo-kosha.or.jp/topics/2003/0001.html" target="_blank" rel="noopener">https://www.tokyo-kosha.or.jp/topics/2003/0001.html</a><br />新型コロナウイルス感染症により経営面の影響を受けている中小企業を対象に、中小企業診断士等の専門家を無料で派遣し、経営改善等に向けたアドバイスを実施します。'
+      },
+      {
+        title: '事業継続緊急対策（テレワーク）助成金',
+        body:
+          '<a href="https://www.shigotozaidan.or.jp/koyo-kankyo/" target="_blank" rel="noopener">https://www.shigotozaidan.or.jp/koyo-kankyo/</a><br />都内中堅・中小企業に対し、テレワークの導入に必要な機器やソフトウェア等の経費を助成します。'
+      },
+      {
+        title: '中小企業者等特別相談窓口',
+        body:
+          '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/01/30/15.html</a> <br />資金繰りに関する相談、経営に関する相談（東京都産業労働局　報道発表）'
+      },
+      {
+        title: '緊急労働相談ダイヤル',
+        body:
+          '<a href="https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html" target="_blank" rel="noopener">https://www.metro.tokyo.lg.jp/tosei/hodohappyo/press/2020/02/26/22.html</a><br />新型コロナウイルスに関する休暇や休業の取り扱い、職場のハラスメントなどについての相談（東京都産業労働局　報道発表）'
+      },
+      {
+        title: '新しいワークスタイルや企業活動の東京モデル「スムーズビズ」',
+        body:
+          '<a href="https://smooth-biz.metro.tokyo.lg.jp/" target="_blank" rel="noopener">https://smooth-biz.metro.tokyo.lg.jp/</a><br />テレワーク・時差出勤などスムーズビズの取組は、新型コロナウイルス感染症の対策としても効果的です。感染症対策として、東京2020大会時の交通混雑緩和に向けた取組の前倒しをお願いします。'
+      }
+    ]
+  }),
+  head: (): LocalHead => ({
+    title: '企業の皆様・はたらく皆様へ'
+  })
+})
 </script>
 <style lang="scss">
 .Worker {

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -12,7 +12,15 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import TextCard from '@/components/TextCard.vue'
-import { ItemData } from '@/types/Items.d.ts'
+
+type ItemData = {
+  items: Item[]
+}
+
+type Item = {
+  title: string
+  body: string
+}
 
 export default Vue.extend({
   components: {

--- a/types/Items.d.ts
+++ b/types/Items.d.ts
@@ -1,8 +1,0 @@
-export interface ItemData {
-  items: Item[]
-}
-
-type Item = {
-  title: string
-  body: string
-}

--- a/types/Items.d.ts
+++ b/types/Items.d.ts
@@ -1,0 +1,8 @@
+export interface ItemsData {
+  items: Item[]
+}
+
+type Item = {
+  title: string
+  body: string
+}

--- a/types/Items.d.ts
+++ b/types/Items.d.ts
@@ -1,4 +1,4 @@
-export interface ItemsData {
+export interface ItemData {
   items: Item[]
 }
 


### PR DESCRIPTION
## 📝 関連issue
- This PR is a part of #621

## ⛏ 変更内容
- pages配下(index.vue以外)を `lang="ts"` 対応しました
- class-component部分を Vue.extendに統一しました

## 📸 スクリーンショット
UI変更はありません。