### PR TITLE
feat: IE 11 対応のために Autoprefixer を導入 

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -79,9 +79,11 @@ export default Vue.extend({
   @include largerThan($small) {
     display: grid;
     grid-template-columns: 240px auto;
+    grid-template-rows: auto auto;
   }
   @include largerThan($huge) {
     grid-template-columns: 325px auto;
+    grid-template-rows: auto auto;
   }
 }
 @include lessThan($small) {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -79,11 +79,11 @@ export default Vue.extend({
   @include largerThan($small) {
     display: grid;
     grid-template-columns: 240px auto;
-    grid-template-rows: auto auto;
+    grid-template-rows: auto;
   }
   @include largerThan($huge) {
     grid-template-columns: 325px auto;
-    grid-template-rows: auto auto;
+    grid-template-rows: auto;
   }
 }
 @include lessThan($small) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -155,7 +155,7 @@ const config: Configuration = {
   build: {
     postcss: {
       plugins: [
-        autoprefixer,
+        autoprefixer({ grid: 'autoplace' }),
         purgecss({
           content: [
             './pages/**/*.vue',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,6 @@
 import { Configuration } from '@nuxt/types'
 const purgecss = require('@fullhuman/postcss-purgecss')
+const autoprefixer = require('autoprefixer')
 
 const config: Configuration = {
   mode: 'universal',
@@ -154,6 +155,7 @@ const config: Configuration = {
   build: {
     postcss: {
       plugins: [
+        autoprefixer,
         purgecss({
           content: [
             './pages/**/*.vue',

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   },
   "browserslist": [
     "defaults",
-    "last 2 version",
     "ie >=11"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@nuxtjs/vuetify": "^1.0.0",
     "@types/chart.js": "^2.9.14",
     "@vue/test-utils": "^1.0.0-beta.27",
+    "autoprefixer": "^9.7.4",
     "babel-jest": "^24.1.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -68,5 +68,10 @@
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "vue-jest": "^4.0.0-0"
-  }
+  },
+  "browserslist": [
+    "defaults",
+    "last 2 version",
+    "ie >=11"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2340,7 +2340,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^9.6.1:
+autoprefixer@^9.6.1, autoprefixer@^9.7.4:
   version "9.7.4"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"
   integrity sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #890 

## ⛏ 変更内容 / Details of Changes
- Autoprefixer をアップデート
- Nuxt.js のビルド設定を追加
- ビルド対象を指定するために `package.json` に broserslist を追加
- Autoprefixer 適応時にエラーが出た箇所に `grid-template-rows` を追加

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-03-09 20 53 18](https://user-images.githubusercontent.com/5207601/76210729-0d634b80-6248-11ea-9073-65f283c1e06d.png)

### After
![スクリーンショット 2020-03-09 20 59 32](https://user-images.githubusercontent.com/5207601/76211137-e48f8600-6248-11ea-8545-559b5ecd9670.png)