### PR TITLE
#750 Lintが落ちたらGithubActionでもfailするようにreporterを修正

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -15,5 +15,5 @@ jobs:
         uses: reviewdog/action-eslint@v1
         with:
           github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
+          reporter: github-pr-check
           eslint_flags: './**/*.{vue,ts,js}'


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #750

## ⛏ 変更内容
Lintが落ちたらGithubActionでもfailするようにreporterを `github-pr-check` に変更しました。
#752  で調査した内容をもとに必要な変更のみにしております。

https://github.com/reviewdog/reviewdog/blob/master/README.md#reporter-github-checks--reportergithub-pr-check

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<img width="653" alt="スクリーンショット 2020-03-08 00 00 08" src="https://user-images.githubusercontent.com/4666330/76145756-cce0c200-60cf-11ea-9996-0bf2ee9608a4.png">
