### PR TITLE
Fix language selector label for zh-TW (体 -> 體)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -133,7 +133,7 @@ const config: Configuration = {
           },
           {
             code: 'zh-tw',
-            name: '繁体字',
+            name: '繁體字',
             iso: 'zh-TW'
           },
           {


### PR DESCRIPTION
## ⛏ 変更内容/Change details
- In the zh-TW selector, use the proper ideograph `體` instead of `体`
