### PR TITLE
parent画面のa-tagのURLを直接表示せず、リンク先タイトルにリンク

### DIFF
--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -25,7 +25,7 @@ export default {
         {
           title: '2 感染症を疑う場合の対応',
           body:
-            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇  「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）<br /><a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
+            '〇　風邪の症状や、37.5度以上の発熱が４日以上続いている、強いだるさ（倦怠感）、息苦しさ（呼吸困難）がある場合は、各保健所にご相談ください。<br />〇 <a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">「新型コロナウイルス感染症にかかる相談窓口について」</a>（東京都福祉保健局）'
         },
         {
           title: '3 その他',


### PR DESCRIPTION
## 📝 関連issue / Related Issues

[/parent] URLを直接表示せずに、リンク先タイトルにリンクしたほうが良さそう#1077 

## ⛏ 変更内容 / Details of Changes
- /parent内のa-tagでURLを非表示に、リンク先タイトルへリンク。

修正前
<img width="1680" alt="LWScreenShot 2020-03-11 at 1 14 30" src="https://user-images.githubusercontent.com/26253721/76334894-141cbc00-6337-11ea-937e-d6256270b00a.png">

修正後
<img width="1680" alt="スクリーンショット 2020-03-11 1 33 26" src="https://user-images.githubusercontent.com/26253721/76335804-66121180-6338-11ea-8fda-bac41448802d.png">
