### PR TITLE
[i18n] components/flow/FlowSpGeneral.vue i18n化残りの分

### DIFF
--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -6,26 +6,30 @@
         {{ $t('一般の方') }}
       </p>
     </div>
-
     <ul :class="$style.Conditions">
       <li :class="['py-4', $style.ConditionsItem]">
         <span>
-          <!-- eslint-disable-next-line prettier/prettier -->
-          <span :class="$style.ConditionsItemLarger">風邪</span>のような症状
+          <i18n path="{cold}のような症状">
+            <span :class="$style.ConditionsItemLarger" place="cold">
+              {{ $t('風邪') }}
+            </span>
+          </i18n>
         </span>
       </li>
       <li :class="['py-4', $style.ConditionsItem]">
-        <!-- eslint-disable-next-line prettier/prettier -->
-        <span>発熱
-          <span
+        <i18n tag="span" path="発熱{temperature}">
+          <i18n
+            tag="span"
+            place="temperature"
+            path="{tempNum}以上"
             :class="[
               $style.ConditionsItemLarger,
               $style.ConditionsItemWithWordBreak
             ]"
           >
-            <span>37.5℃</span>以上
-          </span>
-        </span>
+            <span place="tempNum">37.5℃</span>
+          </i18n>
+        </i18n>
       </li>
       <li :class="['py-3', $style.ConditionsItem, $style.ConditionsItemLarger]">
         {{ $t('強いだるさ') }}
@@ -34,11 +38,18 @@
         {{ $t('息苦しさ') }}
       </li>
     </ul>
-
     <p :class="$style.GeneralText">
-      <span><strong>4</strong>日以上</span>続いている
+      <i18n path="{duration}続いている">
+        <i18n
+          tag="span"
+          place="duration"
+          path="{day}日以上"
+          :class="$style.GeneralTextLarger"
+        >
+          <strong place="day">4</strong>
+        </i18n>
+      </i18n>
     </p>
-
     <a
       v-scroll-to="'#consult'"
       href="#consult"
@@ -60,7 +71,7 @@
     "{day}日以上": "{day}日以上",
     "{cold}のような症状": "{cold}のような症状",
     "風邪": "風邪",
-    "発熱{temperature}以上": "発熱{temperature}",
+    "発熱{temperature}": "発熱{temperature}",
     "{tempNum}以上": "{tempNum}以上",
     "37.5℃": "37.5℃",
     "強いだるさ": "強いだるさ",
@@ -73,12 +84,12 @@
     "{day}日以上": "{day} consecutive days or more",
     "{cold}のような症状": "Having {cold} symptoms",
     "風邪": "cold/flu",
-    "発熱{temperature}以上": "body temperature {temperature}",
+    "発熱{temperature}": "body temperature {temperature}",
     "{tempNum}以上": "above {tempNum}",
     "37.5℃": "37.5℃",
     "強いだるさ": "Extreme fatigue",
     "息苦しさ": "Having difficulty when breathing",
-    "新型コロナ受診相談窓口へ": ""
+    "新型コロナ受診相談窓口へ": "Go COVID-19 advisory"
   },
   "zh-cn": {
     "一般の方": "普通人",
@@ -86,12 +97,12 @@
     "{day}日以上": "{day}天以上",
     "{cold}のような症状": "有疑似{cold}的症状",
     "風邪": "感冒",
-    "発熱{temperature}以上": "发烧 {temperature}",
+    "発熱{temperature}": "发烧 {temperature}",
     "{tempNum}以上": "{tempNum} 以上",
     "37.5℃": "37.5℃",
     "強いだるさ": "有强烈倦怠感",
     "息苦しさ": "感到呼吸困难",
-    "新型コロナ受診相談窓口へ": ""
+    "新型コロナ受診相談窓口へ": "跳转到新冠肺炎就诊咨询窗口"
   },
   "zh-tw": {
     "一般の方": "一般人士",
@@ -99,12 +110,12 @@
     "{day}日以上": "{day}天以上",
     "{cold}のような症状": "疑似{cold}症狀",
     "風邪": "感冒",
-    "発熱{temperature}以上": "發燒 {temperature}",
+    "発熱{temperature}": "發燒 {temperature}",
     "{tempNum}以上": "{tempNum} 以上",
     "37.5℃": "37.5℃",
     "強いだるさ": "有強烈疲倦感",
     "息苦しさ": "呼吸不順暢",
-    "新型コロナ受診相談窓口へ": ""
+    "新型コロナ受診相談窓口へ": "跳到新冠病毒就診諮詢窗口"
   },
   "ko": {
     "一般の方": "일반인",
@@ -112,12 +123,12 @@
     "{day}日以上": "{day}일 이상",
     "{cold}のような症状": "{cold} 비슷한 증상",
     "風邪": "감기와",
-    "発熱{temperature}以上": "{temperature} 발열",
+    "発熱{temperature}": "{temperature} 발열",
     "{tempNum}以上": "{tempNum} 이상의",
     "37.5℃": "37.5도",
     "強いだるさ": "극도의 피로감",
     "息苦しさ": "호흡이 어려운 경우",
-    "新型コロナ受診相談窓口へ": ""
+    "新型コロナ受診相談窓口へ": "코로나 19 수진 상담 창구"
   },
   "ja-basic": {
     "一般の方": "ねつが ないひと",
@@ -125,12 +136,12 @@
     "{day}日以上": "{day}にち より ながく",
     "{cold}のような症状": "{cold} が あるひと",
     "風邪": "かぜ",
-    "発熱{temperature}以上": "{temperature} たかいねつが あるひと",
+    "発熱{temperature}": "{temperature} たかいねつが あるひと",
     "{tempNum}以上": "{tempNum}より",
     "37.5℃": "37.5℃",
     "強いだるさ": "からだがくるしい",
     "息苦しさ": "いきがくるしい",
-    "新型コロナ受診相談窓口へ": ""
+    "新型コロナ受診相談窓口へ": "新（あたら）しい コロナ受診相談窓口（じゅしんそうだんまどぐち）へ ※受診相談窓口：病院（びょういん）で 見（み）てもらうか について 相談（そうだん） するところ"
   }
 }
 </i18n>
@@ -220,7 +231,7 @@ export default {
     color: $gray-2;
     font-weight: bold;
     margin-bottom: 8px;
-    span {
+    &Larger {
       border-bottom: 4px solid $green-1;
       @include lessThan($small) {
         @include font-size(18);


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- flowページi18n化issue: #932

## ⛏ 変更内容 / Details of Changes
- マークアップ修正後の部分もi18n化
- L47 でスタイル`$style.GeneralTextLarger`を追加（定義はL223）
  - 他の`<span>`に影響しないようにするため
  - 把握お願いします(2個目) @kaizumaki 

## あとでやる
- やさしい日本語を漢字ありに更新