### PR TITLE
URLの末尾に "/" が付くケースでもサイドバーのアイテムを Active にする

### DIFF
--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -75,7 +75,7 @@ export default class ListItem extends Vue {
   }
 
   isActive(link: string): string | undefined {
-    if (link === this.$route.path) {
+    if (link === this.$route.path || link + '/' === this.$route.path) {
       return 'isActive'
     }
   }

--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -75,7 +75,7 @@ export default class ListItem extends Vue {
   }
 
   isActive(link: string): string | undefined {
-    if (link === this.$route.path || link + '/' === this.$route.path) {
+    if (link === this.$route.path || `${link}/` === this.$route.path) {
       return 'isActive'
     }
   }


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #{ISSUE_NUMBER}

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- URL の末尾に "/" がつく場合、サイドバーのアイテムが Active になっておらずどこを指しているかわからない状況になっていました。"/" がつく場合でも Active になるように修正しました。

※ https://stopcovid19.metro.tokyo.lg.jp/flow でリロードすると https://stopcovid19.metro.tokyo.lg.jp/flow/ にアクセスしてしまいます。

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->

https://stopcovid19.metro.tokyo.lg.jp/flow/ にアクセスする。

- **before**

「新型コロナウイルス感染症が不安なときに」が Active になっていない。

<img width="1436" alt="スクリーンショット 2020-03-08 1 08 54" src="https://user-images.githubusercontent.com/25548003/76146813-7d9f8f00-60d9-11ea-9391-f4e928604072.png">

- **after**

「新型コロナウイルス感染症が不安なときに」が Active になっている。

<img width="1196" alt="スクリーンショット 2020-03-08 1 10 05" src="https://user-images.githubusercontent.com/25548003/76146823-96a84000-60d9-11ea-9736-d031d3b9e66f.png">