### PR TITLE
[#990] 症状に関するダイアグラムのレイアウトをFigmaの通り修正

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -106,9 +106,20 @@ $z-index-map: (
 
 // ===================
 // card
-@mixin card-container {
+@mixin card-container($withDivider: false) {
   background-color: $white;
   box-shadow: $shadow;
   border: 0.5px solid $gray-4 !important;
   border-radius: 4px;
+  @if ($withDivider) {
+    &::before {
+      content: '';
+      position: absolute;
+      left: 50%;
+      top: 0;
+      width: 1px;
+      height: 100%;
+      background-color: $gray-4;
+    }
+  }
 }

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -53,13 +53,13 @@
     <div :class="$style.FlowRow">
       <div :class="$style.FlowRowRowThree">
         <ul :class="$style.FlowRowRowThreeCareTargetList">
-          <li>
+          <li :class="$style.FlowRowRowThreeCareTargetListItem">
             <img src="/flow/directions_walk-24px.svg" />{{ $t('ご高齢な方') }}
           </li>
-          <li>
+          <li :class="$style.FlowRowRowThreeCareTargetListItem">
             <img src="/flow/accessible-24px.svg" />{{ $t('基礎疾患のある方') }}
           </li>
-          <li>
+          <li :class="$style.FlowRowRowThreeCareTargetListItem">
             <img src="/flow/pregnant_woman-24px.svg" />{{ $t('妊娠中の方') }}
           </li>
         </ul>
@@ -174,10 +174,10 @@
 
 <style module lang="scss">
 .Flow {
+  @include card-container($withDivider: true);
   display: flex;
   flex-direction: row;
   padding: 20px 20px !important;
-  @include card-container();
   position: relative;
   color: $gray-2;
   &Row {
@@ -199,6 +199,9 @@
         margin: 16px auto;
         text-align: left;
         list-style: none;
+        &Item + &Item {
+          margin-top: 14px;
+        }
       }
     }
     &Condition {
@@ -211,6 +214,7 @@
       position: relative;
       border: 2px solid $green-1 !important;
       border-radius: 2px;
+      background-color: $white;
       p {
         text-align: center;
         display: inline-block;

--- a/components/flow/FlowPcPast.vue
+++ b/components/flow/FlowPcPast.vue
@@ -41,20 +41,11 @@
 
 <style module lang="scss">
 .Flow {
-  @include card-container();
+  @include card-container($withDivider: true);
   position: relative;
   padding-bottom: 20px;
   color: $gray-2;
   text-align: center;
-  &::before {
-    content: '';
-    position: absolute;
-    left: 50%;
-    top: 0;
-    width: 1px;
-    height: 100%;
-    background-color: $gray-4;
-  }
   &Heading {
     position: relative;
     width: calc(100% - 2px);


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #990 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 症状に関するダイアグラムのレイアウトをFigmaの通り修正(背景にボーダーを追加、リストの間隔を広げる)

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
before | after
-- | --
<img width="562" alt="before" src="https://user-images.githubusercontent.com/5590142/76283880-21a65780-62df-11ea-85ca-1bc2f6c14f65.png"> | <img width="595" alt="after" src="https://user-images.githubusercontent.com/5590142/76283888-28cd6580-62df-11ea-80d4-a7e65f9f27ca.png">

