### PR TITLE
[i18n] PageHeader.vue 内の文字列をi18n化

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ Tokyo Covid-19 response site contributors
 | [Riki Singh Khorana](https://www.linkedin.com/in/rikilele/) (@Rikilele) | Translations / A11y |
 | Koki Kobayashi | Translations |
 | Fujita Shu (@nard-tech) | Coding, i18n |
+| [Pichu Chen](https://github.com/pichuchen) | i18n |
 | -add your name here!- | -what did you do?- |
 
 ご協力に感謝です！！！

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -7,11 +7,37 @@
       {{ title }}
     </h2>
     <div class="date">
-      <span>最終更新 </span>
+      <span>{{ $t('最終更新') }}</span>
       <time :datetime="formattedDate">{{ date }}</time>
     </div>
   </div>
 </template>
+
+<i18n>
+{
+  "ja": {
+    "最終更新": "最終更新"
+  },
+  "en": {
+    "最終更新": "Last update"
+  },
+  "zh-cn": {
+    "最終更新": "最后更新"
+  },
+  "zh-tw": {
+    "最終更新": "上次更新"
+  },
+  "ko": {
+    "最終更新": "최종갱신"
+  },
+  "pt-BR": {
+    "最終更新": ""
+  },
+  "ja-basic": {
+    "最終更新": "さいごに いちばん あたらしくなおした とき"
+  }
+}
+</i18n>
 
 <script>
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #689 

## ⛏ 変更内容/Change details

- Update en, zh-cn, zh-tw, ko, pt-BR, jp-basic for PageHeader.vue
- Update CONTRIBUTORS.md

## 📸 スクリーンショット/Screenshot
![螢幕快照 0002-03-09 01 16 51](https://user-images.githubusercontent.com/600238/76167708-b5730900-61a3-11ea-88ac-f609313617e5.png)
![螢幕快照 0002-03-09 01 16 25](https://user-images.githubusercontent.com/600238/76167709-b6a43600-61a3-11ea-8690-f3a2e66b5645.png)
![螢幕快照 0002-03-09 01 16 08](https://user-images.githubusercontent.com/600238/76167710-b73ccc80-61a3-11ea-91a1-713cad46da04.png)
![螢幕快照 0002-03-09 01 15 11](https://user-images.githubusercontent.com/600238/76167712-b7d56300-61a3-11ea-94b5-b71a1d714e83.png)


