### PR TITLE
fix: IE 11 でグリッドレイアウトが崩れる問題を修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -78,11 +78,11 @@ export default Vue.extend({
   position: relative;
   @include largerThan($small) {
     display: grid;
-    grid-template-columns: 240px auto;
+    grid-template-columns: 240px 1fr;
     grid-template-rows: auto;
   }
   @include largerThan($huge) {
-    grid-template-columns: 325px auto;
+    grid-template-columns: 325px 1fr;
     grid-template-rows: auto;
   }
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #903

## ⛏ 変更内容 / Details of Changes
- `grid-template-columns` の幅の指定を `auto` から `1fr` に変更

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-03-09 21 26 14](https://user-images.githubusercontent.com/5207601/76213276-b1032a80-624d-11ea-943e-fd85aeff2160.png)

### After
![スクリーンショット 2020-03-09 21 34 07](https://user-images.githubusercontent.com/5207601/76213295-b9f3fc00-624d-11ea-96ad-271c891880f0.png)
