### PR TITLE
fix svg width in case of safari bug #1008

### DIFF
--- a/components/DesktopFlowSvg.vue
+++ b/components/DesktopFlowSvg.vue
@@ -1221,7 +1221,7 @@
 <style lang="scss">
 svg {
   font-family: 'Roboto', sans-serif;
-  width: auto;
+  width: 100%;
 }
 svg .an {
   font-family: 'Roboto', sans-serif !important;

--- a/components/DesktopFlowSvg.vue
+++ b/components/DesktopFlowSvg.vue
@@ -1221,7 +1221,7 @@
 <style lang="scss">
 svg {
   font-family: 'Roboto', sans-serif;
-  width: 100%;
+  width: auto;
 }
 svg .an {
   font-family: 'Roboto', sans-serif !important;

--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -51,9 +51,6 @@ export default {
     @include largerThan($small) {
       padding-right: 7px;
     }
-    svg {
-      width: auto;
-    }
   }
 }
 </style>

--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -51,6 +51,9 @@ export default {
     @include largerThan($small) {
       padding-right: 7px;
     }
+    svg {
+      width: auto;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1008

## ⛏ 変更内容 / Details of Changes
- safariで発生したprinter iconバグの修正

## 📸 スクリーンショット / Screenshots

### before
<img width="1179" alt="スクリーンショット 2020-03-10 17 39 50" src="https://user-images.githubusercontent.com/19667736/76294430-2e827580-62f6-11ea-800b-3791c8d5d2f6.png">

### after
<img width="1190" alt="スクリーンショット 2020-03-10 17 39 05" src="https://user-images.githubusercontent.com/19667736/76294435-30e4cf80-62f6-11ea-9a1c-e58d5f2c458c.png">

