### PR TITLE
[i18n] スマホ版flowページの翻訳を無効化

### DIFF
--- a/components/flow/FlowSp.vue
+++ b/components/flow/FlowSp.vue
@@ -31,7 +31,10 @@
 {
   "ja": {
     "新型コロナウイルス感染症にかかる相談窓口について": "新型コロナウイルス感染症にかかる相談窓口について"
-  },
+  }
+}
+</i18n>
+<!--
   "en": {
     "新型コロナウイルス感染症にかかる相談窓口について": "Regarding the COVID-19 Infection Telephone Advisory Center"
   },
@@ -47,8 +50,7 @@
   "ja-basic": {
     "新型コロナウイルス感染症にかかる相談窓口について": "コロナについての でんわそうだん"
   }
-}
-</i18n>
+-->
 
 <script>
 import FlowSpPast from './FlowSpPast.vue'

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -156,8 +156,12 @@
     "新型コロナ受診相談窓口": "新型コロナ受診相談窓口",
     "自宅で安静に過ごす": "自宅で安静に過ごす",
     "一般の医療機関を受診": "一般の医療機関を受診"
-  },
-  "en": {
+  }
+}
+</i18n>
+
+<!--
+"en": {
     "{advisory}による相談結果": "{advisory}による相談結果",
     "新型コロナ受診相談窓口": "Combined telephone advice center",
     "新型コロナ外来 {advice} と判断された場合": "If you are {advice} for COVID-19",
@@ -267,8 +271,7 @@
     "自宅で安静に過ごす": "いえ で しずか に していてください",
     "一般の医療機関を受診": "ちかくの びょういん で みてもらってください"
   }
-}
-</i18n>
+-->
 
 <script>
 import Apartment from '../../static/flow/apartment-24px.svg'

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -54,7 +54,11 @@
     "平日（夜間）": "平日（夜間）",
     "午後5時から翌朝午前9時": "午後5時から翌朝午前9時",
     "土日祝 終日": "土日祝 終日"
-  },
+  }
+}
+</i18n>
+
+<!--
   "en": {
     "新型コロナ受診相談窓口": "Combined telephone advice center (Support in Japanese only)",
     "帰国者・接触者電話相談センター": "telephone advisory center for returnees and contactees",
@@ -105,8 +109,7 @@
     "午後5時から翌朝午前9時": "ごご５じからごぜん９じまで",
     "土日祝 終日": "やすみのひ いちにちじゅう"
   }
-}
-</i18n>
+-->
 
 <script lang="ts">
 import PhoneIcon from '@/static/flow/phone-24px.svg'

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -80,8 +80,12 @@
     "基礎疾患のある方": "基礎疾患のある方",
     "妊娠中の方": "妊娠中の方",
     "新型コロナ受診相談窓口へ": "新型コロナ受診相談窓口へ"
-  },
-  "en": {
+  }
+}
+</i18n>
+
+<!--
+"en": {
     "{duration}続いている": "Having these symptoms for {duration",
     "{day}日程度": "{day} consecutive days",
     "{cold}のような症状": "Having {cold} symptoms",
@@ -156,8 +160,7 @@
     "妊娠中の方": "おなかに こどもが いるひと",
     "新型コロナ受診相談窓口へ": ""
   }
-}
-</i18n>
+-->
 
 <script lang="ts">
 import AccessibleIcon from '@/static/flow/accessible-24px.svg'

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -66,8 +66,12 @@
     "強いだるさ": "強いだるさ",
     "息苦しさ": "息苦しさ",
     "新型コロナ受診相談窓口へ": "新型コロナ受診相談窓口へ"
-  },
-  "en": {
+  }
+}
+</i18n>
+
+<!--
+"en": {
     "一般の方": "People without any specific health conditions",
     "{duration}続いている": "Having these symptoms for {duration",
     "{day}日以上": "{day} consecutive days or more",
@@ -132,8 +136,7 @@
     "息苦しさ": "いきがくるしい",
     "新型コロナ受診相談窓口へ": ""
   }
