### PR TITLE
[i18n] fix: 英語表記のグラフで文字が重ならないように修正

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -49,7 +49,7 @@
 
 <style lang="scss">
 .DataSelector {
-  margin-top: 2px;
+  margin-top: 20px;
   border: 1px solid $gray-4;
   background-color: $white;
   &-Button {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,15 +1,13 @@
 <template>
   <v-card class="DataView">
     <div class="DataView-Inner">
-      <div class="DataView-Content">
-        <div
-          class="DataView-TitleContainer"
+      <div class="DataView-Header">
+        <h3
+          class="DataView-Title"
           :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >
-          <h3 :id="titleId" class="DataView-Title">
-            {{ title }}
-          </h3>
-        </div>
+          {{ title }}
+        </h3>
         <slot name="infoPanel" />
         <slot name="button" />
       </div>
@@ -88,12 +86,16 @@ export default class DataView extends Vue {
 
 <style lang="scss">
 .DataView {
-  &-Content {
+  &-Header {
     display: flex;
     align-items: center;
     flex-flow: column;
+    max-width: 24em;
+    margin: 0 auto;
     text-align: center;
     @include largerThan($large) {
+      max-width: initial;
+      width: 100%;
       flex-flow: row;
       flex-wrap: wrap;
       text-align: left;
@@ -129,20 +131,16 @@ export default class DataView extends Vue {
     padding: 22px;
     height: 100%;
   }
-  &-TitleContainer {
-    width: 100%;
-    color: $gray-2;
-    @include largerThan($large) {
-      width: 50%;
-    }
-  }
   &-Title {
+    width: 100%;
     margin-bottom: 5px;
     font-size: 1.25rem;
     line-height: 1.5;
     font-weight: normal;
     text-align: center;
+    color: $gray-2;
     @include largerThan($large) {
+      width: 50%;
       text-align: left;
     }
   }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -9,11 +9,9 @@
           <h3 :id="titleId" class="DataView-Title">
             {{ title }}
           </h3>
-          <div>
-            <slot name="button" />
-          </div>
         </div>
         <slot name="infoPanel" />
+        <slot name="button" />
       </div>
       <div
         :class="
@@ -92,12 +90,10 @@ export default class DataView extends Vue {
 .DataView {
   &-Content {
     display: flex;
-    justify-content: space-between;
+    align-items: center;
+    flex-flow: column;
   }
   &-DataInfo {
-    position: absolute;
-    top: 25px;
-    right: 25px;
     &-summary {
       color: $gray-2;
       font-family: Hiragino Sans;
@@ -130,16 +126,15 @@ export default class DataView extends Vue {
   &-TitleContainer {
     display: flex;
     flex-flow: column;
+    width: 100%;
     color: $gray-2;
-    &.with-infoPanel {
-      width: calc(100% - 11em);
-    }
   }
   &-Title {
     margin-bottom: 5px;
     font-size: 1.25rem;
     line-height: 1.5;
     font-weight: normal;
+    text-align: center;
   }
   &-CardText {
     margin: 30px 0;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -90,17 +90,12 @@ export default class DataView extends Vue {
   height: 100%;
   &-Header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     flex-flow: column;
-    max-width: 24em;
-    margin: 0 auto;
-    text-align: center;
     @include largerThan($large) {
-      max-width: initial;
       width: 100%;
       flex-flow: row;
       flex-wrap: wrap;
-      text-align: left;
     }
   }
   &-DataInfo {
@@ -135,15 +130,14 @@ export default class DataView extends Vue {
   }
   &-Title {
     width: 100%;
-    margin-bottom: 5px;
+    margin-bottom: 10px;
     font-size: 1.25rem;
     line-height: 1.5;
     font-weight: normal;
-    text-align: center;
     color: $gray-2;
     @include largerThan($large) {
       width: 50%;
-      text-align: left;
+      margin-bottom: 0;
     }
   }
   &-CardText {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -86,6 +86,8 @@ export default class DataView extends Vue {
 
 <style lang="scss">
 .DataView {
+  @include card-container();
+  height: 100%;
   &-Header {
     display: flex;
     align-items: center;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -92,10 +92,15 @@ export default class DataView extends Vue {
     display: flex;
     align-items: flex-start;
     flex-flow: column;
+    padding: 0 10px;
+    @include largerThan($medium) {
+      padding: 0 5px;
+    }
     @include largerThan($large) {
       width: 100%;
       flex-flow: row;
       flex-wrap: wrap;
+      padding: 0;
     }
   }
   &-DataInfo {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -92,6 +92,12 @@ export default class DataView extends Vue {
     display: flex;
     align-items: center;
     flex-flow: column;
+    text-align: center;
+    @include largerThan($large) {
+      flex-flow: row;
+      flex-wrap: wrap;
+      text-align: left;
+    }
   }
   &-DataInfo {
     &-summary {
@@ -124,10 +130,11 @@ export default class DataView extends Vue {
     height: 100%;
   }
   &-TitleContainer {
-    display: flex;
-    flex-flow: column;
     width: 100%;
     color: $gray-2;
+    @include largerThan($large) {
+      width: 50%;
+    }
   }
   &-Title {
     margin-bottom: 5px;
@@ -135,6 +142,9 @@ export default class DataView extends Vue {
     line-height: 1.5;
     font-weight: normal;
     text-align: center;
+    @include largerThan($large) {
+      text-align: left;
+    }
   }
   &-CardText {
     margin: 30px 0;

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -12,7 +12,7 @@
 <style lang="scss">
 .DataView {
   &-DataInfo {
-    text-align: right;
+    text-align: center;
     &-summary {
       display: inline-block;
       font-family: Hiragino Sans;

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -37,11 +37,6 @@
 }
 .DataView {
   @include card-container();
-  height: 100%;
-  &-Header {
-    background-color: transparent !important;
-    height: auto !important;
-  }
 }
 </style>
 

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -35,9 +35,6 @@
     }
   }
 }
-.DataView {
-  @include card-container();
-}
 </style>
 
 <script lang="ts">

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -12,7 +12,10 @@
 <style lang="scss">
 .DataView {
   &-DataInfo {
-    text-align: center;
+    @include largerThan($large) {
+      text-align: right;
+      width: 50%;
+    }
     &-summary {
       display: inline-block;
       font-family: Hiragino Sans;
@@ -24,7 +27,7 @@
       }
     }
     &-date {
-      white-space: nowrap;
+      white-space: wrap;
       display: inline-block;
       font-size: 12px;
       line-height: 12px;

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -321,7 +321,8 @@ export default {
 
 <style lang="scss" scoped>
 .Graph-Desc {
-  margin: 10px 0;
+  width: 100%;
+  margin: 0;
   font-size: 12px;
   color: $gray-3;
 }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1146

## ⛏ 変更内容 / Details of Changes
- 英語表記のグラフで文字が重ならないようにする
- スモールスクリーンでは、グラフタイトルと数値データを横並びにするのと窮屈になるので、縦並びに変更しました。デザイナーさんの意図と齟齬がある場合は、コメントいただければ修正いたします。

## 📸 スクリーンショット / Screenshots
### Before
#### iPone 6
![スクリーンショット 2020-03-11 23 47 58](https://user-images.githubusercontent.com/5207601/76429821-ebf29300-63f2-11ea-98be-60eff2df5a3d.png)

#### PC
![スクリーンショット 2020-03-11 23 50 57](https://user-images.githubusercontent.com/5207601/76430039-3247f200-63f3-11ea-8d86-ec8d7fcbaef3.png)

### After
#### iPone 6
![スクリーンショット 2020-03-11 23 47 53](https://user-images.githubusercontent.com/5207601/76429825-edbc5680-63f2-11ea-9d69-fbb5fff09728.png)

#### PC
![スクリーンショット 2020-03-11 23 51 01](https://user-images.githubusercontent.com/5207601/76430049-36740f80-63f3-11ea-9e9f-7bf8dc577dbd.png)
