### PR TITLE
fix: 更新日時をカードの下固定にする

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -82,7 +82,10 @@ export default class DataView extends Vue {
   flex-flow: column;
   justify-content: space-between;
   &-content {
-    height: auto !important;
+    display: flex;
+    flex-flow: row;
+    justify-content: space-between;
+    padding: 0 16px;
     .v-toolbar__content {
       align-items: start;
     }
@@ -92,7 +95,7 @@ export default class DataView extends Vue {
     height: auto !important;
   }
   &-TitleContainer {
-    padding: 14px 0 8px;
+    padding: 14px 16px 8px;
     color: $gray-2;
   }
   &-Title {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -86,9 +86,6 @@ export default class DataView extends Vue {
     flex-flow: row;
     justify-content: space-between;
     padding: 0 16px;
-    .v-toolbar__content {
-      align-items: start;
-    }
   }
   &-Header {
     background-color: transparent !important;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card class="DataView pa-1">
-    <v-toolbar flat class="DataView-content">
+    <div class="DataView-content">
       <div class="DataView-TitleContainer">
         <h3 :id="titleId" class="DataView-ToolbarTitle">
           {{ title }}
@@ -9,7 +9,7 @@
       </div>
       <v-spacer />
       <slot name="infoPanel" />
-    </v-toolbar>
+    </div>
     <v-card-text
       :class="
         $vuetify.breakpoint.xs ? 'DataView-CardTextForXS' : 'DataView-CardText'

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -2,7 +2,7 @@
   <v-card class="DataView pa-1">
     <div class="DataView-content">
       <div class="DataView-TitleContainer">
-        <h3 :id="titleId" class="DataView-ToolbarTitle">
+        <h3 :id="titleId" class="DataView-CardTitle">
           {{ title }}
         </h3>
         <slot name="button" />
@@ -98,7 +98,7 @@ export default class DataView extends Vue {
   &-Title {
     @include card-h2();
   }
-  &-ToolbarTitle {
+  &-CardTitle {
     font-size: 1.25rem;
     font-weight: normal;
     line-height: 1.5;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -78,6 +78,9 @@ export default class DataView extends Vue {
 .DataView {
   @include card-container();
   height: 100%;
+  display: flex;
+  flex-flow: column;
+  justify-content: space-between;
   &-content {
     height: auto !important;
     .v-toolbar__content {


### PR DESCRIPTION
## 📝 関連issue/Related issue
- close #512

## ⛏ 変更内容/Change details
- `v-toolbar`を削除する
  - 高さを自動修正する機能がカードのヘッダー部分の余白調整を難しくしているため
- 更新日時をカード下端に揃える

## 補足
こちらで PR #458 を出していましたが、差分が大きくなってきたので各 issue ごとに PR を出せればと思います。（そちらのほうがレビューもやりやすくなると思うので 🙏 ）
※ #458 がマージされたらこちらを close しますmm

## 📸 スクリーンショット/Screenshot
### Before
![スクリーンショット 2020-03-09 17 54 32](https://user-images.githubusercontent.com/5207601/76197281-2f040900-622f-11ea-988c-25af04ed5e3c.png)

### After
![スクリーンショット 2020-03-09 17 54 39](https://user-images.githubusercontent.com/5207601/76197294-31fef980-622f-11ea-9aaf-185d19a4df03.png)
