### PR TITLE
TextCardのlinkが外部リンクの時にアイコンを表示

### DIFF
--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -1,9 +1,18 @@
 <template>
   <div class="TextCard">
     <h3 v-if="title" class="TextCard-Heading">
-      <a v-if="link" :href="link" target="_blank" rel="noopener">
-        {{ title }}
-      </a>
+      <div v-if="link">
+        <a :href="link" target="_blank" rel="noopener">
+          {{ title }}
+        </a>
+        <v-icon
+          v-if="!isInternalLink(link)"
+          class="TextCard-ExternalLinkIcon"
+          size="20"
+        >
+          mdi-open-in-new
+        </v-icon>
+      </div>
       <template v-else>
         {{ title }}
       </template>
@@ -38,6 +47,10 @@ export default class TextCard extends Vue {
     required: false
   })
   body!: string
+
+  isInternalLink(path: string): boolean {
+    return !/^https?:\/\//.test(path)
+  }
 }
 </script>
 
@@ -57,6 +70,10 @@ export default class TextCard extends Vue {
         text-decoration: underline;
       }
     }
+  }
+  &-ExternalLinkIcon {
+    margin-left: 2px;
+    color: $gray-3 !important;
   }
   &-Body {
     * {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1317 

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
- TextCard.vue内のlinkが外部リンクの時のみ、アイコンを表示するように改良した
- ListItemにおけるアイコン表示を参考にした
- アイコンの下までhover時の線が出るとBad UIだと思ったのでアイコンは独立させた

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-14 16 32 12](https://user-images.githubusercontent.com/24960403/76677555-ff7c4480-6612-11ea-8ee3-e03ef594d358.png)

