### PR TITLE
積み上げ棒グラフのツールチップを修正

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -179,18 +179,17 @@ export default {
             label: tooltipItem => {
               const labelTokyo = this.$t('都内')
               const labelOthers = this.$t('その他')
-              let casesTotal, casesTokyo, casesOthers
+              const labelArray = [labelTokyo, labelOthers]
+              let casesTotal, cases
               if (this.dataKind === 'transition') {
                 casesTotal = sumArray[tooltipItem.index]
-                casesTokyo = data[0][tooltipItem.index]
-                casesOthers = data[1][tooltipItem.index]
+                cases = data[tooltipItem.datasetIndex][tooltipItem.index]
               } else {
                 casesTotal = cumulativeSumArray[tooltipItem.index]
-                casesTokyo = cumulativeData[0][tooltipItem.index]
-                casesOthers = cumulativeData[1][tooltipItem.index]
+                cases = cumulativeData[tooltipItem.datasetIndex][tooltipItem.index]
               }
 
-              return `${casesTotal} ${unit} (${labelTokyo}: ${casesTokyo} / ${labelOthers}: ${casesOthers})`
+              return `${casesTotal} ${unit} (${labelArray[tooltipItem.datasetIndex]}: ${cases})`
             },
             title(tooltipItem, data) {
               return data.labels[tooltipItem[0].index]


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #866 

## ⛏ 変更内容 / Details of Changes
・「都内発生」（濃い緑）にマウスオーバー時
```
2/27
191件（都内：110）
```

・「その他」（薄い緑）にマウスオーバー時
```
2/27
191件（その他：81）
```

※i18n化済みだったので、「合計」というテキストを入れずにおきました。

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-11 17 14 30](https://user-images.githubusercontent.com/14883063/76396573-cba7e180-63bc-11ea-8c90-dcd7162ef0a9.png)
![スクリーンショット 2020-03-11 17 14 51](https://user-images.githubusercontent.com/14883063/76396581-d19dc280-63bc-11ea-8869-dff5f1698505.png)
