### PR TITLE
スクリーンショットを撮るコマンドを単純にする

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           python-version: 3.8
       - run: pip install selenium
-      - run: (python -m http.server --directory ./dist 8000 &)  ; python ./ui-test/screenshot.py
+      - run: python ./ui-test/screenshot.py
       - name: Upload screenshot
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -27,6 +27,10 @@ jobs:
       - run: yarn run test
       - run: yarn run generate:deploy
       - run: cp ui-test\dummy.json dist\data/\data.json
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
       - run: pip install selenium
       - run: (python -m http.server --directory ./dist 8000 &)  ; python ./ui-test/screenshot.py
       - name: Upload screenshot

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cp ui-test\dummy.json dist\data/\data.json
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -27,6 +26,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:deploy
+      - run: cp ui-test\dummy.json dist\data/\data.json
       - run: pip install selenium
       - run: (python -m http.server --directory ./dist 8000 &)  ; python ./ui-test/screenshot.py
       - name: Upload screenshot

--- a/ui-test/screenshot.py
+++ b/ui-test/screenshot.py
@@ -1,16 +1,33 @@
-from selenium import webdriver
+import functools
 import os
+from http.server import SimpleHTTPRequestHandler
+from http.server import ThreadingHTTPServer
+import threading
+
+from selenium import webdriver
 
 os.mkdir('screenshots')
 
-SIZES = [[320,480],[375,812],[768,1024],[1024,768],[1920,1080]]
-PATHS = ['/', '/about']
-BROWSERS = ['Chrome', 'Firefox']
+RequestHandlerClass = functools.partial(SimpleHTTPRequestHandler,
+                                        directory='dist')
+with ThreadingHTTPServer(('localhost', 8000), RequestHandlerClass) as httpd:
+    thread = threading.Thread(target=lambda httpd: httpd.serve_forever(),
+                              args=(httpd,))
+    thread.start()
 
-for browser in BROWSERS:
-	driver = getattr(webdriver, browser)()
-	for size in SIZES:
-		driver.set_window_size(size[0], size[1])
-		for path in PATHS:
-			driver.get("http://localhost:8000"+path)
-			driver.save_screenshot('screenshots/'+browser+'_'+str(size[0])+'x'+str(size[1])+'_'+path.replace('/', '_')+'.png')
+    SIZES = [[320, 480], [375, 812], [768, 1024], [1024, 768], [1920, 1080]]
+    PATHS = ['/', '/about']
+    BROWSERS = ['Chrome', 'Firefox']
+
+    for browser in BROWSERS:
+        driver = getattr(webdriver, browser)()
+        for size in SIZES:
+            driver.set_window_size(size[0], size[1])
+            for path in PATHS:
+                driver.get("http://localhost:8000" + path)
+                filename = '{}_{}x{}_{}.png'.format(browser,
+                                                    size[0], size[1],
+                                                    path.replace('/', '_'))
+                driver.save_screenshot(os.path.join('screenshots', filename))
+
+    httpd.shutdown()


### PR DESCRIPTION
## ⛏ 変更内容
- cpコマンドの実行を後ろへ移動
  - distディレクトリ作成前に実行すると、cpコマンドの実行に失敗する
- 利用するPythonのバージョンを指定
  - サーバが使うディレクトリを指定できるのはPython 3.7以降
- スクリーンショットを撮るコマンドを単純化
  - Pythonスクリプト内でサーバを起動するように変更
- Pythonスクリプトのフォーマットを変更
  - 例えば、変更前のPythonスクリプトを[pycodestyle](https://pypi.org/project/pycodestyle/)にかけると下記のエラーが出る
```
ui-test/screenshot.py:6:14: E231 missing whitespace after ','
ui-test/screenshot.py:6:19: E231 missing whitespace after ','
ui-test/screenshot.py:6:24: E231 missing whitespace after ','
ui-test/screenshot.py:6:29: E231 missing whitespace after ','
ui-test/screenshot.py:6:34: E231 missing whitespace after ','
ui-test/screenshot.py:6:40: E231 missing whitespace after ','
ui-test/screenshot.py:6:46: E231 missing whitespace after ','
ui-test/screenshot.py:6:51: E231 missing whitespace after ','
ui-test/screenshot.py:6:57: E231 missing whitespace after ','
ui-test/screenshot.py:11:1: W191 indentation contains tabs
ui-test/screenshot.py:11:2: E117 over-indented
ui-test/screenshot.py:12:1: W191 indentation contains tabs
ui-test/screenshot.py:13:1: W191 indentation contains tabs
ui-test/screenshot.py:13:3: E117 over-indented
ui-test/screenshot.py:14:1: W191 indentation contains tabs
ui-test/screenshot.py:15:1: W191 indentation contains tabs
ui-test/screenshot.py:15:4: E117 over-indented
ui-test/screenshot.py:16:1: W191 indentation contains tabs
ui-test/screenshot.py:16:80: E501 line too long (117 > 79 characters)
```
