### PR TITLE
[/flow] [i18n] (PR) SP英語版で「n日程度続いている」の日数部分が表示されていない

### DIFF
--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -96,7 +96,7 @@
     "新型コロナ受診相談窓口へ": "新型コロナ受診相談窓口へ"
   },
   "en": {
-    "{duration}続いている": "Having these symptoms for {duration",
+    "{duration}続いている": "Having these symptoms for {duration}",
     "{day}日程度": "{day} consecutive days",
     "{cold}のような症状": "Having {cold} symptoms",
     "風邪": "cold/flu",

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -80,7 +80,7 @@
   },
   "en": {
     "一般の方": "People without any specific health conditions",
-    "{duration}続いている": "Having these symptoms for {duration",
+    "{duration}続いている": "Having these symptoms for {duration}",
     "{day}日以上": "{day} consecutive days or more",
     "{cold}のような症状": "Having {cold} symptoms",
     "風邪": "cold/flu",


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #1228 

## ⛏ 変更内容 / Details of Changes

- `FlowSpGeneral` `FlowSpElder` コンポーネントの該当部分を修正

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/3162324/76511500-98d21c00-6496-11ea-9b0a-834495627fa6.png)
