### PR TITLE
IE11でflowページが崩れる対応（PC版、日本語のみ）

### DIFF
--- a/components/DesktopFlowSvg.vue
+++ b/components/DesktopFlowSvg.vue
@@ -1,5 +1,11 @@
+<!-- eslint-disable vue/html-indent -->
 <template>
-  <svg viewBox="0 0 1046 1256" xmlns="http://www.w3.org/2000/svg">
+  <svg
+    width="625"
+    height="750"
+    viewBox="0 0 1046 1256"
+    xmlns="http://www.w3.org/2000/svg"
+  >
     <defs>
       <style>
         .a,

--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -14,6 +14,9 @@
       <div :class="$style.Advisory">
         <flow-pc-advisory />
       </div>
+      <div :class="$style.Advisory2">
+        <flow-pc-advisory2 />
+      </div>
     </div>
     <h3>
       <i18n
@@ -59,6 +62,7 @@ import FlowPcPast from './FlowPcPast.vue'
 import FlowPcDays from './FlowPcDays.vue'
 import FlowPcSuspect from './FlowPcSuspect.vue'
 import FlowPcAdvisory from './FlowPcAdvisory.vue'
+import FlowPcAdvisory2 from './FlowPcAdvisory2.vue'
 import FlowPcRequired from './FlowPcRequired.vue'
 import FlowPcPcr from './FlowPcPcr.vue'
 import FlowPcNotRequired from './FlowPcNotRequired.vue'
@@ -70,6 +74,7 @@ export default {
     FlowPcDays,
     FlowPcSuspect,
     FlowPcAdvisory,
+    FlowPcAdvisory2,
     FlowPcRequired,
     FlowPcPcr,
     FlowPcNotRequired,
@@ -119,7 +124,11 @@ export default {
     & > *:nth-child(4) {
       -ms-grid-column: 3;
       -ms-grid-row: 1;
-      -ms-grid-row-span: 5;
+      -ms-grid-row-span: 3;
+    }
+    & > *:nth-child(5) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
     }
     margin-bottom: 36px;
   }
@@ -211,6 +220,20 @@ export default {
     transform: rotateZ(30deg);
   }
 }
