### PR TITLE
[/flow] コンポーネントコーディング モバイル版 FlowSpAdvisory.vue

### DIFF
--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -1,0 +1,95 @@
+<template>
+  <div>
+    <h3 :class="[$style.SodanHeader, $style.Title]">
+      新型コロナ受診相談窓口
+    </h3>
+    <p :class="$style.SodanHeader">
+      帰国者・接触者電話相談センター
+    </p>
+    <div :class="$style.SodanHeader">
+      <div :class="$style.SodanChip">
+        24時間対応
+      </div>
+    </div>
+    <dl>
+      <div :class="$style.SodanHeijitsu">
+        <dt :class="$style.Heijitsu">
+          平日（日中）
+        </dt>
+        <dd>
+          <a
+            :class="$style.Link"
+            href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
+            target="_blank"
+            rel="noopener"
+          >
+            各保健所の電話番号は福祉保健局HPへ
+            <v-icon size="16">
+              mdi-open-in-new
+            </v-icon>
+          </a>
+        </dd>
+      </div>
+      <div :class="$style.SodanYakan">
+        <dt :class="$style.Yakan">
+          平日（夜間）
+          <br />
+          <span :class="$style.SodanTime">午後５時から翌朝午前９時</span>
+          <br />
+          土日祝 終日
+        </dt>
+        <dd :class="$style.TelLink">
+          <a href="tel:0353204592">
+            <img src="/flow/sp/sp_flow_tel_03@2x.png" alt="03-5320-4592" />
+          </a>
+        </dd>
+      </div>
+    </dl>
+  </div>
+</template>
+
+<style module lang="scss">
+.SodanHeader {
+  text-align: center;
+  &.Title {
+    @include font-size(24);
+  }
+}
+.SodanChip {
+  display: inline-block;
+  background-color: $white;
+  border-radius: 4px;
+  padding: 8px 24px;
+  margin: 0 auto 12px;
+  color: $green-1;
+  font-weight: bold;
+}
+.SodanHeijitsu {
+  display: flex;
+  align-items: center;
+  padding: 12px 0;
+  border-width: 0.5px 0;
+  border-style: solid;
+  border-color: $gray-3;
+  .Heijitsu {
+    width: 70%;
+    margin-right: 5px;
+  }
+}
+.SodanYakan {
+  padding-top: 12px;
+  .Yakan {
+    text-align: center;
+    .SodanTime {
+      @include font-size(14);
+    }
+  }
+}
+.TelLink {
+  width: 80%;
+  margin: 0 auto;
+}
+.Link {
+  @include text-link();
+}
+</style>

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -1,25 +1,25 @@
 <template>
   <div>
-    <h3 :class="[$style.SodanHeader, $style.Title]">
+    <h3 :class="[$style.AlignCenter, $style.FontSize24]">
       新型コロナ受診相談窓口
     </h3>
-    <p :class="$style.SodanHeader">
+    <p :class="$style.AlignCenter">
       帰国者・接触者電話相談センター
     </p>
-    <div :class="$style.SodanHeader">
-      <div :class="$style.SodanChip">
+    <div :class="$style.AlignCenter">
+      <div :class="$style.ConsultationChip">
         24時間対応
       </div>
     </div>
     <dl>
-      <div :class="$style.SodanHeijitsu">
-        <dt :class="$style.Heijitsu">
+      <div :class="$style.ConsultationDaytime">
+        <dt :class="$style.ConsultationDaytimeTitle">
           平日（日中）
         </dt>
         <dd>
           <a
             :class="$style.Link"
-            href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
+            href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronaConsultation.html"
             target="_blank"
             rel="noopener"
           >
@@ -30,11 +30,11 @@
           </a>
         </dd>
       </div>
-      <div :class="$style.SodanYakan">
-        <dt :class="$style.Yakan">
+      <div :class="$style.PaddingTop12">
+        <dt :class="$style.AlignCenter">
           平日（夜間）
           <br />
-          <span :class="$style.SodanTime">午後５時から翌朝午前９時</span>
+          <span :class="$style.FontSize14">午後５時から翌朝午前９時</span>
           <br />
           土日祝 終日
         </dt>
