### PR TITLE
ドキュメントの本番リンクを修正

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -35,7 +35,7 @@
 ## 開発に関する情報
 * 開発サイト https://dev-covid19-tokyo.netlify.com/
 * ステージングサイト https://stg-covid19-tokyo.netlify.com/
-* 本番サイト https://covid19-tokyo.netlify.com/
+* 本番サイト https://stopcovid19.metro.tokyo.lg.jp/
 * [デザイン](https://www.figma.com/file/V7vt80p2gauhdgTZeVNbgj/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=121%3A156)
 
 本 ドキュメント の更新も大歓迎です！

--- a/.github/CONTRIBUTING_EN.md
+++ b/.github/CONTRIBUTING_EN.md
@@ -31,7 +31,7 @@ This page shows how you can contribute to the development of this site.
 ## Development information
 * Development site https://dev-covid19-tokyo.netlify.com/
 * Staging site https://stg-covid19-tokyo.netlify.com/
-* Production site https://covid19-tokyo.netlify.com/
+* Production site https://stopcovid19.metro.tokyo.lg.jp/
 * [Design](https://www.figma.com/file/V7vt80p2gauhdgTZeVNbgj/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=121%3A156)
 
 Updates to this document are also welcome!

--- a/.github/CONTRIBUTING_ES.md
+++ b/.github/CONTRIBUTING_ES.md
@@ -30,7 +30,7 @@ Esta página muestra cómo puede contribuir al desarrollo de este sitio.
 ## Información de desarrollo
 * Sitio en desarrollo https://dev-covid19-tokyo.netlify.com/
 * Sitio de prueba https://stg-covid19-tokyo.netlify.com/
-* Sitio en producción https://covid19-tokyo.netlify.com/
+* Sitio en producción https://stopcovid19.metro.tokyo.lg.jp/
 * [Design](https://www.figma.com/file/V7vt80p2gauhdgTZeVNbgj/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=121%3A156)
 
 ¡Las actualizaciones de este documento también son bienvenidas!

--- a/.github/CONTRIBUTING_KO.md
+++ b/.github/CONTRIBUTING_KO.md
@@ -34,7 +34,7 @@
 ## 개발에 관한 정보
 * 개발사이트 https://dev-covid19-tokyo.netlify.com/
 * 스테이징 배포사이트 https://stg-covid19-tokyo.netlify.com/
-* 운영 배포사이트 https://covid19-tokyo.netlify.com/
+* 운영 배포사이트 https://stopcovid19.metro.tokyo.lg.jp/
 * [디자인](https://www.figma.com/file/V7vt80p2gauhdgTZeVNbgj/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=121%3A156)
 
 이 문서의 갱신도 환영합니다!

--- a/.github/CONTRIBUTING_ZH_TW.md
+++ b/.github/CONTRIBUTING_ZH_TW.md
@@ -36,7 +36,7 @@
 ## 開發相關的資訊
 * 開發環境 (Dev.) https://dev-covid19-tokyo.netlify.com/
 * Stage 站 https://stg-covid19-tokyo.netlify.com/
-* 正式環境 https://covid19-tokyo.netlify.com/
+* 正式環境 https://stopcovid19.metro.tokyo.lg.jp/
 * [設計稿](https://www.figma.com/file/V7vt80p2gauhdgTZeVNbgj/UI%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=121%3A156)
 
 也很歡迎更新此文件！


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #924 

## ⛏ 変更内容 / Details of Changes
ドキュメントの本番URLが
* https://covid19-tokyo.netlify.com/
* https://stopcovid19.metro.tokyo.lg.jp/ 

の2つあるので、 https://stopcovid19.metro.tokyo.lg.jp/ に統一しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
