### PR TITLE
[i18n] リンクのスタイルが意図せず書き換わる問題を修正

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -50,6 +50,7 @@ export default class TextCard extends Vue {
     @include card-h1();
     margin-bottom: 12px;
     a {
+      @include text-link();
       @include card-h1();
     }
   }

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -490,8 +490,4 @@ export default {
     padding: 12px 0;
   }
 }
-
-a {
-  @include text-link();
-}
 </style>

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -162,7 +162,4 @@ export default {
     margin-bottom: 12px;
   }
 }
-a {
-  @include text-link();
-}
 </style>

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -179,7 +179,4 @@ export default {
     margin-bottom: 12px;
   }
 }
-a {
-  @include text-link();
-}
 </style>


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #1129 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `/parent`, `/worker`, `/about` に存在していた `<a>` タグに対するCSSを削除
- `TextCard-Heading`の`<a>`タグにはコンポーネント側でCSSを適用させる

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- #1129 に示した再現手順を行った結果です
![image](https://user-images.githubusercontent.com/42484226/76411307-e4bc8c80-63d4-11ea-9361-b7d7ceeeba01.png)