@@ -49,13 +49,18 @@
 </template>
 
 <style module lang="scss">
-.SodanHeader {
-  text-align: center;
-  &.Title {
-    @include font-size(24);
+@each $size in 14, 24 {
+  .FontSize#{$size} {
+    @include font-size($size);
   }
 }
-.SodanChip {
+.AlignCenter {
+  text-align: center;
+}
+.PaddingTop12 {
+  padding-top: 12px;
+}
+.ConsultationChip {
   display: inline-block;
   background-color: $white;
   border-radius: 4px;
@@ -64,25 +69,16 @@
   color: $green-1;
   font-weight: bold;
 }
-.SodanHeijitsu {
+.ConsultationDaytime {
   display: flex;
   align-items: center;
   padding: 12px 0;
   border-width: 0.5px 0;
   border-style: solid;
   border-color: $gray-3;
-  .Heijitsu {
+  &Title {
     width: 70%;
     margin-right: 5px;
-  }
-}
-.SodanYakan {
-  padding-top: 12px;
-  .Yakan {
-    text-align: center;
-    .SodanTime {
-      @include font-size(14);
-    }
   }
 }
 .TelLink {

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <h3 :class="[$style.AlignCenter, $style.FontSize24]">
+    <h3 :class="[$style.AlignCenter, $style.FontSize22]">
       新型コロナ受診相談窓口
     </h3>
     <p :class="$style.AlignCenter">
@@ -49,7 +49,7 @@
 </template>
 
 <style module lang="scss">
-@each $size in 14, 24 {
+@each $size in 14, 22 {
   .FontSize#{$size} {
     @include font-size($size);
   }

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -76,7 +76,7 @@
   padding: 12px 0;
   border-width: 0.5px 0;
   border-style: solid;
-  border-color: $gray-3;
+  border-color: $gray-4;
   &Title {
     width: 70%;
     margin-right: 5px;

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -38,9 +38,10 @@
           <br />
           土日祝 終日
         </dt>
-        <dd :class="$style.TelLink">
+        <dd :class="[$style.TelLink, $style.FontSize24]">
+          <img src="/flow/phone-24px.svg" alt="Phone" />
           <a href="tel:0353204592">
-            <img src="/flow/sp/sp_flow_tel_03@2x.png" alt="03-5320-4592" />
+            03-5320-4592
           </a>
         </dd>
       </div>
@@ -49,7 +50,7 @@
 </template>
 
 <style module lang="scss">
-@each $size in 14, 22 {
+@each $size in 14, 22, 24 {
   .FontSize#{$size} {
     @include font-size($size);
   }
@@ -82,8 +83,14 @@
   }
 }
 .TelLink {
-  width: 80%;
-  margin: 0 auto;
+  font-family: 'Roboto', sans-serif;
+  font-weight: bold;
+  display: flex;
+  justify-content: center;
+  a {
+    color: $gray-2;
+    text-decoration: none;
+  }
 }
 .Link {
   @include text-link();

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -268,7 +268,7 @@ export default {
       padding: 30px 20px;
       margin-bottom: 20px;
       &.Flat {
-        background-color: $gray-4;
+        background-color: $gray-5;
       }
       .TelLink {
         width: 80%;

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -268,7 +268,7 @@ export default {
       padding: 30px 20px;
       margin-bottom: 20px;
       &.Flat {
-        background-color: $gray-5;
+        background-color: $gray-4;
       }
       .TelLink {
         width: 80%;


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #672

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- /flow の「新型コロナ受診相談窓口」部分を `FlowSpAdvisory.vue` で置き換え
  - 1枚画像のコンポーネントではないので、主にクラス名等のリファクタ程度
  - **電話番号をテキスト化**
  - **ボーダーと背景のグレー色を変更**
  - 「窓口」が折り返されているので、文字を少し小さくしました（**下記スクショ**参照）

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

|Before|After|
|:---:|:---:|
|![before](https://user-images.githubusercontent.com/19541094/76140891-4b266f80-60a2-11ea-80b3-a212b8206268.png)|![after](https://user-images.githubusercontent.com/19541094/76147158-cf95e400-60dc-11ea-9948-0c1b39c1f125.png)|
