### PR TITLE
DataSelectorとListItemにfocus時のoutlineを追加,LanguageSelecterのoutlineを削除

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -32,6 +32,9 @@
     &::before {
       background-color: inherit;
     }
+    &:focus {
+      outline: solid $green-1 2px;
+    }
   }
 
   & .v-btn--active {

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -70,9 +70,6 @@ export default class LanguageSelector extends Vue {
       font-size: 12px;
       box-sizing: border-box;
       cursor: pointer;
-      &:focus {
-        outline: none;
-      }
     }
   }
   &-Background {

--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -138,6 +138,9 @@ export default class ListItem extends Vue {
         }
       }
     }
+    &:focus {
+      outline: solid $green-1 2px;
+    }
   }
   &-Text {
     color: $gray-1;


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
(プルリクを一度出したんですが、不慮の事故でoriginのcommitが消えてしまったので再度投稿します)
- close #1147

## ⛏ 変更内容 / Details of Changes
SideNavigation BarとDataselectorのfocusに$green-1 solidを追加
ブラウザの規定したoutlineを使うために、inheritにすることも考えられたんですが、vuetifyのv-btn, v-listの親要素にoutline: noneがあったので断念しました。
<参考 vuetifyのソースコード>
https://github.com/vuetifyjs/vuetify/blob/81dfbf8e4ac6bf6fbbc0e61e121245a4e68f56bf/packages/vuetify/src/components/VList/VListItem.sass
https://github.com/vuetifyjs/vuetify/blob/de967aca925d06f9af32907a3be1f0170e024e70/packages/vuetify/src/components/VBtn/VBtn.sass

## 📸 スクリーンショット / Screenshots
<img width="246" alt="スクリーンショット 2020-03-13 8 44 53" src="https://user-images.githubusercontent.com/24960403/76606113-093f7280-6555-11ea-8ffd-63968df9c13c.png">
<img width="168" alt="スクリーンショット 2020-03-13 8 45 05" src="https://user-images.githubusercontent.com/24960403/76606117-0c3a6300-6555-11ea-80c4-513b5295d863.png">