+.Advisory {
+  position: relative;
+  &::after {
+    content: '';
+    position: absolute;
+    left: calc(50% - 23px);
+    transform: rotate(90deg);
+    z-index: 1;
+    display: block;
+    width: 46px;
+    height: 46px;
+    background: url('/flow/flow_arrow.svg') no-repeat;
+  }
+}
 .Past {
   grid-column: 1 / 2;
   grid-row: 1 / 2;
@@ -225,7 +248,11 @@ export default {
 }
 .Advisory {
   grid-column: 2 / 3;
-  grid-row: 1 / 4;
+  grid-row: 1 / 3;
+}
+.Advisory2 {
+  grid-column: 2 / 3;
+  grid-row: 3 / 4;
 }
 .Required {
   grid-column: 1 / 2;

--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -99,12 +99,51 @@ export default {
   grid-gap: 12px;
   &Upper {
     grid-template-columns: 70% 30%;
+    -ms-grid-columns: 70% 12px 30%;
     grid-template-rows: repeat(3, auto);
+    -ms-grid-rows: auto 12px auto 12px auto;
+    // HACK: IEでGridの順番がうまくいかない対応
+    // https://github.com/tokyo-metropolitan-gov/covid19/issues/1313
+    & > *:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    & > *:nth-child(2) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 3;
+    }
+    & > *:nth-child(3) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 5;
+    }
+    & > *:nth-child(4) {
+      -ms-grid-column: 3;
+      -ms-grid-row: 1;
+      -ms-grid-row-span: 5;
+    }
     margin-bottom: 36px;
   }
   &Lower {
     grid-template-columns: repeat(2, 1fr);
     grid-template-rows: repeat(3, auto);
+    // HACK: IEでGridの順番がうまくいかない対応
+    // https://github.com/tokyo-metropolitan-gov/covid19/issues/1313
+    & > *:nth-child(1) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 1;
+    }
+    & > *:nth-child(2) {
+      -ms-grid-column: 1;
+      -ms-grid-row: 2;
+    }
+    & > *:nth-child(3) {
+      -ms-grid-column: 2;
+      -ms-grid-row: 1;
+    }
+    & > *:nth-child(4) {
+      -ms-grid-column: 2;
+      -ms-grid-row: 3;
+    }
   }
 }
 .Title {

--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -125,7 +125,9 @@ export default {
   }
   &Lower {
     grid-template-columns: repeat(2, 1fr);
+    -ms-grid-columns: 1fr 12px 1fr;
     grid-template-rows: repeat(3, auto);
+    -ms-grid-rows: auto 12px auto 12px auto;
     // HACK: IEでGridの順番がうまくいかない対応
     // https://github.com/tokyo-metropolitan-gov/covid19/issues/1313
     & > *:nth-child(1) {
@@ -134,15 +136,17 @@ export default {
     }
     & > *:nth-child(2) {
       -ms-grid-column: 1;
-      -ms-grid-row: 2;
+      -ms-grid-row: 3;
+      -ms-grid-row-span: 3;
     }
     & > *:nth-child(3) {
-      -ms-grid-column: 2;
+      -ms-grid-column: 3;
       -ms-grid-row: 1;
+      -ms-grid-row-span: 3;
     }
     & > *:nth-child(4) {
-      -ms-grid-column: 2;
-      -ms-grid-row: 3;
+      -ms-grid-column: 3;
+      -ms-grid-row: 5;
     }
   }
 }

--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -10,7 +10,7 @@
         <div :class="[$style.AdvisoryContentsColsSentense, $style.Mt16]">
           {{ $t('帰国者・接触者 電話相談センター') }}
         </div>
-        <div :class="[$style.AdvisoryBlockCentering, $style.Mt20]">
+        <div :class="$style.Mt20">
           <div :class="[$style.AdvisoryBoxContainer, $style.AdvisoryWhiteBox]">
             <span :class="$style.AdvisoryWhiteBoxSentense">
               {{ $t('24時間対応') }}
@@ -150,7 +150,7 @@
     border-radius: 4px;
     text-align: center;
     padding: 20px 10px;
-    margin: 20px auto 40px;
+    margin: 20px auto;
   }
   &WhiteBox {
     background-color: $white;
@@ -164,9 +164,9 @@
   }
   &BlackBox {
     background-color: $gray-2;
-    width: 200px;
-    height: 200px;
-    margin-bottom: 25px;
+    width: 100%;
+    height: 210px; // FIXME: 左のGridと揃える
+    margin: 0;
     display: flex;
     justify-content: center;
     align-items: center;

--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -7,7 +7,7 @@
             $t('新型コロナ受診相談窓口')
           }}</span>
         </div>
-        <div :class="[$style.AdvisoryContentsColsSentense, $style.Mt16]">
+        <div :class="[$style.AdvisoryContentsColsSentense, 'mt-4']">
           {{ $t('帰国者・接触者 電話相談センター') }}
         </div>
         <div>
@@ -28,7 +28,7 @@
             :class="[
               $style.AdvisoryLink,
               $style.AdvisoryBlockCentering,
-              $style.Mt16
+              'mt-4'
             ]"
           >
             <a
@@ -52,7 +52,7 @@
           </div>
           <span>{{ $t('午後5時から翌朝午前9時') }}</span>
         </div>
-        <div :class="$style.Mt4">
+        <div class="mt-1">
           <span :class="$style.AdvisoryContentsSubTitle">
             {{ $t('土日祝 終日') }}
           </span>
@@ -61,24 +61,12 @@
           :class="[
             $style.AdvisoryTelephoneArea,
             $style.AdvisoryBlockCentering,
-            $style.Mt4
+            'mt-1'
           ]"
         >
           <img src="/flow/phone-24px.svg" />
           <span :class="$style.AdvisoryTelephone">03-5320-4592</span>
         </div>
-      </div>
-    </div>
-
-    <div :class="$style.AdvisoryBlockCentering">
-      <img src="/flow/flow_arrow.svg" :class="$style.Rotate" />
-    </div>
-
-    <div :class="$style.AdvisoryBlockCentering">
-      <div :class="[$style.AdvisoryBoxContainer, $style.AdvisoryBlackBox]">
-        <span :class="$style.AdvisoryBlackBoxSentense">{{
-          $t('専門的な助言が必要な場合')
-        }}</span>
       </div>
     </div>
   </div>
