### PR TITLE
特定の端末においてsidenavが見切れる現象に対処

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -256,8 +256,10 @@ export default {
     left: 0;
     display: block !important;
     width: 100%;
-    z-index: z-index-of(opened-side-navigation);    
+    z-index: z-index-of(opened-side-navigation);
     background-color: $white;
+    height: 100%;
+    overflow-y: scroll;
   }
 }
 @include largerThan($small) {


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #803 

## ⛏ 変更内容/Change details
- 一部の端末でメニューが見切れていたため`components/SideNavigation.vue`のcssを調整
  - height
  - overflow

## 確認した端末 / 
- iOS 12.4.1 / Safari iPhone6
- iOS 13.3.1 / Safari iPhoneXR
- iOS 13.1.2 / iPad Pro(9.7inch) 横向き/縦向き

## 📸 スクリーンショット/Screenshot

iPhoneSE実機画面
![iPhoneSE_sidenav](https://user-images.githubusercontent.com/45744323/76163074-800bf280-6186-11ea-8cae-63bdc6510483.gif)



