### PR TITLE
[WIP]changes project to Creative Commons Attribution-ShareAlike

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -55,8 +55,24 @@
           </a>
         </div>
         <small class="SideNavigation-Copyright" lang="en">
-          Copyright &copy; 2020 Tokyo Metropolitan Government. All Rights
-          Reserved.
+          <a
+            rel="license"
+            href="http://creativecommons.org/licenses/by-sa/4.0/"
+          >
+            <img
+              alt="Creative Commons License"
+              style="border-width:0"
+              src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"
+            /> </a
+          ><br />This work is licensed under a
+          <a
+            rel="license"
+            href="http://creativecommons.org/licenses/by-sa/4.0/"
+          >
+            Creative Commons Attribution-ShareAlike 4.0 International License</a
+          >
+          <br />
+          2020 Tokyo Metropolitan Government.
         </small>
       </div>
     </div>
@@ -256,7 +272,7 @@ export default {
     left: 0;
     display: block !important;
     width: 100%;
-    z-index: z-index-of(opened-side-navigation);    
+    z-index: z-index-of(opened-side-navigation);
     background-color: $white;
   }
 }

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -63,16 +63,17 @@
               alt="Creative Commons License"
               style="border-width:0"
               src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png"
-            /> </a
-          ><br />This work is licensed under a
+            />
+          </a>
+          <br />This work is licensed under a
           <a
             rel="license"
             href="http://creativecommons.org/licenses/by-sa/4.0/"
           >
-            Creative Commons Attribution-ShareAlike 4.0 International License</a
-          >
+            Creative Commons Attribution-ShareAlike 4.0 International License
+          </a>
           <br />
-          2020 Tokyo Metropolitan Government.
+          2020 Tokyo Metropolitan Government
         </small>
       </div>
     </div>


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #832 

## ⛏ 変更内容/Change details
- changed the license in the SideNavigation.vuew to Creative Commons Attribution-ShareAlike 4.0 International

## 📸 スクリーンショット/Screenshot
<img width="370" alt="Screen Shot 2020-03-08 at 9 32 01 AM" src="https://user-images.githubusercontent.com/1502180/76163803-ad718580-611f-11ea-9f54-96439b8b2084.png">
