### PR TITLE
[/flow] English表示の時、769〜959pxの画面幅におけるテキストの表示調整

### DIFF
--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -135,8 +135,8 @@ export default {
     margin-bottom: 36px;
   }
   &Lower {
-    grid-template-columns: repeat(2, 1fr);
-    -ms-grid-columns: 1fr 12px 1fr;
+    grid-template-columns: repeat(2, calc(50% - 6px));
+    -ms-grid-columns: calc(50% - 6px) 12px calc(50% - 6px);
     grid-template-rows: repeat(3, auto);
     -ms-grid-rows: auto 12px auto 12px auto;
     // HACK: IEでGridの順番がうまくいかない対応

--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -90,6 +90,8 @@ export default {
   @include card-container();
   padding: 20px;
   margin-bottom: 20px;
+  word-break: break-word;
+  hyphens: auto;
   > h3 {
     color: $gray-2;
     font-size: 1.5rem;

--- a/components/flow/FlowSp.vue
+++ b/components/flow/FlowSp.vue
@@ -58,6 +58,8 @@ export default {
   @include card-container();
   padding: 20px;
   margin-bottom: 20px;
+  word-break: break-word;
+  hyphens: auto;
   > h3 {
     color: $gray-2;
     font-size: 1.5rem;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/1438

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/1411

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- Lang: Englishのとき、FlowPcで画面幅が小さいときに文字がCardからはみ出していた
- 適切な位置で行の折返し・ハイフネーションを行なうようにした
- それでもスタイルが崩れてしまっている箇所のSCSSを修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

Chromeにて横幅779px:
![localhost_3000_en_flow](https://user-images.githubusercontent.com/10768439/76693554-86c8c700-66aa-11ea-9070-0eeddcdab96e.png)
