### PR TITLE
「東京都主催等 中止又は延期するイベント等」のリンク先を変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -146,7 +146,7 @@ export default {
         {
           title: this.$t('東京都主催等 中止又は延期するイベント等'),
           link:
-            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html'
+            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/event00.html'
         },
         {
           title: this.$t('知事からのメッセージ'),


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1326 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイドナビゲーションのリンク先を変更
  - 変更前: https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html
  - 変更後: https://www.seisakukikaku.metro.tokyo.lg.jp/information/event02.html

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42484226/76619117-7f4fd380-656d-11ea-949d-e1aed7ccce32.png)
