### PR TITLE
トップページの canvas 要素の id 属性が重複しないよう変更 (宛先branch変更)

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -7,7 +7,12 @@
         *都営地下鉄4路線の自動改札出場数
       </p>
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="chartOption" :height="240" />
+    <bar
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="chartOption"
+      :height="240"
+    />
   </data-view>
 </template>
 

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -7,7 +7,7 @@
         *都営地下鉄4路線の自動改札出場数
       </p>
     </template>
-    <bar :chart-data="displayData" :options="chartOption" :height="240" />
+    <bar :chart-id="chartId" :chart-data="displayData" :options="chartOption" :height="240" />
   </data-view>
 </template>
 
@@ -37,6 +37,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    chartId: {
+      type: String,
+      required: false,
+      default: 'metro-bar-chart'
     },
     chartData: {
       type: Object,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,12 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="displayOption" :height="240" />
+    <bar
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="displayOption"
+      :height="240"
+    />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -3,7 +3,7 @@
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-data="displayData" :options="displayOption" :height="240" />
+    <bar :chart-id="chartId" :chart-data="displayData" :options="displayOption" :height="240" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -33,6 +33,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    chartId: {
+      type: String,
+      required: false,
+      default: 'time-bar-chart'
     },
     chartData: {
       type: Array,

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -6,7 +6,7 @@
       </p>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-data="displayData" :options="options" :height="240" />
+    <bar :chart-id="chartId" :chart-data="displayData" :options="options" :height="240" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -34,6 +34,11 @@ export default {
       type: String,
       required: false,
       default: ''
+    },
+    chartId: {
+      type: String,
+      required: false,
+      default: 'time-stacked-bar-chart'
     },
     chartData: {
       type: Array,

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -6,7 +6,12 @@
       </p>
       <data-selector v-model="dataKind" />
     </template>
-    <bar :chart-id="chartId" :chart-data="displayData" :options="options" :height="240" />
+    <bar
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="options"
+      :height="240"
+    />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,6 +29,7 @@
         <time-bar-chart
           title="陽性患者数"
           :title-id="'number-of-confirmed-cases'"
+          :chart-id="'time-bar-chart-patients'"
           :chart-data="patientsGraph"
           :date="Data.patients.date"
           :unit="'人'"
@@ -54,6 +55,7 @@
         <time-stacked-bar-chart
           title="検査実施数"
           :title-id="'number-of-tested'"
+          :chart-id="'time-stacked-bar-chart-inspections'"
           :chart-data="inspectionsGraph"
           :date="Data.inspections_summary.date"
           :items="inspectionsItems"
@@ -65,6 +67,7 @@
         <time-bar-chart
           title="新型コロナコールセンター相談件数"
           :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
+          :chart-id="'time-bar-chart-contacts'"
           :chart-data="contactsGraph"
           :date="Data.contacts.date"
           :unit="'件'"
@@ -75,6 +78,7 @@
         <time-bar-chart
           title="新型コロナ受診相談窓口相談件数"
           :title-id="'number-of-reports-to-covid19-consultation-desk'"
+          :chart-id="'time-bar-chart-querents'"
           :chart-data="querentsGraph"
           :date="Data.querents.date"
           :unit="'件'"
@@ -85,6 +89,7 @@
         <metro-bar-chart
           title="都営地下鉄の利用者数の推移"
           :title-id="'predicted-number-of-toei-subway-passengers'"
+          :chart-id="'metro-bar-chart'"
           :chart-data="metroGraph"
           :chart-option="metroGraphOption"
           :date="metroGraph.date"


### PR DESCRIPTION
## 📝 関連issue
<!--
  ・ 関連するissueがなければ消してください
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️
-->
- close #683 

#699 でマージ先のブランチが `feature/types/development` になっていたので宛先を `development` に変更して再度PRを出します。

## ⛏ 変更内容
<!-- 変更を端的に箇条書きで -->
- `MetroBarChart` , `TimeBarChart` , `TimeStackedBarChart` 各 component に canvas 要素の id を設定できる prop を追加しました。
- トップページの 5 つのグラフについて、重複しない id を設定しました。

## 📸 スクリーンショット
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<img width="527" alt="スクリーンショット 2020-03-07 15 26 25" src="https://user-images.githubusercontent.com/12806694/76138154-389f3c80-6088-11ea-935d-9a86d48f868d.png">
<img width="529" alt="スクリーンショット 2020-03-07 15 26 34" src="https://user-images.githubusercontent.com/12806694/76138155-3c32c380-6088-11ea-8f97-af58f7e1cbbd.png">
<img width="528" alt="スクリーンショット 2020-03-07 15 26 41" src="https://user-images.githubusercontent.com/12806694/76138157-3fc64a80-6088-11ea-8830-8c09de81b772.png">
<img width="526" alt="スクリーンショット 2020-03-07 15 26 48" src="https://user-images.githubusercontent.com/12806694/76138159-4228a480-6088-11ea-9706-73a7acb079f8.png">
<img width="524" alt="スクリーンショット 2020-03-07 15 26 56" src="https://user-images.githubusercontent.com/12806694/76138162-46ed5880-6088-11ea-8f1a-8e569e527f6d.png">
