### PR TITLE
[i18n] 検査陽性者の状況 英語表示時のレイアウト崩れの修正

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -239,23 +239,24 @@ export default {
   }
 }
 .box {
+  $box-height: 170px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
   position: relative;
   padding-bottom: 26px;
   width: 100%;
-  height: 150px;
+  height: $box-height;
   border: 3px solid $green-1;
   color: $green-1;
   @include font-size(14);
   text-align: center;
   line-height: 1.2;
   &.tall {
-    height: 185px;
+    height: $box-height + 35px;
   }
   &.short {
-    height: 115px;
+    height: $box-height - 35px;
   }
   span:last-child {
     margin-top: 0.2em;

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -392,21 +392,21 @@ export default {
 
 // variables.scss Breakpoints: huge
 @include lessThan(1440) {
-  @include variation(1440, 3, 14, 150, 35);
+  @include variation(1440, 3, 14, 180, 35);
 }
 
 // Vuetify Breakpoints: Large
 @include lessThan(1263) {
-  @include variation(1263, 2, 12, 107, 24);
+  @include variation(1263, 2, 12, 150, 24);
 }
 
 // Vuetify Breakpoints: Small
 @include lessThan(959) {
-  @include variation(960, 4, 16, 180, 40);
+  @include variation(960, 4, 16, 250, 40);
 }
 
 // Vuetify Breakpoints: Extra Small
 @include lessThan(599) {
-  @include variation(600, 3, 14, 150, 35);
+  @include variation(600, 3, 14, 200, 35);
 }
 </style>

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -28,7 +28,7 @@
       </div>
       <ul class="group">
         <li class="item in-hospital">
-          <div class="gutter">
+          <div class="gutter oneThird">
             <div class="box">
               <span>{{ $t('入院中') }}</span>
               <span>
@@ -234,6 +234,9 @@ export default {
 .gutter {
   width: 100%;
   padding-right: 3px;
+  &.oneThird {
+    width: calc(100% / 3);
+  }
 }
 .box {
   display: flex;


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1117 

## ⛏ 変更内容 / Details of Changes
- 英語表記の際にレイアウトが崩れないように修正

## 📸 スクリーンショット / Screenshots
### Before (en)
![スクリーンショット 2020-03-11 18 36 34](https://user-images.githubusercontent.com/5207601/76402815-4b3aae00-63c7-11ea-902b-60faffbd4bb4.png)

### After (en)
![スクリーンショット 2020-03-11 18 36 39](https://user-images.githubusercontent.com/5207601/76402820-4c6bdb00-63c7-11ea-8a6c-b602952eef8e.png)

日本語表記では高さに余裕がでますが、英語表記で読めるようにするほうが優先度が高いと思ったので、このような実装にしています。
言語ごとに css のクラスをつける仕組みがあると細かく制御することもできます。

### Before (ja)
![スクリーンショット 2020-03-11 18 40 27](https://user-images.githubusercontent.com/5207601/76403298-09f6ce00-63c8-11ea-86d5-1f8f8f44a82d.png)

### After (ja)
![スクリーンショット 2020-03-11 18 40 32](https://user-images.githubusercontent.com/5207601/76403302-0bc09180-63c8-11ea-9532-3df5a49a072a.png)


