### PR TITLE
Language Selector を /cards/* など階層構造パスへ対応

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -27,15 +27,23 @@ import SelectMenuIcon from '@/static/selectmenu.svg'
   components: { EarthIcon, SelectMenuIcon }
 })
 export default class LanguageSelector extends Vue {
+  locales = ['en', 'zh-cn', 'zh-tw', 'ko', 'ja-basic']
+
   navigate(locale: string) {
     // @fixme 超ダーティーハックです。。。
     const mypath =
-      ['/en', '/zh-cn', '/zh-tw', '/ko'].indexOf(
-        this.$router.currentRoute.path
-      ) === 0
+      this.locales.map(x => '/' + x).indexOf(this.$router.currentRoute.path) ===
+      0
         ? this.$router.currentRoute.path + '/'
         : this.$router.currentRoute.path
-    const matches = mypath.match(/.*(\/.*)/)
+    const reg = new RegExp(
+      '(?:' +
+        this.locales.join('|') +
+        ')?(/(?!' +
+        this.locales.join('|') +
+        ').*)$'
+    )
+    const matches = mypath.match(reg)
     if (matches === null) {
       return
     }


### PR DESCRIPTION
## 📝 関連issue / Related Issues

<!--
  ・ 関連するissue 番号を記載してください。 Issue 番号がない PR は受け付けません。
  ・ issueを閉じるとは関係ないものは#{ISSUE_NUMBER}だけでOKです🙆‍♂️

  ・ You can remove this section if there are no related issues
  ・ If the issue is related but doesn't close upon merge, you can just write - #{ISSUE_NUMBER} 🙆‍♂️
-->
<!--
  ・ Please specify related Issue ID. We don't accept PRs which has no issue ID.
  ・ If there's no reason to close the issue, just "#{ISSUE_NUMBER}" is OK🙆‍♂️
-->
- #774
- #835 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- Language Selector を /cards/* など階層構造パスへ対応
- URLとして下記のスクリーンショットのパターンなどがありえる中で、prefixがlocaleに関するものがある時とないときに関わらず、それ以外の部分を抽出することで言語の切り替えに対応
  - 正規表現はこういう形: `(?:en|zh-ch|zh-tw|ko|ja-basic)?(\/(?!en|zh-ch|zh-tw|ko|ja-basic).*)$`
  - あと一応、今後階層構造が増えた場合もうまく抽出できている

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

<img width="899" alt="Online_regex_tester_and_debugger__PHP__PCRE__Python__Golang_and_JavaScript" src="https://user-images.githubusercontent.com/54614/76559139-e9229b80-64e1-11ea-9132-b9fbd12296c0.png">
