### PR TITLE
/flow の「詳細を見る」のリンク先変更

### DIFF
--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -199,7 +199,7 @@
         </div>
       </div>
       <a
-        href="https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html"
+        href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
         target="_blank"
         rel="noopener"
         class="Flow-Card-Button"


### PR DESCRIPTION
## 📝 関連issue
- close #780 

## ⛏ 変更内容
- /flow 下部の「詳細を見る」の遷移先を変更

### After
https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html

### Before
https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
![image](https://user-images.githubusercontent.com/42484226/76146500-8e9ad100-60d6-11ea-887b-8dc820951b01.png)
