### PR TITLE
トップページの陽性患者の属性を陽性患者発表情報に変更した

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -37,7 +37,7 @@
       </v-col>
       <v-col cols="12" md="6" class="DataCard">
         <data-table
-          :title="'陽性患者の属性'"
+          :title="'陽性患者発表情報'"
           :title-id="'attributes-of-confirmed-cases'"
           :chart-data="patientsTable"
           :chart-option="{}"


### PR DESCRIPTION
## 📝 関連issue / Related Issues
close #1084 

## ⛏ 変更内容 / Details of Changes
トップページの`陽性患者の属性`を`陽性患者発表情報`に変更した

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-11 2 49 50](https://user-images.githubusercontent.com/6235307/76343312-46341b00-6343-11ea-8bc4-4ce19d268481.png)
