### PR TITLE
サイドバーのアイテムをホバーした時にテキストに下線を表示させる

### DIFF
--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -113,6 +113,7 @@ export default class ListItem extends Vue {
     }
     &:hover {
       color: transparent !important;
+      text-decoration: underline;
       & .ListItem-Text {
         font-weight: bold;
       }


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #{ISSUE_NUMBER}

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- https://stopcovid19.metro.tokyo.lg.jp もしくは https://stopcovid19.metro.tokyo.lg.jp/flow/ を開いた時、サイドバーのアイテムをホバーすると下線が付いていなかったので表示させました。
別のパス (https://stopcovid19.metro.tokyo.lg.jp/parent など) に切り替えて戻ってくると下線が表示されるようになるので、下線が表示されるのが正なのかと思い PR を送らせていただきました。

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

https://stopcovid19.metro.tokyo.lg.jp にアクセスして、アイテムをホバーする。

- **before**
<img width="220" alt="スクリーンショット 2020-03-07 22 20 55" src="https://user-images.githubusercontent.com/25548003/76144282-05799f00-60c2-11ea-8875-3e4df1db23a9.png">

- **after**
<img width="241" alt="スクリーンショット 2020-03-07 22 23 22" src="https://user-images.githubusercontent.com/25548003/76144319-538ea280-60c2-11ea-9c32-77c093fb0a13.png">

