### PR TITLE
 #846 noscriptを追加

### DIFF
--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -1,0 +1,94 @@
+<template>
+  <noscript>
+    <div class="noscript">
+      <style>.loader { display: none; }</style>
+      <div class="noscript-heading">
+        <img src="/logo.svg" :alt="$t('東京都')" />
+        {{ $t('新型コロナウイルス感染症') }}<br />{{ $t('対策サイト') }}
+      </div>
+      <div class="noscript-body">
+        {{ $t('当サイトではJavaScriptを使用しております。') }}<br />
+        {{
+          $t(
+            'JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。'
+          )
+        }}<br />
+        {{
+          $t(
+            '当サイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。'
+          )
+        }}
+      </div>
+    </div>
+  </noscript>
+</template>
+
+<i18n>
+{
+  "ja": {
+    "東京都": "東京都",
+    "新型コロナウイルス感染症": "新型コロナウイルス感染症",
+    "対策サイト": "対策サイト",
+    "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。"
+  },
+  "en": {
+    "東京都": "Tokyo Metropolitan Government",
+    "新型コロナウイルス感染症": "COVID-19",
+    "対策サイト": "Task Force website",
+    "当WebサイトではJavaScriptを使用しております。JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "This site uses Javascript. If Javascript is disabled, the site may not work as expected or may not display correctly. Please make sure to enable Javascript when browsing this site."
+  },
+  "zh-cn": {
+    "東京都": "東京都",
+    "新型コロナウイルス感染症": "新型冠状病毒",
+    "対策サイト": "资讯站",
+    "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "本网站使用了Javascript。如果您将Javascript设为无效化，会造成网页无法正常操作，或者造成网页无法正常显示。当您使用本网站时，请务必将Javascript设为有效。"
+  },
+  "zh-tw": {
+    "東京都": "东京都",
+    "新型コロナウイルス感染症": "新型冠狀病毒",
+    "対策サイト": "戰情中心",
+    "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "本網站使用了 Javascript。如果您將 Javascript 設為無效化，會造成網頁無法正常操作，或者造成網頁無法正常顯示。當您使用本網站時，請務必將 Javascript 設為有效。"
+  },
+  "ko": {
+    "東京都": "도쿄도청",
+    "新型コロナウイルス感染症": "코로나19",
+    "対策サイト": "TF 웹사이트",
+    "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "본 웹사이트에서는 자바스크립트를 사용합니다. 자바스크립트를 허용하지 않으면 각 페이지가 제대로 작동하지 않거나 표시되지 않을 수 있습니다. 본 웹사이트를 이용시에는 자바스크립트를 허용해 주시기를 요청드립니다."
+  },
+  "ja-basic": {
+    "東京都": "とうきょうと",
+    "新型コロナウイルス感染症": "あたらしいコロナウイルスの",
+    "対策サイト": "びょうきについて",
+    "当WebサイトではJavaScriptを使用しております。 JavaScriptを無効にして使用された場合、各ページが正常に動作しない、または、表示されない場合がございます。 当Webサイトをご利用の際には、JavaScriptを有効にして頂きますようお願いいたします。": "このページでは、JavaScriptというぎじゅつをつかっています。これをOFFにしていると、ページがうまくみられない場合があるので、ONにしてください。"
+  }
+}
+</i18n>
+
+<style lang="scss" scoped>
+.noscript {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  min-width: 310px;
+  max-width: 440px;
+  transform: translateY(-50%) translateX(-50%);
+}
+.noscript-heading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  @include font-size(13);
+  color: #898989;
+  img {
+    margin-right: 16px;
+  }
+}
+.noscript-body {
+  @include font-size(13);
+  @include card-container();
+  border-radius: 4px;
+  margin-top: 16px;
+  padding: 1em;
+  color: rgba(0,0,0,.87);
+}
+</style>

--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- eslint-disable vue/html-indent -->
   <noscript>
     <div class="noscript">
       <style>
@@ -25,6 +26,7 @@
       </div>
     </div>
   </noscript>
+  <!--eslint-enable-->
 </template>
 
 <i18n>

--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -1,7 +1,11 @@
 <template>
   <noscript>
     <div class="noscript">
-      <style>.loader { display: none; }</style>
+      <style>
+        .loader {
+          display: none;
+        }
+      </style>
       <div class="noscript-heading">
         <img src="/logo.svg" :alt="$t('東京都')" />
         {{ $t('新型コロナウイルス感染症') }}<br />{{ $t('対策サイト') }}
@@ -89,6 +93,6 @@
   border-radius: 4px;
   margin-top: 16px;
   padding: 1em;
-  color: rgba(0,0,0,.87);
+  color: rgba(0, 0, 0, 0.87);
 }
 </style>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -256,7 +256,7 @@ export default {
     left: 0;
     display: block !important;
     width: 100%;
-    z-index: z-index-of(opened-side-navigation);    
+    z-index: z-index-of(opened-side-navigation);
     background-color: $white;
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -19,6 +19,7 @@
         </v-container>
       </div>
     </div>
+    <NoScript />
   </v-app>
 </template>
 <script lang="ts">
@@ -26,6 +27,7 @@ import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 import SideNavigation from '@/components/SideNavigation.vue'
+import NoScript from '@/components/NoScript.vue'
 
 type LocalData = {
   isOpenNavigation: boolean
@@ -35,7 +37,8 @@ type LocalData = {
 export default Vue.extend({
   components: {
     ScaleLoader,
-    SideNavigation
+    SideNavigation,
+    NoScript
   },
   data(): LocalData {
     return {


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #846

## ⛏ 変更内容
- noscriptタグを追加
- 既存のUIを流用しnoscipt内部の要素を作成

## 📸 スクリーンショット
|before|after|
|--|--|
|![スクリーンショット 2020-03-07 21 52 19](https://user-images.githubusercontent.com/27715262/76143846-16c0ac80-60be-11ea-8324-1e7698eea95d.png)|![スクリーンショット 2020-03-07 21 52 34](https://user-images.githubusercontent.com/27715262/76143851-1de7ba80-60be-11ea-85dc-41c1f1044aca.png)|

|pc|iphone|iPad|
|-|-|-|
|![スクリーンショット 2020-03-07 21 52 34](https://user-images.githubusercontent.com/27715262/76143901-7f0f8e00-60be-11ea-9189-7fcdf5c470b0.png)|![スクリーンショット 2020-03-07 21 33 59](https://user-images.githubusercontent.com/27715262/76143924-c0a03900-60be-11ea-9089-2b64bfceb867.png)|![スクリーンショット 2020-03-07 21 34 45](https://user-images.githubusercontent.com/27715262/76143927-c5fd8380-60be-11ea-8370-0f903ce7e84c.png)|

## ❓変更理由
- Lighthouseで、Does not provide fallback content when JavaScript is not available の警告が出てているの解消するため
![スクリーンショット 2020-03-07 21 35 27](https://user-images.githubusercontent.com/27715262/76143991-30162880-60bf-11ea-9d29-a09215502184.png)

- JavaScript Off の状態でアクセスすると、ローディングのUIが表示され続けており、ユーザに次のアクションを期待させてしまう。

- [当サイトについて](https://stopcovid19.metro.tokyo.lg.jp/about)内でJavaScriptに関しての記述があるが、
  JavaScript Off のユーザは該当画面を確認するすべがない

## ❗️備考
- 本来はJavaScript Offの状態でも主要コンテンツが閲覧できるのがベストなため、
いったん暫定の対応。

   
