### PR TITLE
time要素へのdatetime属性の追加・属性値のフォーマット修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -18,7 +18,7 @@
       <slot />
     </v-card-text>
     <v-footer class="DataView-Footer">
-      <time :datetime="date">{{ date }} 更新</time>
+      <time :datetime="convertDateToISO8601Format(date)">{{ date }} 更新</time>
       <a
         v-if="url"
         class="OpenDataLink"
@@ -36,6 +36,7 @@
 </template>
 
 <script lang="ts">
+import dayjs from 'dayjs'
 import { Component, Prop, Vue } from 'vue-property-decorator'
 
 @Component
@@ -45,6 +46,10 @@ export default class DataView extends Vue {
   @Prop() private date!: string
   @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
+
+  convertDateToISO8601Format(dateString: string): string {
+    return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
+  }
 }
 </script>
 

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -18,7 +18,7 @@
       <slot />
     </v-card-text>
     <v-footer class="DataView-Footer">
-      <time :datetime="convertDateToISO8601Format(date)">{{ date }} 更新</time>
+      <time :datetime="formattedDate">{{ date }} 更新</time>
       <a
         v-if="url"
         class="OpenDataLink"
@@ -36,8 +36,8 @@
 </template>
 
 <script lang="ts">
-import dayjs from 'dayjs'
 import { Component, Prop, Vue } from 'vue-property-decorator'
+import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 
 @Component
 export default class DataView extends Vue {
@@ -47,9 +47,7 @@ export default class DataView extends Vue {
   @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
 
-  convertDateToISO8601Format(dateString: string): string {
-    return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
-  }
+  formattedDate: string = convertDatetimeToISO8601Format(this.date)
 }
 </script>
 

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -8,20 +8,35 @@
     </h2>
     <div class="date">
       <span>最終更新 </span>
-      <time :datetime="convertDateToISO8601Format(date)">{{ date }}</time>
+      <time :datetime="formattedDate">{{ date }}</time>
     </div>
   </div>
 </template>
 
 <script>
-import dayjs from 'dayjs'
+import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 
 export default {
-  props: ['title', 'icon', 'date'],
-  methods: {
-    convertDateToISO8601Format(dateString) {
-      return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
+  props: {
+    title: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    icon: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    date: {
+      type: String,
+      required: false,
+      default: ''
     }
+  },
+  data() {
+    const formattedDate = convertDatetimeToISO8601Format(this.date)
+    return { formattedDate }
   }
 }
 </script>

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -7,14 +7,22 @@
       {{ title }}
     </h2>
     <div class="date">
-      <span>最終更新 </span><time>{{ date }}</time>
+      <span>最終更新 </span>
+      <time :datetime="convertDateToISO8601Format(date)">{{ date }}</time>
     </div>
   </div>
 </template>
 
 <script>
+import dayjs from 'dayjs'
+
 export default {
-  props: ['title', 'icon', 'date']
+  props: ['title', 'icon', 'date'],
+  methods: {
+    convertDateToISO8601Format(dateString) {
+      return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
+    }
+  }
 }
 </script>
 

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -14,9 +14,12 @@
           target="_blank"
           rel="noopener"
         >
-          <time class="WhatsNew-list-item-anchor-time px-2">{{
-            item.date
-          }}</time>
+          <time
+            class="WhatsNew-list-item-anchor-time px-2"
+            :datetime="convertDateToISO8601Format(item.date)"
+          >
+            {{ item.date }}
+          </time>
           <span class="WhatsNew-list-item-anchor-link">
             {{ item.text }}
             <v-icon
@@ -34,6 +37,8 @@
 </template>
 
 <script>
+import dayjs from 'dayjs'
+
 export default {
   props: {
     items: {
@@ -44,6 +49,9 @@ export default {
   methods: {
     isInternalLink(path) {
       return !/^https?:\/\//.test(path)
+    },
+    convertDateToISO8601Format(dateString) {
+      return dayjs(dateString).format('YYYY-MM-DD')
     }
   }
 }

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -16,7 +16,7 @@
         >
           <time
             class="WhatsNew-list-item-anchor-time px-2"
-            :datetime="convertDateToISO8601Format(item.date)"
+            :datetime="formattedDate(item.date)"
           >
             {{ item.date }}
           </time>
@@ -37,7 +37,7 @@
 </template>
 
 <script>
-import dayjs from 'dayjs'
+import { convertDateToISO8601Format } from '@/utils/formatDate'
 
 export default {
   props: {
@@ -50,8 +50,8 @@ export default {
     isInternalLink(path) {
       return !/^https?:\/\//.test(path)
     },
-    convertDateToISO8601Format(dateString) {
-      return dayjs(dateString).format('YYYY-MM-DD')
+    formattedDate(dateString) {
+      return convertDateToISO8601Format(dateString)
     }
   }
 }

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -1,0 +1,9 @@
+import dayjs from 'dayjs'
+
+export const convertDatetimeToISO8601Format = (dateString: string): string => {
+  return dayjs(dateString).format('YYYY-MM-DDTHH:mm:ss')
+}
+
+export const convertDateToISO8601Format = (dateString: string): string => {
+  return dayjs(dateString).format('YYYY-MM-DD')
+}


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/721

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- time要素にdatetime属性を追加することでマシンリーダブルにします
    - [MDN Web doc](https://developer.mozilla.org/ja/docs/Web/HTML/Element/time#Valid_datetime_Values)
- 日時フォーマットが妥当でない形式だったものは、修正しました
- 以下の箇所が該当
    - トップページの「都内の最新感染動向」の最新更新日時
    - トップページの「最新のお知らせ」の日付
    - トップページの各グラフの更新日時
- フォーマット変換の処理をutilsに置いています
- a11y対応はまだ行なってないです（i18nとの兼ね合いを考慮）

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

<img width="1618" alt="Screen Shot 2020-03-07 at 19 48 01" src="https://user-images.githubusercontent.com/10768439/76141997-a2314200-60ac-11ea-8bfa-f730adb2bfeb.png">
