### PR TITLE
[/flow] コンポーネントコーディング デスクトップ版 FlowPcRequired.vue

### DIFF
--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -33,13 +33,11 @@
 </template>
 <style module lang="scss">
 .Container {
+  @include card-container();
   display: flex;
   flex-direction: column;
   position: relative;
   padding: 20px 30px 15px !important;
-  border: 2px solid $gray-4;
-  border-radius: 4px;
-  box-shadow: 0px 0px 4px $gray-4;
   font-family: HiraginoSans-W6, Hiragino Sans;
 }
 .Row {

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -1,20 +1,32 @@
 <template>
   <div :class="$style.Container">
     <div :class="$style.Row">
-      <p :class="$style.Catch">新型コロナ外来<span :class="$style.Emphasis">受診が必要</span>と判断された場合</p>
+      <p :class="$style.Catch">
+        新型コロナ外来
+        <span :class="$style.Emphasis">受診が必要</span>
+        と判断された場合
+      </p>
     </div>
     <div :class="$style.Row">
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
-        <p :class="$style.Outpatient">新型コロナ外来（帰国者・接触者外来）</p>
-        <p :class="$style.Judge">医師による判断</p>
+        <p :class="$style.Outpatient">
+          新型コロナ外来（帰国者・接触者外来）
+        </p>
+        <p :class="$style.Judge">
+          医師による判断
+        </p>
       </div>
     </div>
     <div :class="$style.TwoRow">
       <div :class="[$style.Card, $style.CardGreen]">
-        <p :class="$style.CardGreenText">検査の必要あり</p>
+        <p :class="$style.CardGreenText">
+          検査の必要あり
+        </p>
       </div>
       <div :class="[$style.Card, $style.CardWhite]">
-        <p :class="$style.CardWhiteText">検査の必要なし</p>
+        <p :class="$style.CardWhiteText">
+          検査の必要なし
+        </p>
       </div>
     </div>
   </div>

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -1,11 +1,7 @@
 <template>
   <div :class="$style.Container">
     <div :class="$style.Row">
-      <p :class="$style.Catch">
-        新型コロナ外来
-        <span :class="$style.Emphasis">受診が必要</span>
-        と判断された場合
-      </p>
+      <p :class="$style.Catch">新型コロナ外来<span :class="$style.Emphasis">受診が必要</span>と判断された場合</p>
     </div>
     <div :class="$style.Row">
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
@@ -42,7 +38,7 @@
   margin-bottom: 15px;
 }
 .Row:last-of-type {
-  margin:0;
+  margin: 0;
 }
 .TwoRow {
   flex: 1;
@@ -67,7 +63,7 @@
   }
 }
 .CardLarge {
-  padding: 10px 80px !important; 
+  padding: 10px 80px !important;
 }
 
 .CardGray {

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -1,0 +1,105 @@
+<template>
+  <div :class="$style.Container">
+    <div :class="$style.Row">
+      <p :class="$style.Catch">
+        新型コロナ外来
+        <span :class="$style.Emphasis">受診が必要</span>
+        と判断された場合
+      </p>
+    </div>
+    <div :class="$style.Row">
+      <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
+        <p :class="$style.Outpatient">新型コロナ外来（帰国者・接触者外来）</p>
+        <p :class="$style.Judge">医師による判断</p>
+      </div>
+    </div>
+    <div :class="$style.TwoRow">
+      <div :class="[$style.Card, $style.CardGreen]">
+        <p :class="$style.CardGreenText">検査の必要あり</p>
+      </div>
+      <div :class="[$style.Card, $style.CardWhite]">
+        <p :class="$style.CardWhiteText">検査の必要なし</p>
+      </div>
+    </div>
+  </div>
+</template>
+<style module lang="scss">
+.Container {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  padding: 20px 30px 15px !important;
+  border: 2px solid $gray-4;
+  border-radius: 4px;
+  box-shadow: 0px 0px 4px $gray-4;
+  font-family: HiraginoSans-W6, Hiragino Sans;
+}
+.Row {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-bottom: 15px;
+}
+.Row:last-of-type {
+  margin:0;
+}
+.TwoRow {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.Catch {
+  color: $gray-2;
+  font-size: 16px;
+  margin: 0 !important;
+}
+.Card {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  padding: 10px 35px;
+  p {
+    margin: 0;
+  }
+}
+.CardLarge {
+  padding: 10px 80px !important; 
+}
+
+.CardGray {
+  color: $white;
+  background-color: $gray-2;
+  border: 0.5px solid $gray-4 !important;
+}
+.CardWhite {
+  background-color: $white;
+  border: 2px solid $green-1 !important;
+  &Text {
+    font-size: 22px;
+    color: $gray-2;
+  }
+}
+.CardGreen {
+  background-color: $green-1;
+  &Text {
+    color: $white;
+    font-size: 22px;
+  }
+}
+.Outpatient {
+  font-size: 18px;
+}
+.Judge {
+  font-size: 20px;
+}
+.Emphasis {
+  font-size: 35px;
+}
+</style>
+<script>
+export default {}
+</script>


### PR DESCRIPTION
## 📝 関連issue
#664

## ⛏ 変更内容
components/flow直下にFlowPcRequired.vueを作成しました。

## 📸 スクリーンショット
上：新規作成したコンポーネント
下：既存の画像で作成されたコンポーネント
![image](https://user-images.githubusercontent.com/49679298/76141889-a14be080-60ab-11ea-9eff-3837d8704ffe.png)

![image](https://user-images.githubusercontent.com/49679298/76141939-ee2fb700-60ab-11ea-9e27-397b552e90c0.png)

## 確認事項
- コンポーネントの境界にある黄色の矢印のパーツは入っていません。
- 拡大・縮小時の挙動について考慮できていないため、サイズを変えるとレイアウトが崩れます。 
 デザインの方針がありましたらご教示ください。対応します。
また、初めてのPRなので何か不備があればお知らせください。