### PR TITLE
「最新のお知らせ」の見出しレベルを修正

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="WhatsNew">
-    <h2 class="WhatsNew-heading">
+    <h3 class="WhatsNew-heading">
       <v-icon size="24" class="WhatsNew-heading-icon">
         mdi-information
       </v-icon>
       {{ $t('最新のお知らせ') }}
-    </h2>
+    </h3>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
         <a


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/1073

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- トップページ「最新のお知らせ」の見出しレベルをh3に変更
- これらは「都内の最新感染動向」の内部にある見出しであるため
- styleの変更はありません

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- <img width="845" alt="Screen Shot 2020-03-11 at 1 47 24" src="https://user-images.githubusercontent.com/10768439/76337177-572c5e80-633a-11ea-8204-98efb4312a69.png">
