### PR TITLE
noscript対応でローダーを外しました

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,6 @@
 <template>
   <v-app class="app">
-    <div v-if="loading" class="loader">
-      <img src="/logo.svg" alt="東京都" />
-      <scale-loader color="#00A040" />
-    </div>
-    <div v-else class="appContainer">
+    <div class="appContainer">
       <div class="naviContainer">
         <SideNavigation
           :is-navi-open="isOpenNavigation"
@@ -24,27 +20,20 @@
 <script lang="ts">
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
-import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 import SideNavigation from '@/components/SideNavigation.vue'
 
 type LocalData = {
   isOpenNavigation: boolean
-  loading: boolean
 }
 
 export default Vue.extend({
   components: {
-    ScaleLoader,
     SideNavigation
   },
   data(): LocalData {
     return {
-      isOpenNavigation: false,
-      loading: true
+      isOpenNavigation: false
     }
-  },
-  mounted() {
-    this.loading = false
   },
   methods: {
     openNavigation(): void {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #974 
- close #1063 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ローダーを外しました
- noscriptで閲覧できるようになりました
- 副作用としてhead/titleやmetaが正常反映されるようになりました
  - 理由として、v-if内にページコンポーネントが入っていたのでマウントされるまでtitle/metaが更新されなかった感じです

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->


![スクリーンショット 2020-03-10 23 45 09](https://user-images.githubusercontent.com/13947046/76324883-fd239d00-6329-11ea-9293-02a77a7e48cd.png)
![スクリーンショット 2020-03-10 23 45 53](https://user-images.githubusercontent.com/13947046/76324895-00b72400-632a-11ea-96d6-99379e4b9bc1.png)
![スクリーンショット 2020-03-10 23 45 59](https://user-images.githubusercontent.com/13947046/76324899-01e85100-632a-11ea-8983-e128d3ca05b3.png)
![スクリーンショット 2020-03-10 23 46 04](https://user-images.githubusercontent.com/13947046/76324901-0280e780-632a-11ea-88af-f19872bd12ca.png)
![スクリーンショット 2020-03-10 23 46 14](https://user-images.githubusercontent.com/13947046/76324904-03197e00-632a-11ea-93d2-c1f2be57e2d5.png)

グラフがみれなくなりましたが他のページは問題なさそうに見えます