### PR TITLE
change the Chinese(Taiwan) to Chinese(Traditional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![東京都 新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://stopcovid19.metro.tokyo.lg.jp/)
 
-### 日本語 | [English](./README_EN.md) | [Spanish](./README_ES.md) | [Korean](./README_KO.md) | [Chinese (Taiwan)](./README_ZH_TW.md) | [Chinese (Simplified)](./README_ZH_CN.md) | [Vietnamese](./README_VI.md)
+### 日本語 | [English](./README_EN.md) | [Spanish](./README_ES.md) | [Korean](./README_KO.md) | [Chinese (Traditional)](./README_ZH_TW.md) | [Chinese (Simplified)](./README_ZH_CN.md) | [Vietnamese](./README_VI.md)
 
 ## 貢献の仕方
 Issues にあるいろいろな修正にご協力いただけると嬉しいです。


### PR DESCRIPTION
担当者の皆さん、
お疲れ様です。covid19の影響で、日本国民の健康をここから祈ります。

多言語の正式名称をご利用ください。
_**そして、台湾地方だけ繁体字の中国語利用していることではないですから。**_

元々、サイト側のChinese(Taiwan)はどういう意味でしょうか。**繁体字中国語**っていう意味でしょうか。あるいは台湾専用な繁体字中国語のみを簡単字以外に支持したいでしょうか。**繁体字中国語**だったら、 **Chinese(Traditional)** が正しいです。東京側のcovid19対策サイトですから、正式用語を対応すれば良いでしょう。

## 📝 関連issue / Related Issues

- Open #1053 

## ⛏ 変更内容 / Details of Changes
Chinese(Taiwan) → Chinese(Traditional)

## 📸 スクリーンショット / Screenshots
After：
<img width="1001" alt="截屏2020-03-1021 40 42" src="https://user-images.githubusercontent.com/8623423/76313736-d9a42680-6318-11ea-85c6-35f86bb79a1e.png">
Before：
<img width="987" alt="截屏2020-03-1021 46 31" src="https://user-images.githubusercontent.com/8623423/76313750-e0cb3480-6318-11ea-9b1d-f4322ad01061.png">
