### PR TITLE
OGPイメージにタイムスタンプを付与

### DIFF
--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -167,7 +167,9 @@ export default {
   },
   head() {
     const url = 'https://stopcovid19.metro.tokyo.lg.jp'
-    const ogpImage = url + '/ogp-' + this.$route.params.card + '.png'
+    const timestamp = new Date().getTime()
+    const ogpImage =
+      url + '/ogp-' + this.$route.params.card + '.png?t=' + timestamp
     const description =
       this.updatedAt +
       ' 更新 | ' +


### PR DESCRIPTION
各種SNSのキャッシュが飛ばないため