### PR TITLE
「企業の皆様・はたらく皆様へ」の見出しにリンクのスタイルを適用する

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -51,6 +51,11 @@ export default class TextCard extends Vue {
     margin-bottom: 12px;
     a {
       @include card-h1();
+      color: $link !important;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+      }
     }
   }
   &-Body {


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #1134 
- `dev-i18n` に取り込まれた #902 が前提のため `dev-i18n` 宛のPRにしていますが、`development`向けで問題なければ変更します。

## ⛏ 変更内容 / Details of Changes
- `TextCard-Heading`内の`<a>`タグにリンクのスタイルを設定

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### 変更後
![image](https://user-images.githubusercontent.com/42484226/76415888-63b5c300-63dd-11ea-8d60-07bbdefe3cf5.png)

### 変更前
![image](https://user-images.githubusercontent.com/42484226/76416125-d161ef00-63dd-11ea-96ab-be3861feedbe.png)

