### PR TITLE
[/flow] SPレイアウトでも印刷ボタンのラベルがスクリーンリーダーで読み上げられるようにする

### DIFF
--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -36,7 +36,15 @@ export default {
 .PrinterButton {
   &-Text {
     @include lessThan($small) {
-      display: none;
+      position: absolute !important;
+      height: 1px !important;
+      width: 1px !important;
+      padding: 0 !important;
+      border: 0 !important;
+      white-space: nowrap !important;
+      overflow: hidden !important;
+      clip: rect(1px, 1px, 1px, 1px) !important;
+      clip-path: inset(50%) !important;
     }
   }
   &-PrinterIcon {

--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -32,7 +32,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .PrinterButton {
   &-Text {
     @include lessThan($small) {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1415 

## 📝 関連する issue / Related Issues
- #1411

## ⛏ 変更内容 / Details of Changes
- style 要素を scoped にした
- https://a11yproject.com/posts/how-to-hide-content/ を参考に visually-hidden なクラスに変更した

## 📸 スクリーンショット / Screenshots

macOS 10.15 Catalina / VoiceOver でアクセスしているキャプチャです。テキストは表示されていませんが、VO字幕で「印刷する」が表示され、音声でも読み上げられています。

![スクリーンショット 2020-03-14 18 42 59](https://user-images.githubusercontent.com/710216/76679980-4d4f7780-6628-11ea-8c04-45004b4543dc.png)
