### PR TITLE
トップページ「都庁来庁者数の推移」とその下部のグラフで重複しているidタグを削除

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,5 +1,10 @@
 <template>
   <data-view :title="title" :date="date" :url="url">
+    <template v-slot:button>
+      <small :class="$style.DataViewDesc">
+        ※土・日・祝日を除く庁舎開庁日の1週間累計数
+      </small>
+    </template>
     <bar
       :chart-id="chartId"
       :chart-data="displayData"

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date" :url="url">
+  <data-view :title="title" :card-link="cardLink" :date="date" :url="url">
     <template v-slot:button>
       <small :class="$style.DataViewDesc">
         ※土・日・祝日を除く庁舎開庁日の1週間累計数
@@ -87,6 +87,11 @@ export default {
       type: String,
       required: false,
       default: 'agency-bar-chart'
+    },
+    cardLink: {
+      type: String,
+      required: false,
+      default: ''
     },
     unit: {
       type: String,

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,10 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
-    <template v-slot:button>
-      <small :class="$style.DataViewDesc">
-        ※土・日・祝日を除く庁舎開庁日の1週間累計数
-      </small>
-    </template>
+  <data-view :title="title" :date="date" :url="url">
     <bar
       :chart-id="chartId"
       :chart-data="displayData"
@@ -79,11 +74,6 @@ export default {
   components: { DataView },
   props: {
     title: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date" :url="url">
+  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
     <template v-slot:button>
       <span />
     </template>
@@ -103,6 +103,10 @@ export default {
   components: { DataView, DataViewBasicInfoPanel },
   props: {
     title: {
+      type: String,
+      default: ''
+    },
+    titleId: {
       type: String,
       default: ''
     },

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :card-link="cardLink" :date="date" :url="url">
     <template v-slot:button>
       <span />
     </template>
@@ -106,7 +106,7 @@ export default {
       type: String,
       default: ''
     },
-    titleId: {
+    cardLink: {
       type: String,
       default: ''
     },

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :date="date" :url="url">
     <template v-slot:button>
       <span />
     </template>
@@ -103,10 +103,6 @@ export default {
   components: { DataView, DataViewBasicInfoPanel },
   props: {
     title: {
-      type: String,
-      default: ''
-    },
-    titleId: {
       type: String,
       default: ''
     },

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -134,6 +134,7 @@ import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 @Component
 export default class DataView extends Vue {
   @Prop() private title!: string
+  @Prop() private titleId!: string
   @Prop() private date!: string
   @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -134,7 +134,6 @@ import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 @Component
 export default class DataView extends Vue {
   @Prop() private title!: string
-  @Prop() private titleId!: string
   @Prop() private date!: string
   @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -134,7 +134,7 @@ import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 @Component
 export default class DataView extends Vue {
   @Prop() private title!: string
-  @Prop() private titleId!: string
+  @Prop() private cardLink!: string
   @Prop() private date!: string
   @Prop() private url!: string
   @Prop() private info!: any // FIXME expect info as {lText:string, sText:string unit:string}
@@ -152,7 +152,7 @@ export default class DataView extends Vue {
   }
 
   permalink(host: boolean = false, embed: boolean = false) {
-    let permalink = '/cards/' + this.titleId
+    let permalink = '/cards/' + this.cardLink
     if (embed) {
       permalink = permalink + '?embed=true'
     }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date">
+  <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:button>
       <p class="MetroGraph-Desc">
         {{
@@ -78,6 +78,11 @@ export default {
   components: { DataView },
   props: {
     title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view :title="title" :date="date">
     <template v-slot:button>
       <p class="MetroGraph-Desc">
         {{
@@ -78,11 +78,6 @@ export default {
   components: { DataView },
   props: {
     title: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view :title="title" :card-link="cardLink" :date="date">
     <template v-slot:button>
       <p class="MetroGraph-Desc">
         {{
@@ -82,7 +82,7 @@ export default {
       required: false,
       default: ''
     },
-    titleId: {
+    cardLink: {
       type: String,
       required: false,
       default: ''

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view class="SvgCard" :title="title" :title-id="titleId" :date="date">
+  <data-view class="SvgCard" :title="title" date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view class="SvgCard" :title="title" date="date">
+  <data-view class="SvgCard" :title="title" :title-id="titleId" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{

--- a/components/SvgCard.vue
+++ b/components/SvgCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view class="SvgCard" :title="title" :title-id="titleId" :date="date">
+  <data-view class="SvgCard" :title="title" :card-link="cardLink" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{
@@ -79,7 +79,7 @@ export default {
       type: String,
       default: ''
     },
-    titleId: {
+    cardLink: {
       type: String,
       default: ''
     },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :date="date" :url="url">
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
@@ -70,11 +70,6 @@ export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
     title: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view :title="title" :card-link="cardLink" :date="date" :url="url">
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
@@ -74,7 +74,7 @@ export default {
       required: false,
       default: ''
     },
-    titleId: {
+    cardLink: {
       type: String,
       required: false,
       default: ''

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date" :url="url">
+  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
     <template v-slot:button>
       <data-selector v-model="dataKind" />
     </template>
@@ -70,6 +70,11 @@ export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
     title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view :title="title" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{ $t('（注）同一の対象者について複数の検体を調査する場合あり') }}
@@ -91,11 +91,6 @@ export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
     title: {
-      type: String,
-      required: false,
-      default: ''
-    },
-    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view :title="title" :card-link="cardLink" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{ $t('（注）同一の対象者について複数の検体を調査する場合あり') }}
@@ -95,7 +95,7 @@ export default {
       required: false,
       default: ''
     },
-    titleId: {
+    cardLink: {
       type: String,
       required: false,
       default: ''

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <data-view :title="title" :date="date">
+  <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:button>
       <p class="Graph-Desc">
         {{ $t('（注）同一の対象者について複数の検体を調査する場合あり') }}
@@ -91,6 +91,11 @@ export default {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
     title: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    titleId: {
       type: String,
       required: false,
       default: ''

--- a/components/cards/AgencyCard.vue
+++ b/components/cards/AgencyCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <agency-bar-chart
       :title="$t('都庁来庁者数の推移')"
-      :title-id="'agency'"
+      :card-link="'agency'"
       :chart-id="'agency'"
       :url="''"
       :unit="$t('人')"

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <data-table
       :title="$t('陽性患者の属性')"
-      :title-id="'attributes-of-confirmed-cases'"
+      :card-link="'attributes-of-confirmed-cases'"
       :chart-data="patientsTable"
       :chart-option="{}"
       :date="Data.patients.date"

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <svg-card
       :title="$t('検査陽性者の状況')"
-      :title-id="'details-of-confirmed-cases'"
+      :card-link="'details-of-confirmed-cases'"
       :date="Data.inspections_summary.date"
     >
       <confirmed-cases-table

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
       :title="$t('陽性患者数')"
-      :title-id="'number-of-confirmed-cases'"
+      :card-link="'number-of-confirmed-cases'"
       :chart-id="'time-bar-chart-patients'"
       :chart-data="patientsGraph"
       :date="Data.patients.date"

--- a/components/cards/ConsultationDeskReportsNumberCard.vue
+++ b/components/cards/ConsultationDeskReportsNumberCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
       :title="$t('新型コロナ受診相談窓口相談件数')"
-      :title-id="'number-of-reports-to-covid19-consultation-desk'"
+      :char-link="'number-of-reports-to-covid19-consultation-desk'"
       :chart-id="'time-bar-chart-querents'"
       :chart-data="querentsGraph"
       :date="Data.querents.date"

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <metro-bar-chart
       :title="$t('都営地下鉄の利用者数の推移')"
-      :title-id="'predicted-number-of-toei-subway-passengers'"
+      :card-link="'predicted-number-of-toei-subway-passengers'"
       :chart-id="'metro-bar-chart'"
       :chart-data="metroGraph"
       :chart-option="metroGraphOption"

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
       :title="$t('新型コロナコールセンター相談件数')"
-      :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
+      :card-link="'number-of-reports-to-covid19-telephone-advisory-center'"
       :chart-id="'time-bar-chart-contacts'"
       :chart-data="contactsGraph"
       :date="Data.contacts.date"

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <time-stacked-bar-chart
       :title="$t('検査実施数')"
-      :title-id="'number-of-tested'"
+      :card-link="'number-of-tested'"
       :chart-id="'time-stacked-bar-chart-inspections'"
       :chart-data="inspectionsGraph"
       :date="Data.inspections_summary.date"


### PR DESCRIPTION
## 📝 関連issue / Related Issues
https://github.com/tokyo-metropolitan-gov/covid19/issues/1185
<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close #{ISSUE_NUMBER}

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 1要素のdivに対して複数idが設定されていた。
- 使用されていないtitle-idを削除しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="635" alt="Screen Shot 2020-03-12 at 19 17 41" src="https://user-images.githubusercontent.com/37738112/76513421-9de49a80-6499-11ea-8b3c-413d3b9d30fc.png">
ローカルでのAuditsです。重複の警告メッセージは表示されなくなっています。