### PR TITLE
SNSのリンクの範囲を、画像の真上のみ効くように変更 #1106

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -249,11 +249,11 @@ export default {
   }
   &-SocialLinkContainer {
     display: flex;
+    & a:not(:last-of-type) {
+      margin-right: 10px;
+    }
     & img {
       width: 30px;
-      &:first-of-type {
-        margin-right: 10px;
-      }
     }
   }
   &-Copyright {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #1106 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイドバー内ソーシャルアカウントのリンク範囲が広かったので、リンク範囲を画像の真上のみ効くように変更しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

- Before 
<img width="219" alt="Before" src="https://user-images.githubusercontent.com/8909592/76383468-4c57e500-639f-11ea-9d80-f504a57da66a.png">

- After
<img width="219" alt="After" src="https://user-images.githubusercontent.com/23334091/76389669-20446000-63af-11ea-8fa9-b4900a5f2cee.png">