### PR TITLE
合計・累計値の文字フォーマットを他カードと統一する

### DIFF
--- a/components/TimeBarChart.i18n.json
+++ b/components/TimeBarChart.i18n.json
@@ -1,37 +1,37 @@
 {
   "ja": {
-    "実績値": "実績値",
-    "累計値": "累計値",
+    "{date}の全体累計": "%{date}の全体累計",
+    "{date}の合計": "%{date}の合計",
     "前日比": "前日比"
   },
   "en": {
-    "実績値": "Actual value",
-    "累計値": "Cumulative value",
+    "{date}の全体累計": "Cumulative total as of %{date}",
+    "{date}の合計": "Actual value as of %{date}",
     "前日比": "day-over-day change"
   },
   "zh-cn": {
-    "実績値": "实际值",
-    "累計値": "累计值",
+    "{date}の全体累計": "累計値 %{date}",
+    "{date}の合計": "実績値 %{date}",
     "前日比": "较前一天"
   },
   "zh-tw": {
-    "実績値": "實際值",
-    "累計値": "累計值",
+    "{date}の全体累計": "累計值 %{date}",
+    "{date}の合計": "實際值 %{date}",
     "前日比": "與前日相比"
   },
   "ko": {
-    "実績値": "실제 값",
-    "累計値": "누계 값",
+    "{date}の全体累計": "%{date}의 누적 수",
+    "{date}の合計": "%{date}의 실제 수",
     "前日比": "전일대비 확진환자 증감"
   },
   "pt-BR": {
-    "実績値": "Valor real",
-    "累計値": "Valor acumulado",
+    "{date}の全体累計": "Valor acumulado de %{date}",
+    "{date}の合計": "Valor real de %{date}",
     "前日比": "anterior"
   },
   "ja-basic": {
-    "実績値": "そのときの すうじ",
-    "累計値": "これまでの ぜんぶのすうじ",
+    "{date}の全体累計": "%{date}までの ぜんぶのすうじ",
+    "{date}の合計": "%{date}の すうじ",
     "前日比": "まえのひ と くらべると"
   }
 }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -87,7 +87,9 @@ export default {
       if (this.dataKind === 'transition') {
         return {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
-          sText: `${this.$t('実績値')}（${this.$t('前日比')}: ${
+          sText: `${this.$t('{date}の合計', {
+            date: this.chartData.slice(-1)[0].label
+          })}（${this.$t('前日比')}: ${
             this.displayTransitionRatio
           } ${this.unit}）`,
           unit: this.unit
@@ -97,11 +99,19 @@ export default {
         lText: this.chartData[
           this.chartData.length - 1
         ].cumulative.toLocaleString(),
+<<<<<<< HEAD
         sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
-          '累計値'
+          '{date}の全体累計', {
+          date: this.chartData.slice(-1)[0].label
+        }
         )}（${this.$t('前日比')}: ${this.displayCumulativeRatio} ${
           this.unit
         }）`,
+=======
+        sText: `${this.chartData.slice(-1)[0].label} の累計値（前日比：${
+          this.displayCumulativeRatio
+        } ${this.unit}）`,
+>>>>>>> unify text formats
         unit: this.unit
       }
     },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -99,7 +99,6 @@ export default {
         lText: this.chartData[
           this.chartData.length - 1
         ].cumulative.toLocaleString(),
-<<<<<<< HEAD
         sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
           '{date}の全体累計', {
           date: this.chartData.slice(-1)[0].label
@@ -107,11 +106,6 @@ export default {
         )}（${this.$t('前日比')}: ${this.displayCumulativeRatio} ${
           this.unit
         }）`,
-=======
-        sText: `${this.chartData.slice(-1)[0].label} の累計値（前日比：${
-          this.displayCumulativeRatio
-        } ${this.unit}）`,
->>>>>>> unify text formats
         unit: this.unit
       }
     },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -89,9 +89,9 @@ export default {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
           sText: `${this.$t('{date}の合計', {
             date: this.chartData.slice(-1)[0].label
-          })}（${this.$t('前日比')}: ${
-            this.displayTransitionRatio
-          } ${this.unit}）`,
+          })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
           unit: this.unit
         }
       }
@@ -99,11 +99,9 @@ export default {
         lText: this.chartData[
           this.chartData.length - 1
         ].cumulative.toLocaleString(),
-        sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
-          '{date}の全体累計', {
+        sText: `${this.$t('{date}の全体累計', {
           date: this.chartData.slice(-1)[0].label
-        }
-        )}（${this.$t('前日比')}: ${this.displayCumulativeRatio} ${
+        })}（${this.$t('前日比')}: ${this.displayCumulativeRatio} ${
           this.unit
         }）`,
         unit: this.unit

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,26 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@mdi/font@^5.0.45":
+  version "5.0.45"
+  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.0.45.tgz#8eda40c41dc7ee9e7a51dbe9191c5c38b8482422"
+  integrity sha512-3sOO/UMyQqrmizW5zjvhKJP4FZFO7LblRw4G0alDxK1ekUwNxNXI7hYv8ACAv8H44riBuqlVJ7u39XDqv/Xwuw==
+
+"@microsoft/tsdoc-config@0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.13.2.tgz#73f739a4ee91bcd87fc306927572bb4c3e8a30ed"
+  integrity sha512-XSwH2Gs+oPDom9BDFfH8Y+x440m1aKE9dvRmjJyNgakOBevLeEg+ELcrhC93gyf+bH9Ah8vGtC0CmpH9EvWdhQ==
+  dependencies:
+    "@microsoft/tsdoc" "0.12.18"
+    ajv "~6.10.2"
+    jju "~1.4.0"
+    resolve "~1.12.0"
+
+"@microsoft/tsdoc@0.12.18":
+  version "0.12.18"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.18.tgz#7e7aadc7009e57a25fbf6c9f48b44c2fe30ada88"
+  integrity sha512-3rypGnknRaPGlU4HFx2MorC4zmhoGJx773cVbDfcUgc6zI/PFfFaiWmeRR6JiVyKRrLnU/ZH0pc/6jePzy/QyQ==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -1027,26 +1047,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
-
-"@mdi/font@^5.0.45":
-  version "5.0.45"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.0.45.tgz#8eda40c41dc7ee9e7a51dbe9191c5c38b8482422"
-  integrity sha512-3sOO/UMyQqrmizW5zjvhKJP4FZFO7LblRw4G0alDxK1ekUwNxNXI7hYv8ACAv8H44riBuqlVJ7u39XDqv/Xwuw==
-
-"@microsoft/tsdoc-config@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.13.2.tgz#73f739a4ee91bcd87fc306927572bb4c3e8a30ed"
-  integrity sha512-XSwH2Gs+oPDom9BDFfH8Y+x440m1aKE9dvRmjJyNgakOBevLeEg+ELcrhC93gyf+bH9Ah8vGtC0CmpH9EvWdhQ==
-  dependencies:
-    "@microsoft/tsdoc" "0.12.18"
-    ajv "~6.10.2"
-    jju "~1.4.0"
-    resolve "~1.12.0"
-
-"@microsoft/tsdoc@0.12.18":
-  version "0.12.18"
-  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.18.tgz#7e7aadc7009e57a25fbf6c9f48b44c2fe30ada88"
-  integrity sha512-3rypGnknRaPGlU4HFx2MorC4zmhoGJx773cVbDfcUgc6zI/PFfFaiWmeRR6JiVyKRrLnU/ZH0pc/6jePzy/QyQ==
 
 "@nuxt/babel-preset-app@2.11.0":
   version "2.11.0"
@@ -2435,7 +2435,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@^9.6.1:
+autoprefixer@^9.6.1, autoprefixer@^9.7.4:
   version "9.7.4"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"
   integrity sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1003

## ⛏ 変更内容 / Details of Changes
- 「陽性患者数」カードの左上の日本語文字フォーマットを整えました

## 📸 スクリーンショット / Screenshots
<img width="560" alt="スクリーンショット_2020-03-10_15_02_21" src="https://user-images.githubusercontent.com/316463/76285947-510b9300-62e4-11ea-8173-270897c8f962.png">

<img width="559" alt="スクリーンショット_2020-03-10_15_02_29" src="https://user-images.githubusercontent.com/316463/76285954-55d04700-62e4-11ea-8d73-3d6a16ea25bb.png">

![スクリーンショット_2020-03-10_15_42_11](https://user-images.githubusercontent.com/316463/76286537-d6437780-62e5-11ea-878b-7e7f56d748b6.png)