-}
-</i18n>
+-->
 
 <script lang="ts">
 import HumanIcon from '@/static/flow/accessibility-24px.svg'

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -2,66 +2,109 @@
   <div :class="$style.container">
     <p :class="$style.heading">
       <i18n path="{past}の出来ごとと症状" tag="span">
-        <i18n :class="$style.large" tag="span" path="発症前{two}週間以内" place="past">
+        <i18n
+          :class="$style.large"
+          tag="span"
+          path="発症前{two}週間以内"
+          place="past"
+        >
           <span :class="$style.numeric" place="two">2</span>
         </i18n>
       </i18n>
     </p>
     <p :class="$style.type">
       <template v-if="!langsNeedReversedOrder.includes($i18n.locale)">
-        <strong :class="$style.source">{{ $t('「新型コロナウイルス感染者」と') }}</strong>
+        <strong :class="$style.source">
+          {{ $t('「新型コロナウイルス感染者」と') }}
+        </strong>
         <i18n tag="span" path="{closeContact}をした方" :class="$style.behavior">
-          <em :class="$style.underline" place="closeContact">{{ $t('濃厚接触') }}</em>
+          <em :class="$style.underline" place="closeContact">
+            {{ $t('濃厚接触') }}
+          </em>
         </i18n>
       </template>
       <template v-else>
         <i18n tag="span" path="{closeContact}をした方" :class="$style.behavior">
-          <em :class="$style.underline" place="closeContact">{{ $t('濃厚接触') }}</em>
+          <em :class="$style.underline" place="closeContact">
+            {{ $t('濃厚接触') }}
+          </em>
         </i18n>
-        <span :class="$style.source">{{ $t('「新型コロナウイルス感染者」と') }}</span>
+        <span :class="$style.source">
+          {{ $t('「新型コロナウイルス感染者」と') }}
+        </span>
       </template>
     </p>
     <div :class="$style.condition">
       <div :class="$style.item">
-        <div class="py-4">{{ $t('発熱') }}</div>
+        <div class="py-4">
+          {{ $t('発熱') }}
+        </div>
       </div>
-      <div :class="$style.item">{{ $t('または') }}</div>
       <div :class="$style.item">
-        <div class="py-4">{{ $t('呼吸器症状') }}</div>
+        {{ $t('または') }}
+      </div>
+      <div :class="$style.item">
+        <div class="py-4">
+          {{ $t('呼吸器症状') }}
+        </div>
       </div>
     </div>
     <div :class="$style.hr" />
     <p :class="$style.type">
       <template v-if="!langsWithoutFlowTitle.includes($i18n.locale)">
-        <strong :class="$style.source">{{ $t('流行地域への渡航・居住歴がある方') }}</strong>
-        <i18n tag="span" :class="$style.behavior" path="{you} か {closeContact}をした方">
-          <em :class="$style.underline" place="you">{{ $t('ご本人') }}</em>
-          <em :class="$style.underline" place="closeContact">{{ $t('濃厚接触') }}</em>
+        <strong :class="$style.source">
+          {{ $t('流行地域への渡航・居住歴がある方') }}
+        </strong>
+        <i18n
+          tag="span"
+          :class="$style.behavior"
+          path="{you} か {closeContact}をした方"
+        >
+          <em :class="$style.underline" place="you">
+            {{ $t('ご本人') }}
+          </em>
+          <em :class="$style.underline" place="closeContact">
+            {{ $t('濃厚接触') }}
+          </em>
         </i18n>
       </template>
       <template v-else>
-        <i18n tag="span" :class="[$style.behavior, $style.small]" path="travel history from {area}">
-          <em :class="$style.underline" place="area">{{ $t('COVID-19 prevalent area') }}</em>
+        <i18n
+          tag="span"
+          :class="[$style.behavior, $style.small]"
+          path="travel history from {area}"
+        >
+          <em :class="$style.underline" place="area">
+            {{ $t('COVID-19 prevalent area') }}
+          </em>
         </i18n>
         <i18n
           tag="span"
           :class="[$style.source, $style.small]"
           path="been {inCloseContact} with returnees"
         >
