### PR TITLE
data.json "inspections" のvalueの整数値が文字列で格納されている問題 #700

### DIFF
--- a/tool/convert.php
+++ b/tool/convert.php
@@ -216,7 +216,7 @@ function readInspections() : array{
   });
   return [
     'date' => '2020/3/5/ 00:00', //TODO 現在のエクセルに更新日付がないので変更する必要あり
-    'data' => $data
+    'data' => intval(str_replace(' ', '', $data))
   ];
 }
 
@@ -226,10 +226,10 @@ function readInspectionsSummary(array $inspections) : array
     'date' => $inspections['date'],
     'data' => [
       '都内' => $inspections['data']->map(function ($row) {
-        return str_replace(' ', '', $row['（小計①）']);
+        return $row['（小計①）'];
       }),
       'その他' => $inspections['data']->map(function ($row) {
-        return str_replace(' ', '', $row['（小計②）']);
+        return $row['（小計②）'];
       }),
     ],
     'labels' =>$inspections['data']->map(function ($row) {


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #700

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- `data.json` を作成している `tool/convert.php` の `inspections` の値を設定している部分で、これまで文字列型で設定していたものを、無駄なスペースを取り除いた後に数値型に変換するように修正。
- 同様に `inspections_summary` の値を設定している部分では、これまで無駄なスペースを取り除く処理をしていたが、元の値の `inspections` に正しく数値型が設定されるようになったのでこの処理を削除。

## その他
- `data.json` のファイル自体は変更しておりません。今のところvueでは `inspections_summary` の値が使用されており `inspections` の値は使用されていないことと、自動生成されるファイルは手動で変更しない方がいいと判断いたしました。
-  この処理の元となる `xlsx` ファイルの入手方法がわからなかったので、一度正しいファイルで取り込みを行って確認していただければと思います。