### PR TITLE
ページ内のランドマークを改善しスクリーンリーダーのアクセシビリティを向上する

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -20,7 +20,7 @@
       >
         <slot />
       </div>
-      <v-footer class="DataView-Footer">
+      <div class="DataView-Footer">
         <a class="Permalink" :href="permalink()">
           <time :datetime="date">{{ $t('{date} 更新', { date }) }}</time>
         </a>
@@ -36,8 +36,8 @@
             mdi-open-in-new
           </v-icon>
         </a>
-      </v-footer>
-      <v-footer v-if="this.$route.query.embed != 'true'" class="DataView-Share">
+      </div>
+      <div v-if="this.$route.query.embed != 'true'" class="DataView-Share py-2">
         <button @click="openGraphEmbed = true">
           <v-icon class="icon-resize embed" size="40">
             mdi-code-tags
@@ -70,8 +70,8 @@
             LINE
           </div>
         </button>
-      </v-footer>
-      <v-footer v-if="openGraphEmbed">
+      </div>
+      <div v-if="openGraphEmbed" class="DataView-Embed pa-2">
         <button @click="openGraphEmbed = false">
           <v-icon size="16">
             mdi-close
@@ -81,7 +81,7 @@
           {{ $t('グラフの埋め込み') }}
         </div>
         <textarea v-model="graphEmbedValue" />
-      </v-footer>
+      </div>
     </div>
   </v-card>
 </template>
@@ -251,9 +251,13 @@ export default class DataView extends Vue {
     margin-bottom: 46px;
     margin-top: 70px;
   }
+  &-Embed {
+    background-color: $gray-5;
+  }
   &-Footer {
     @include font-size(12);
     padding: 0 !important;
+    display: flex;
     justify-content: space-between;
     flex-direction: row-reverse;
     color: $gray-3 !important;

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="SideNavigation">
-    <div class="SideNavigation-HeadingContainer sp-flex">
+    <header class="SideNavigation-HeadingContainer sp-flex">
       <v-icon
         class="SideNavigation-HeadingIcon pc-none"
         :aria-label="$t('サイドメニュー項目を開く')"
@@ -16,7 +16,7 @@
           {{ $t('新型コロナウイルス感染症') }}<br />{{ $t('対策サイト') }}
         </h1>
       </nuxt-link>
-    </div>
+    </header>
     <v-divider class="SideNavigation-HeadingDivider" />
     <div class="sp-none" :class="{ open: isNaviOpen }">
       <v-icon
@@ -26,21 +26,23 @@
       >
         mdi-close
       </v-icon>
-      <v-list :flat="true">
-        <v-container
-          v-for="(item, i) in items"
-          :key="i"
-          class="SideNavigation-ListItemContainer"
-          @click="closeNavi"
-        >
-          <ListItem :link="item.link" :icon="item.icon" :title="item.title" />
-          <v-divider v-show="item.divider" class="SideNavigation-Divider" />
-        </v-container>
-      </v-list>
-      <div class="SideNavigation-LanguageMenu">
-        <LanguageSelector />
-      </div>
-      <div class="SideNavigation-Footer">
+      <nav>
+        <v-list :flat="true">
+          <v-container
+            v-for="(item, i) in items"
+            :key="i"
+            class="SideNavigation-ListItemContainer"
+            @click="closeNavi"
+          >
+            <ListItem :link="item.link" :icon="item.icon" :title="item.title" />
+            <v-divider v-show="item.divider" class="SideNavigation-Divider" />
+          </v-container>
+        </v-list>
+        <div class="SideNavigation-LanguageMenu">
+          <LanguageSelector />
+        </div>
+      </nav>
+      <v-footer class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
           <a
             href="https://line.me/R/ti/p/%40822sysfc"
@@ -80,7 +82,7 @@
           <br />
           2020 Tokyo Metropolitan Government
         </small>
-      </div>
+      </v-footer>
     </div>
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,11 +9,11 @@
           @closeNavi="hideNavigation"
         />
       </div>
-      <div class="mainContainer" :class="{ open: isOpenNavigation }">
+      <main class="mainContainer" :class="{ open: isOpenNavigation }">
         <v-container class="px-4 py-8">
           <nuxt />
         </v-container>
-      </div>
+      </main>
     </div>
     <div v-else class="embed">
       <v-container>


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/1159

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- header, nav, main, footer要素を適切に配置する。
  - `.SideNavigation-HeadingContainer`をheader要素で包む
  - `v-list v-sheet v-sheet--tile theme--light v-list--flat`となっている左ナビと`.SideNavigation-LanguageMenu`をまとめてひとつのnav要素で包む
  - `.mainContainer`をmain要素で包む
  - `.SideNavigation-Footer`をfooter要素で包む
  - `.DataView-Inner`内の最下部にあるfooter要素はdiv要素に置き換える
- PC版を基準に配置したため、モバイルにおいてはとくにサイドメニューあたりで見た目に反している可能性がある

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

<img width="1446" alt="Screen Shot 2020-03-12 at 20 59 59" src="https://user-images.githubusercontent.com/10768439/76519493-747d3c00-64a4-11ea-98fc-4d01871b0a96.png">
見た目の変更は発生しません