### PR TITLE
最新のお知らせのリンクがあたる幅を修正

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -83,7 +83,7 @@ export default {
 
   &-item {
     &-anchor {
-      display: flex;
+      display: inline-flex;
       text-decoration: none;
       margin: 5px;
       font-size: 14px;


### PR DESCRIPTION
## 📝 関連issue/Related issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
<!--
  ・ If there's no related issue, please remove this section
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #804 

## ⛏ 変更内容/Change details
<!-- 変更を端的に箇条書きで -->
<!-- Please concisely list the changes -->
- linkが親要素の幅いっぱいにあたってたものを文字列の部分だけにしました