### PR TITLE
FlowSp.vueの調整追加

### DIFF
--- a/components/flow/FlowSp.vue
+++ b/components/flow/FlowSp.vue
@@ -15,7 +15,7 @@
     <div :class="$style.FlowCard">
       <flow-sp-suspect />
     </div>
-    <div :class="[$style.FlowCard, $style.FlowCardBrayBg]">
+    <div :class="[$style.FlowCard, $style.FlowCardGrayBg]">
       <flow-sp-advisory />
     </div>
     <div :class="$style.FlowCard">
@@ -62,6 +62,7 @@ export default {
   }
   &GrayBg {
     background-color: $gray-5;
+    box-shadow: none;
   }
 }
 </style>

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -63,7 +63,6 @@
 import LanguageSelector from '@/components/LanguageSelector.vue'
 import CovidIcon from '@/static/covid.svg'
 import PrinterButton from '@/components/PrinterButton'
-// import DesktopFlowSvg from '@/components/DesktopFlowSvg.vue'
 import FlowPc from '@/components/flow/FlowPc.vue'
 import FlowSp from '@/components/flow/FlowSp.vue'
 
@@ -72,7 +71,6 @@ export default {
     LanguageSelector,
     CovidIcon,
     PrinterButton,
-    // DesktopFlowSvg,
     FlowPc,
     FlowSp
   },
@@ -118,6 +116,10 @@ export default {
     &-ExternalLinkIcon {
       margin-left: 2px;
       color: $green-1 !important;
+    }
+    @include lessThan($medium) {
+      text-align: center;
+      width: 100%;
     }
   }
   &-PullRight {

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -107,9 +107,11 @@ export default {
     @include button-text('md');
     margin: 24px auto 0;
     @include font-size(20);
-    font-weight: 600;
+    font-weight: bold;
+    display: block;
     text-decoration: none;
     color: $green-1 !important;
+    text-align: center;
     &:hover {
       color: $white !important;
     }
@@ -117,9 +119,8 @@ export default {
       margin-left: 2px;
       color: $green-1 !important;
     }
-    @include lessThan($medium) {
-      text-align: center;
-      width: 100%;
+    @include largerThan($medium) {
+      width: 25rem;
     }
   }
   &-PullRight {

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -15,17 +15,19 @@
       <div class="only-sp">
         <flow-sp />
       </div>
-      <a
-        href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
-        target="_blank"
-        rel="noopener"
-        class="Flow-Card-Button"
-      >
-        {{ $t('詳細を見る(東京都福祉保健局)') }}
-        <v-icon class="Flow-Card-Button-ExternalLinkIcon" size="20">
-          mdi-open-in-new
-        </v-icon>
-      </a>
+      <div class="Flow-Card-Button-Wrapper mt-6">
+        <a
+          href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
+          target="_blank"
+          rel="noopener"
+          class="Flow-Card-Button"
+        >
+          {{ $t('詳細を見る(東京都福祉保健局)') }}
+          <v-icon class="Flow-Card-Button-ExternalLinkIcon" size="20">
+            mdi-open-in-new
+          </v-icon>
+        </a>
+      </div>
     </div>
   </div>
 </template>
@@ -105,22 +107,20 @@ export default {
   }
   &-Card-Button {
     @include button-text('md');
-    margin: 24px auto 0;
     @include font-size(20);
     font-weight: bold;
-    display: block;
+    display: inline-block;
     text-decoration: none;
     color: $green-1 !important;
-    text-align: center;
+    &-Wrapper {
+      text-align: center;
+    }
     &:hover {
       color: $white !important;
     }
     &-ExternalLinkIcon {
       margin-left: 2px;
       color: $green-1 !important;
-    }
-    @include largerThan($medium) {
-      width: 25rem;
     }
   }
   &-PullRight {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/891

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「新型コロナ受信相談窓口」のbackground-colorをgray-5に指定、box-shadowを無効にする
- 「詳細を見る」リンクをCardと同じ幅にする

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- ![localhost_3000_flow_(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/10768439/76270999-7e434b80-62ba-11ea-88ec-e588a05e4101.png)
- ![localhost_3000_flow_(iPhone 6_7_8 Plus) (1)](https://user-images.githubusercontent.com/10768439/76271007-826f6900-62ba-11ea-8c4b-452079fa5331.png)
