### PR TITLE
[/flow] デスクトップ版のアイコンをSVGに置き換える

### DIFF
--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -11,11 +11,11 @@
     </h3>
     <ul :class="$style.actions">
       <li>
-        <img src="/flow/house-24px.svg" />
+        <img :class="$style.icon" src="/flow/house-24px.svg" />
         自宅で安静に過ごす
       </li>
       <li>
-        <img src="/flow/apartment-24px.svg" />
+        <img :class="$style.icon" src="/flow/apartment-24px.svg" />
         一般の医療機関を受診
       </li>
     </ul>
@@ -76,6 +76,9 @@
     display: flex;
     align-items: center;
   }
+}
+.icon {
+  margin-right: 10px;
 }
 .nextAction {
   width: 49%;

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -78,6 +78,7 @@
     text-align: start;
     margin-bottom: 1rem;
     display: flex;
+    align-items: center;
   }
 }
 .nextAction {

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -11,15 +11,15 @@
     </h3>
     <ul :class="$style.actions">
       <li>
-        <v-icon class="mr-2">
-          mdi-home
-        </v-icon>
+        <i>
+          <img src="/flow/house-24px.svg" />
+        </i>
         自宅で安静に過ごす
       </li>
       <li>
-        <v-icon class="mr-2">
-          mdi-hospital-building
-        </v-icon>
+        <i>
+          <img src="/flow/apartment-24px.svg" />
+        </i>
         一般の医療機関を受診
       </li>
     </ul>

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -11,15 +11,11 @@
     </h3>
     <ul :class="$style.actions">
       <li>
-        <i>
-          <img src="/flow/house-24px.svg" />
-        </i>
+        <img src="/flow/house-24px.svg" />
         自宅で安静に過ごす
       </li>
       <li>
-        <i>
-          <img src="/flow/apartment-24px.svg" />
-        </i>
+        <img src="/flow/apartment-24px.svg" />
         一般の医療機関を受診
       </li>
     </ul>


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #968

## ⛏ 変更内容 / Details of Changes
- mdi アイコンが指定してあった部分を `static/flow` 直下にある SVG アイコンに置き換えました
- アイコンとテキストを上下中央寄せにする

## 気になったこと
アイコンとテキストの間隔が狭くなったので、余白を追加したほうがいいかもと思いました。
もし調整したほうが良ければコメントいただければこの PR で調整いたします。

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-03-10 11 41 03](https://user-images.githubusercontent.com/5207601/76274442-11cd4a00-62c4-11ea-8302-1def76b7ab30.png)

### After
![スクリーンショット 2020-03-10 11 40 40](https://user-images.githubusercontent.com/5207601/76274445-13970d80-62c4-11ea-943d-1ddb224b9abf.png)