### PR TITLE
都内の最新感染動向の time 要素の datetime 属性値を ISO8601 形式に修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -22,7 +22,9 @@
       </div>
       <div class="DataView-Footer">
         <a class="Permalink" :href="permalink()">
-          <time :datetime="date">{{ $t('{date} 更新', { date }) }}</time>
+          <time :datetime="formattedDate">
+            {{ $t('{date} 更新', { date }) }}
+          </time>
         </a>
         <a
           v-if="url"


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #1199

## ⛏ 変更内容 / Details of Changes
- 都内の最新感染動向の各グラフの最終更新日時の time 要素の datetime 属性値を ISO8601 形式に修正

- 他はちゃんとフォーマットされていそうです
```
$ ag ':datetime='                                                                                                                                                              
components/PageHeader.vue
11:      <time :datetime="formattedDate">{{ date }}</time>

components/WhatsNew.vue
19:            :datetime="formattedDate(item.date)"

components/DataView.vue
24:        <time :datetime="date">{{ $t('{date} 更新', { date }) }}</time>
```

## 📸 スクリーンショット / Screenshots
<img width="1177" alt="スクリーンショット 2020-03-12 20 03 21" src="https://user-images.githubusercontent.com/25524755/76515199-8a86fe80-649c-11ea-9159-b7b58fc408db.png">