-          <em :class="$style.underline" place="inCloseContact">{{ $t('in close contact') }}</em>
+          <em :class="$style.underline" place="inCloseContact">
+            {{ $t('in close contact') }}
+          </em>
         </i18n>
       </template>
     </p>
     <div :class="$style.condition">
       <div :class="$style.item">
-        <div class="py-4">{{ $t('呼吸器症状') }}</div>
+        <div class="py-4">
+          {{ $t('呼吸器症状') }}
+        </div>
       </div>
-      <div :class="$style.item">{{ $t('かつ') }}</div>
+      <div :class="$style.item">
+        {{ $t('かつ') }}
+      </div>
       <div :class="$style.item">
         <div>
           <i18n tag="span" path="発熱{temperature}" :class="$style.temp">
             <i18n tag="span" path="{tempNum}以上" place="temperature">
-              <span :class="$style.temp" place="tempNum">{{ $t('37.5℃') }}</span>
+              <span :class="$style.temp" place="tempNum">
+                {{ $t('37.5℃') }}
+              </span>
             </i18n>
           </i18n>
         </div>
@@ -93,8 +136,12 @@
     "発熱{temperature}": "発熱{temperature}",
     "{tempNum}以上": "{tempNum}以上",
     "37.5℃": "37.5℃"
-  },
-  "en": {
+  }
+}
+</i18n>
+
+<!--
+"en": {
     "{past}の出来ごとと症状": "{past}, if you have...",
     "発症前{two}週間以内": "In the past {two} weeks",
     "「新型コロナウイルス感染者」と": "with a COVID-19 patient",
@@ -191,8 +238,7 @@
     "{tempNum}以上": "{tempNum}より",
     "37.5℃": "37.5℃"
   }
-}
-</i18n>
+-->
 
 <script lang="ts">
 import ArrowForwardIcon from '@/static/flow/arrow_forward-24px.svg'
@@ -201,10 +247,10 @@ export default {
   components: { ArrowForwardIcon },
   computed: {
     langsNeedReversedOrder() {
-      return ['en']
+      return [] // ['en']
     },
     langsWithoutFlowTitle() {
-      return ['en', 'zh-cn', 'zh-tw']
+      return [] // ['en', 'zh-cn', 'zh-tw']
     }
   }
 }

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -65,8 +65,12 @@
     "新型コロナコールセンター": "新型コロナコールセンター",
     "午前9時から午後9時（土日祝含む）": "午前9時から午後9時（土日祝含む）",
     "専門的な助言が必要な場合": "専門的な助言が必要な場合"
-  },
-  "en": {
+  }
+}
+</i18n>
+
+<!--
+"en": {
     "不安に思う方": "For those who suspect they have COVID-19 infection",
     "微熱": "Having slight fever",
     "軽い咳": "Having minor coughs",
@@ -111,8 +115,7 @@
     "午前9時から午後9時（土日祝含む）": "まいにち あさ の ごぜん９じ～よる の ごご９じまで（やすみ の ひも やっています）",
     "専門的な助言が必要な場合": "コロナをよくしっているひとから くわしい はなし を ききたい とき"
   }
-}
-</i18n>
+-->
 
 <script lang="ts">
 import ArrowForwardIcon from '@/static/flow/arrow_forward-24px.svg'


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- i18n総合issue: #680

## ⛏ 変更内容 / Details of Changes
- 「新型コロナウイルス感染症が心配なときに」をスマホで見たときに、どの言語設定でも日本語が表示されるように（暫定措置）
- ページ上部のタイトルと、最下部の「詳細を見る(東京都福祉保健局)」ボタンは、PC版とスマホ版で共通の部品なので翻訳が適用されます
