### PR TITLE
feat: 都庁入庁者の推移グラフに補足の文言を追加

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,5 +1,10 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+    <template v-slot:button>
+      <small :class="$style.DataViewDesc">
+        ※土・日・祝日を除く庁舎開庁日の1週間累計数
+      </small>
+    </template>
     <bar
       :chart-id="chartId"
       :chart-data="displayData"
@@ -8,6 +13,17 @@
     />
   </data-view>
 </template>
+
+<style module lang="scss">
+.DataView {
+  &Desc {
+    margin-top: 10px;
+    margin-bottom: 0 !important;
+    font-size: 12px;
+    color: $gray-3;
+  }
+}
+</style>
 
 <i18n>
 {


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- #987 

## ⛏ 変更内容 / Details of Changes
- 都庁入庁者の推移グラフに補足の文言を追加
```
※土・日・祝日を除く庁舎開庁日の1週間累計数
```
- 多言語化は後回しでよいとのことなので、取り急ぎ日本語だけ追加しました

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-12 23 21 07](https://user-images.githubusercontent.com/5207601/76531545-b4e6b500-64b8-11ea-84ed-9c4f8dd1963c.png)

