### PR TITLE
ローディング表示のif-else分岐を改善して、titleやOGPが反映されるようにする

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,10 +1,12 @@
 <template>
   <v-app class="app">
-    <div v-if="loading" class="loader">
-      <img src="/logo.svg" alt="東京都" />
-      <scale-loader color="#00A040" />
-    </div>
-    <div v-else-if="hasNavigation" class="appContainer">
+    <v-overlay v-if="loading" color="#F8F9FA" opacity="1" z-index="9999">
+      <div class="loader">
+        <img src="/logo.svg" alt="東京都" />
+        <scale-loader color="#00A040" />
+      </div>
+    </v-overlay>
+    <div v-if="hasNavigation" class="appContainer">
       <div class="naviContainer">
         <SideNavigation
           :is-navi-open="isOpenNavigation"
@@ -92,7 +94,6 @@ export default Vue.extend({
   background-color: inherit !important;
 }
 .embed {
-
   .container {
     padding: 0 !important;
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1414

## 📝 関連する issue / Related Issues
- #1401
- #1063 
- #1071 
- #1382 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ローディング表示のif-elseブロックを調整しました
- ローディング表示を画面全体にオーバーレイするため、v-overlayを用いて表示を構成しました
    - cf. [Overlay component — Vuetify\.js](https://vuetifyjs.com/ja/components/overlays/)

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
以下のようにローディング表示されることは確認しました。
![Image from Gyazo](https://i.gyazo.com/a8672e71b900513837d7ffb551a92400.gif)

また、generateした静的ページにもタイトルが反映されていることは確認しました。
![image](https://user-images.githubusercontent.com/1389856/76686235-42fba080-665d-11ea-905c-6316ddeca87b.png)
