### PR TITLE
[/flow] 「コンポーネントコーディング デスクトップ版 FlowPcSuspect.vue」を追加

### DIFF
--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -40,8 +40,8 @@
       </div>
 
       <div :class="$style.TelLink">
-        <img src="/flow/phone-24px.svg" alt="Phone" />
         <a href="tel:0570550571">
+          <img src="/flow/phone-24px.svg" alt="Phone" />
           0570-550571
         </a>
       </div>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -2,7 +2,12 @@
   <div :class="$style.FlowComponent">
     <div :class="[$style.SubtleBox, $style.Box1]">
       <div :class="$style.RowItems">
-        <div><img src="/flow/sentiment_very_dissatisfied-24px.svg" alt="dissatisfied face icon" /></div>
+        <div>
+          <img
+            src="/flow/sentiment_very_dissatisfied-24px.svg"
+            alt="dissatisfied face icon"
+          />
+        </div>
         <div :class="$style.SmallerText">
           不安に思う方
         </div>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -1,0 +1,140 @@
+<template>
+  <div :class="$style.FlowComponent">
+    <div :class="[$style.SubtleBox, $style.Box1]">
+      <div :class="$style.RowItems">
+        <div><img src="/flow/sentiment_very_dissatisfied-24px.svg" alt="dissatisfied face icon" /></div>
+        <div :class="$style.SmallerText">
+          不安に思う方
+        </div>
+      </div>
+      <div :class="$style.RowItems">
+        <div :class="$style.CheckBox">
+          微熱
+        </div>
+        <div :class="$style.CheckBox">
+          軽い咳
+        </div>
+        <div :class="$style.CheckBox">
+          感染の不安
+        </div>
+      </div>
+    </div>
+
+    <div :class="$style.FlowArrow">
+      <img src="/flow/flow_arrow.svg" alt="→" />
+    </div>
+
+    <div :class="[$style.SubtleBox, $style.Box2]">
+      <div :class="$style.LargerText">
+        新型コロナコールセンター
+      </div>
+
+      <div :class="$style.SmallerText">
+        午前9時から午後9時<br />
+        （土日祝含む）
+      </div>
+
+      <div :class="$style.TelLink">
+        <img src="/flow/phone-24px.svg" alt="Phone" />
+        <a href="tel:0570550571">
+          0570-550571
+        </a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style module lang="scss">
+$green-1: #00a040;
+$gray-2: #4d4d4d;
+$background-color: #f2f2f2;
+$border-color: #d9d9d9;
+
+.FlowComponent {
+  color: $gray-2;
+  font-family: 'Roboto', sans-serif;
+  margin: 0 0;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.TelLink {
+  font-family: 'Roboto', sans-serif;
+  a {
+    color: $gray-2;
+    text-decoration: none;
+    font-weight: bold;
+  }
+}
+
+.CheckBox {
+  position: relative;
+  font-size: larger;
+  font-family: HiraginoSans-W6, Hiragino Sans;
+  border: 2px solid $green-1;
+  border-radius: 4px;
+  margin: 8px;
+  padding: 4px 0;
+  max-width: 200px;
+
+  &:after {
+    position: absolute;
+    left: -8px;
+    top: -8px;
+    content: url(/flow/check_circle-24px.svg);
+  }
+
+  &:before {
+    position: absolute;
+    left: -4px;
+    top: -4px;
+    width: 20px;
+    height: 20px;
+    background-color: white;
+    content: '';
+  }
+}
+
+.SubtleBox {
+  border-radius: 4px;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  margin: 0 4px;
+  padding: 0.5em;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.Box1 {
+  flex-grow: 2;
+}
+
+.Box2 {
+  flex-grow: 1;
+  flex-direction: column;
+  div {
+    margin: 0.5em;
+  }
+}
+
+.RowItems {
+  flex-grow: 1;
+  margin: 0 2em;
+}
+
+.FlowArrow {
+  margin: 0 -20px;
+}
+
+.LargerText {
+  font-size: Larger;
+  font-weight: bold;
+}
+
+.SmallerText {
+  font-size: smaller;
+}
+</style>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -104,8 +104,7 @@
 }
 
 .SubtleBox {
-  border-radius: 4px;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
+  @include card-container();
   margin: 0 4px;
   padding: 0.5em;
   display: flex;
@@ -136,6 +135,7 @@
 
 .FlowArrow {
   margin: 0 -20px;
+  z-index: 1;
 }
 
 .LargerText {

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -50,11 +50,6 @@
 </template>
 
 <style module lang="scss">
-$green-1: #00a040;
-$gray-2: #4d4d4d;
-$background-color: #f2f2f2;
-$border-color: #d9d9d9;
-
 .FlowComponent {
   color: $gray-2;
   font-family: 'Roboto', sans-serif;
@@ -67,7 +62,7 @@ $border-color: #d9d9d9;
 
 .TelLink {
   font-family: 'Roboto', sans-serif;
-  @media all and (min-width: 850px) {
+  @include largerThan($medium) {
     font-size: larger;
   }
   a {
@@ -86,7 +81,7 @@ $border-color: #d9d9d9;
   margin: 8px;
   padding: 4px 0;
   max-width: 200px;
-  @media all and (min-width: 850px) {
+  @include largerThan($medium) {
     font-size: larger;
   }
 
@@ -134,7 +129,7 @@ $border-color: #d9d9d9;
 .RowItems {
   flex-grow: 1;
   margin: 0 4px;
-  @media all and (min-width: 1024px) {
+  @include largerThan($large) {
     margin: 0 2em;
   }
 }
@@ -144,7 +139,7 @@ $border-color: #d9d9d9;
 }
 
 .LargerText {
-  font-size: Larger;
+  font-size: larger;
   font-weight: bold;
 }
 

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -67,6 +67,9 @@ $border-color: #d9d9d9;
 
 .TelLink {
   font-family: 'Roboto', sans-serif;
+  @media all and (min-width: 850px) {
+    font-size: larger;
+  }
   a {
     color: $gray-2;
     text-decoration: none;
@@ -76,13 +79,16 @@ $border-color: #d9d9d9;
 
 .CheckBox {
   position: relative;
-  font-size: larger;
+  font-size: normal;
   font-family: HiraginoSans-W6, Hiragino Sans;
   border: 2px solid $green-1;
   border-radius: 4px;
   margin: 8px;
   padding: 4px 0;
   max-width: 200px;
+  @media all and (min-width: 850px) {
+    font-size: larger;
+  }
 
   &:after {
     position: absolute;
@@ -127,7 +133,10 @@ $border-color: #d9d9d9;
 
 .RowItems {
   flex-grow: 1;
-  margin: 0 2em;
+  margin: 0 4px;
+  @media all and (min-width: 1024px) {
+    margin: 0 2em;
+  }
 }
 
 .FlowArrow {


### PR DESCRIPTION
デスクトップ版 FlowPcSuspect.vue のコンポーネントを作りました。 #662

## 📝 関連issue

#662 

## ⛏ 変更内容

- デスクトップ版 FlowPcSuspect.vue のコンポーネントを作りました。

## 📸 スクリーンショット

<img width="853" alt="image" src="https://user-images.githubusercontent.com/118150/76142597-8af55300-60b2-11ea-9e82-f94c3765fa73.png">

## TODO

~~[ ] i18n~~  (#747にi18nは次の段階とあったので)
