### PR TITLE
Revert "トップページの canvas 要素の id 属性が重複しないよう変更"

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -7,7 +7,7 @@
         *都営地下鉄4路線の自動改札出場数
       </p>
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="chartOption" :height="240" />
+    <bar :chart-data="displayData" :options="chartOption" :height="240" />
   </data-view>
 </template>
 
@@ -36,7 +36,6 @@ export default Vue.extend<
   {},
   {},
   {
-    chartId: string
     chartData: ChartData
     chartOption: ChartOptions
     title: string
@@ -54,11 +53,6 @@ export default Vue.extend<
       type: String,
       required: false,
       default: ''
-    },
-    chartId: {
-      type: String,
-      required: false,
-      default: 'metro-bar-chart'
     },
     chartData: Object,
     chartOption: Object,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="displayOption" :height="240" />
+    <bar :chart-data="displayData" :options="displayOption" :height="240" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -33,11 +33,6 @@ export default {
       type: String,
       required: false,
       default: ''
-    },
-    chartId: {
-      type: String,
-      required: false,
-      default: 'time-bar-chart'
     },
     chartData: {
       type: Array,

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="options" :height="240" />
+    <bar :chart-data="displayData" :options="options" :height="240" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -31,11 +31,6 @@ export default {
       type: String,
       required: false,
       default: ''
-    },
-    chartId: {
-      type: String,
-      required: false,
-      default: 'time-stacked-bar-chart'
     },
     chartData: {
       type: Array,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -28,7 +28,6 @@
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="陽性患者数"
-          :chart-id="'time-bar-chart-patients'"
           :title-id="'number-of-confirmed-cases'"
           :chart-data="patientsGraph"
           :date="Data.patients.date"
@@ -54,7 +53,6 @@
       <v-col cols="12" md="6" class="DataCard">
         <time-stacked-bar-chart
           title="検査実施数"
-          :chart-id="'time-stacked-bar-chart-inspections'"
           :title-id="'number-of-tested'"
           :chart-data="inspectionsGraph"
           :date="Data.inspections_summary.date"
@@ -66,7 +64,6 @@
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
-          :chart-id="'time-bar-chart-contacts'"
           :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
           :chart-data="contactsGraph"
           :date="Data.contacts.date"
@@ -77,7 +74,6 @@
       <v-col cols="12" md="6" class="DataCard">
         <time-bar-chart
           title="新型コロナ受診相談窓口相談件数"
-          :chart-id="'time-bar-chart-querents'"
           :title-id="'number-of-reports-to-covid19-consultation-desk'"
           :chart-data="querentsGraph"
           :date="Data.querents.date"
@@ -88,7 +84,6 @@
       <v-col cols="12" md="6" class="DataCard">
         <metro-bar-chart
           title="都営地下鉄の利用者数の推移"
-          :chart-id="'metro-bar-chart'"
           :title-id="'predicted-number-of-toei-subway-passengers'"
           :chart-data="metroGraph"
           :chart-option="metroGraphOption"


### PR DESCRIPTION
Reverts tokyo-metropolitan-gov/covid19#699

`develop` に向けるべきだったのを `feature/types/development` にマージしてしまったので Revert します。