@@ -161,31 +149,5 @@
       font-weight: bold;
     }
   }
-  &BlackBox {
-    background-color: $gray-2;
-    width: 100%;
-    height: 210px; // FIXME: 左のGridと揃える
-    margin: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    &Sentense {
-      color: $white;
-      font-size: 20px;
-      line-height: 26px;
-    }
-  }
-}
-.Rotate {
-  transform: rotate(-90deg);
-}
-.Mt4 {
-  margin-top: 4px;
-}
-.Mt16 {
-  margin-top: 16px;
-}
-.Mt20 {
-  margin-top: 20px;
 }
 </style>

--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -10,7 +10,7 @@
         <div :class="[$style.AdvisoryContentsColsSentense, $style.Mt16]">
           {{ $t('帰国者・接触者 電話相談センター') }}
         </div>
-        <div :class="$style.Mt20">
+        <div>
           <div :class="[$style.AdvisoryBoxContainer, $style.AdvisoryWhiteBox]">
             <span :class="$style.AdvisoryWhiteBoxSentense">
               {{ $t('24時間対応') }}
@@ -20,7 +20,7 @@
       </div>
 
       <div :class="$style.AdvisoryContents">
-        <div>
+        <div class="py-8">
           <div :class="$style.AdvisoryContentsTitle2">
             {{ $t('平日（日中）') }}
           </div>
@@ -46,7 +46,7 @@
       </div>
 
       <div :class="$style.AdvisoryContents">
-        <div>
+        <div class="pt-8">
           <div :class="$style.AdvisoryContentsTitle2">
             {{ $t('平日（夜間）') }}
           </div>
