### PR TITLE
[/flow] SPレイアウトで「新型コロナ受診相談窓口へ」のページ内リンクを押した時にURLにハッシュをつける

### DIFF
--- a/components/flow/FlowSp.vue
+++ b/components/flow/FlowSp.vue
@@ -30,6 +30,8 @@
 <i18n src="./FlowSp.i18n.json"></i18n>
 
 <script>
+import VueScrollTo from 'vue-scrollto'
+
 import FlowSpPast from './FlowSpPast.vue'
 import FlowSpGeneral from './FlowSpGeneral.vue'
 import FlowSpElder from './FlowSpElder.vue'
@@ -47,6 +49,13 @@ export default {
     FlowSpAdvisory,
     FlowSpAccording,
     FlowSpHospitalized
+  },
+  mounted() {
+    // ハッシュつきのURLにアクセスされたらすぐに遷移する
+    const hash = this.$route.hash
+    if (hash !== '') {
+      VueScrollTo.scrollTo(hash, 1000, { offset: -72 }) // NOTE: nuxt.config.tsと同じoffset
+    }
   }
 }
 </script>

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -64,7 +64,10 @@
     </p>
 
     <a
-      v-scroll-to="'#consult'"
+      v-scroll-to="{
+        el: '#consult',
+        onDone: onDoneScroll
+      }"
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
@@ -77,6 +80,7 @@
 <i18n src="./FlowSpElder.i18n.json"></i18n>
 
 <script lang="ts">
+import { onDoneScroll } from '@/utils/vueScrollTo'
 import AccessibleIcon from '@/static/flow/responsive/accessible.svg'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 import DirectionsWalkIcon from '@/static/flow/responsive/directions_walk.svg'
@@ -88,7 +92,8 @@ export default {
     ArrowForwardIcon,
     DirectionsWalkIcon,
     PregnantWomanIcon
-  }
+  },
+  methods: { onDoneScroll }
 }
 </script>
 

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -48,7 +48,10 @@
       </i18n>
     </p>
     <a
-      v-scroll-to="'#consult'"
+      v-scroll-to="{
+        el: '#consult',
+        onDone: onDoneScroll
+      }"
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
@@ -61,10 +64,12 @@
 <i18n src="./FlowSpGeneral.i18n.json"></i18n>
 
 <script lang="ts">
+import { onDoneScroll } from '@/utils/vueScrollTo'
 import HumanIcon from '@/static/flow/responsive/accessibility.svg'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 export default {
-  components: { HumanIcon, ArrowForwardIcon }
+  components: { HumanIcon, ArrowForwardIcon },
+  methods: { onDoneScroll }
 }
 </script>
 

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -111,7 +111,10 @@
       </p>
     </div>
     <a
-      v-scroll-to="'#consult'"
+      v-scroll-to="{
+        el: '#consult',
+        onDone: onDoneScroll
+      }"
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
@@ -124,6 +127,7 @@
 <i18n src="./FlowSpPast.i18n.json"></i18n>
 
 <script lang="ts">
+import { onDoneScroll } from '@/utils/vueScrollTo'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 
 export default {
@@ -135,7 +139,8 @@ export default {
     langsWithoutFlowTitle() {
       return ['en', 'zh-cn', 'zh-tw']
     }
-  }
+  },
+  methods: { onDoneScroll }
 }
 </script>
 

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -35,7 +35,10 @@
     </div>
 
     <a
-      v-scroll-to="'#consult'"
+      v-scroll-to="{
+        el: '#consult',
+        onDone: onDoneScroll
+      }"
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
@@ -48,12 +51,14 @@
 <i18n src="./FlowSpSuspect.i18n.json"></i18n>
 
 <script lang="ts">
+import { onDoneScroll } from '@/utils/vueScrollTo'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 import PhoneIcon from '@/static/flow/responsive/phone.svg'
 import SentimentIcon from '@/static/flow/responsive/sentiment_very_dissatisfied.svg'
 
 export default {
-  components: { ArrowForwardIcon, PhoneIcon, SentimentIcon }
+  components: { ArrowForwardIcon, PhoneIcon, SentimentIcon },
+  methods: { onDoneScroll }
 }
 </script>
 

--- a/utils/vueScrollTo.ts
+++ b/utils/vueScrollTo.ts
@@ -1,0 +1,10 @@
+/**
+ * v-scroll-to完了時のcallback
+ * ページ内リンクであることを前提に、URLにハッシュを付与する
+ */
+export const onDoneScroll = (element: Element) => {
+  const elementHasId = typeof element.id !== 'undefined'
+  if (elementHasId) {
+    history.pushState(null, '', `#${element.id}`)
+  }
+}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/1421

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/1411

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- スマートフォン向けのFlowページで、「新型コロナ受診相談窓口へ」リンクを押したときに、URLに`#consult`というハッシュを付与します
- さらに、`/flow/#consult`に直接アクセスしてきた場合は、「新型コロナ受診相談窓口 帰国者・接触者電話相談センター」のコンポーネントを見せるようにします。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

![scrnshot](https://user-images.githubusercontent.com/10768439/76683129-f015ef00-6644-11ea-8484-381b320ef42a.gif)