@@ -96,6 +96,7 @@
   &Container {
     background-color: $gray-5;
     border-radius: 4px;
+    height: 100%;
     padding: 30px 20px 20px 20px;
     margin-bottom: 10px;
     text-align: center;
@@ -104,10 +105,8 @@
     font-weight: bold;
     &:not(:first-child) {
       border-top: 0.5px solid $gray-4;
-      padding-top: 12px;
     }
     &:not(:last-child) {
-      padding-bottom: 16px;
     }
     &Title {
       font-size: 26px;
@@ -150,7 +149,7 @@
     border-radius: 4px;
     text-align: center;
     padding: 20px 10px;
-    margin: 20px auto;
+    margin: 24px auto;
   }
   &WhiteBox {
     background-color: $white;

--- a/components/flow/FlowPcAdvisory2.vue
+++ b/components/flow/FlowPcAdvisory2.vue
@@ -1,0 +1,31 @@
+<template>
+  <div :class="$style.Container">
+    <div :class="['pa-4', $style.AdvisoryBoxContainer]">
+      <span :class="$style.AdvisoryBlackBoxSentense">{{
+        $t('専門的な助言が必要な場合')
+      }}</span>
+    </div>
+  </div>
+</template>
+
+<i18n src="./FlowPcAdvisory.i18n.json"></i18n>
+
+<style module lang="scss">
+.Container {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+.AdvisoryBoxContainer {
+  @include font-size(20);
+  align-items: center;
+  background-color: $gray-2;
+  border-radius: 4px;
+  color: $white;
+  display: flex;
+  width: 80%;
+  text-align: center;
+  justify-content: center;
+}
+</style>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -113,7 +113,9 @@
   position: relative;
   color: $gray-2;
   &Row {
-    flex: 1 0 36%;
+    flex-grow: 1;
+    flex-shrink: 0;
+    flex-basis: 36%;
     display: flex;
     flex-direction: column;
     text-align: center;
@@ -122,13 +124,13 @@
       margin: 0 10px;
     }
     &RowThree {
-      flex: 3;
+      flex-grow: 3;
       display: flex;
       align-items: center;
       justify-content: center;
       margin-top: 20px;
       &CareTargetList {
-        margin: 16px auto;
+        margin: 16px 0;
         text-align: left;
         list-style: none;
         &Item + &Item {
@@ -137,7 +139,7 @@
       }
     }
     &Condition {
-      flex: 1;
+      flex-grow: 1;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -150,7 +152,7 @@
       p {
         text-align: center;
         display: inline-block;
-        margin: 0;
+        margin: 0 !important; // FIXME: IEだとv-applicationのmarginが優先される
         font-size: calc(0.875rem + ((1vw - 7.68px) * 0.8929));
         font-weight: bold;
         @include largerThan($large) {

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -7,21 +7,23 @@
         </strong>
       </i18n>
     </h3>
-    <ul :class="$style.actions">
-      <li>
-        <img :class="$style.icon" src="/flow/house-24px.svg" />
-        {{ $t('自宅で安静に過ごす') }}
-      </li>
-      <li>
-        <img :class="$style.icon" src="/flow/apartment-24px.svg" />
-        {{ $t('一般の医療機関を受診') }}
-      </li>
-    </ul>
-    <div :class="$style.nextAction">
-      <i18n path="{getWorse}{advisory}に相談" :class="$style.content">
-        <span place="getWorse">{{ $t('症状が良くならない場合は') }}</span>
-        <strong place="advisory">{{ $t('新型コロナ受診相談窓口') }}</strong>
-      </i18n>
+    <div :class="$style.actionContainer">
+      <ul :class="$style.actions">
+        <li>
+          <img :class="$style.icon" src="/flow/house-24px.svg" />
+          {{ $t('自宅で安静に過ごす') }}
+        </li>
+        <li>
+          <img :class="$style.icon" src="/flow/apartment-24px.svg" />
+          {{ $t('一般の医療機関を受診') }}
+        </li>
+      </ul>
+      <div :class="$style.nextAction">
+        <i18n path="{getWorse}{advisory}に相談" :class="$style.content">
+          <span place="getWorse">{{ $t('症状が良くならない場合は') }}</span>
+          <strong place="advisory">{{ $t('新型コロナ受診相談窓口') }}</strong>
+        </i18n>
+      </div>
     </div>
   </div>
 </template>
@@ -54,11 +56,16 @@
     font-weight: bold;
   }
 }
+.actionContainer {
+  display: flex;
+  justify-content: space-between;
+}
 .actions {
   width: 49%;
-  justify-items: auto;
-  margin: auto 0;
-  padding: 1rem !important;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 0 !important; // FIXME: for ul element
   li {
     list-style-type: none;
     text-align: start;

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -52,7 +52,7 @@
   text-align: center;
 }
 .Row {
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -62,7 +62,7 @@
   margin: 0;
 }
 .TwoRow {
-  flex: 1;
+  flex-grow: 1;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -73,7 +73,7 @@
   margin: 0 !important;
 }
 .Card {
-  flex-basis: 48%;
+  width: 48%;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -81,7 +81,7 @@
   border-radius: 4px;
   padding: 10px;
   p {
-    margin: 0;
+    margin: 0 !important; // FIXME: IEだとv-applicationのmarginが優先される
   }
 }
 .CardLarge {

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -106,7 +106,9 @@
 
 .Box1 {
   position: relative;
-  flex: 0 0 60%;
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 60%;
   flex-direction: row;
   &::after {
     content: '';
@@ -122,8 +124,11 @@
 }
 
 .Box2 {
-  flex: 0 0 38%;
+  flex-grow: 0;
+  flex-shrink: 0;
+  width: 38%;
   flex-direction: column;
+  justify-content: center;
   div {
     margin: 0.5em;
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/1313

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- IE11でflowページが崩れていたので、修正します
- IE11で印刷時に図が小さくなっていたので、サイズを調整します。
- スマホ版も崩れちゃってますが、ひとまず需要があるPCのみ対応しています。
- あとで全体のスタイルを調整すると思うので、ひとまず日本語のみ対応します。
    - IEのflexのバグで、文が長いと行の折返しが効かなかったりしています

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

<img width="1718" alt="Screen Shot 2020-03-13 at 23 33 45" src="https://user-images.githubusercontent.com/10768439/76630449-5cc8b500-6583-11ea-800b-32036cd20b67.png">

<img width="1718" alt="Screen Shot 2020-03-13 at 23 33 54" src="https://user-images.githubusercontent.com/10768439/76630460-60f4d280-6583-11ea-98c7-72e02bfd5815.png">
