### PR TITLE
CONTRIBUTORS.md の整理

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,107 +3,107 @@ Tokyo Covid-19 response site contributors
 
 本サイトにご協力いただいた皆様
 
-| Name(link) | Contribution |
-| --- | --- |
-| [Hal Seki(Code for Japan)](https://github.com/halsk) | Project facilitation |
-| [Yu Uno(Cookpad Inc.)](https://twitter.com/saladdays) | UI/UX Design |
-| [Kenshiro Fujii(Cookpad Inc.)](https://twitter.com/kenshir0f) | UI Design / Frontend |
-| [Kazuki Imamura(Code for CAT)](https://code4cat.org/) | Coding |
-| [mikkame](https://github.com/mikkame) | Backend |
-| [Hiroaki Ishii](https://twitter.com/hiroishi0422) | Translation |
-| [osoken](https://github.com/osoken) | Coding |
-| [yokinist](https://github.com/yokinist) | Frontend |
-| [Hiroki Komamiya(Yahoo Japan Corp)](https://github.com/hkomamiy) | Data Visualization(Design) / Coding |
-| [Yuichi Nakamura（Yahoo! JAPAN Corp.）](https://twitter.com/sonatax) | Frontend |
-| Akane Suzuki | Translation |
-| [ocean3fish（Code for YOKOHAMA）](https://twitter.com/Shishamous) | Data Steward |
-| [Hayashi Noriko（Code for INZAI / Iinfosign, Inc.）](https://twitter.com/forestgtree) | Flow page Design |
-| [potato4d / Takuma HANATANI (LINE / ElevenBack LLC.)](https://twitter.com/potato4d) | Frontend / OSS Community Triage |
-| [daitasu(Code for Japan / STORES.jp)](https://twitter.com/daitasu) | Frontend |
-| [amotarao](https://github.com/amotarao) | Frontend |
-| [Taro Matsuzawa](https://twitter.com/smellman) (@smellman) | Coding |
-| [Riki Singh Khorana](https://www.linkedin.com/in/rikilele/) (@Rikilele) | Translations / A11y |
-| Koki Kobayashi | Translations |
-| Fujita Shu (@nard-tech) | Coding, i18n |
-| [kaizumaki](https://github.com/kaizumaki) ||
-| [Shigetaka Shirouchi](https://github.com/shgtkshruch) ||
-| [Kawokas](https://github.com/kawoka) ||
-| [Spenser Black](https://github.com/spenserblack) ||
-| [Jxck](https://github.com/Jxck) ||
-| [Takuma Hashimoto](https://github.com/af12066) ||
-| [takanakahiko](https://github.com/takanakahiko) ||
-| [DJ Yoko](https://github.com/DJYoko) ||
-| [MaySoMusician](https://github.com/MaySoMusician) ||
-| [Ryo Maeda](https://github.com/epaew) ||
-| [Tatsukichi](https://github.com/tatsuki26) ||
-| [Yusuke Hayashi](https://github.com/yhay81) ||
-| ken.okamura ||
-| [naoki-umeyama](https://github.com/naoki-umeyama) ||
-| [Kouki Narumi](https://github.com/sunecosuri) ||
-| [MOCHI*2](https://github.com/fussy113) ||
-| [Shun Kawahara](https://github.com/shun91) ||
-| [inductor](https://github.com/inductor) ||
-| [koji-koji](https://github.com/koji-koji) ||
-| [nokazn](https://github.com/nokazn) ||
-| [ya-mori](https://github.com/ya-mori) ||
-| [Kenta Yasuoka](https://github.com/rozeo) ||
-| [Soichi Masuda](https://github.com/masuP9) ||
-| [dafujii](https://github.com/dafujii) ||
-| [koizoom1](https://github.com/koizoom1) ||
-| [shotaro aono](https://github.com/shotaro) ||
-| [なりたけいすけ](https://github.com/narikei) ||
-| [Not yet](https://github.com/madana-1) ||
-| [Takahiro Nakatsu](https://github.com/tknakatsu) ||
-| [purin](https://github.com/puriso) ||
-| [0Delta](https://github.com/0Delta) ||
-| [178inaba](https://github.com/178inaba) ||
-| [Masaru Oinaga](https://github.com/Scstechr) ||
-| [Muneyuki Noguchi](https://github.com/mnogu) ||
-| [Munieru](https://github.com/munierujp) ||
-| [Shigeo Kitamura](https://github.com/shigeokitamura) ||
-| [Shun Sakai](https://github.com/sorairolake) ||
-| [Tasuku Suzuki](https://github.com/task-jp) ||
-| [Timothy Lin](https://github.com/timothylin) ||
-| [YanaPIIDXer](https://github.com/YanaPIIDXer) ||
-| [kuromoka](https://github.com/kuromoka) ||
-| [okawa-h](https://github.com/okawa-h) ||
-| [segur](https://github.com/segurvita) ||
-| [ufoo68](https://github.com/ufoo68) ||
-| [4geru koichi uchinishi ](https://github.com/4geru) ||
-| [Francis](https://github.com/francisfuzz) ||
-| KatsuyaAkasaka ||
-| [Keiichi Watanabe](https://github.com/keiichiw) ||
-| [Kentaro Ohkouchi](https://github.com/nanasess) ||
-| [Masatoshi Hanai](https://github.com/hanahana0201) ||
-| [Satoshi KOJIMA](https://github.com/skoji) ||
-| [Shingo INADA](https://github.com/inada-s) ||
-| [Shinobu Hayashi](https://github.com/Shinyaigeek) ||
-| [Shotaro Ishihara](https://github.com/upura) ||
-| [TASUKU](https://github.com/task-k0414) ||
-| [Takuho NAKANO](https://github.com/takotakot) ||
-| [Yfuruchin](https://github.com/Yfuruchin) ||
-| [Yoshihisa Kaino](https://github.com/yoshi1125hisa) ||
-| [akrolayer](https://github.com/akrolayer) ||
-| [blue9](https://github.com/cyblue9) ||
-| [kebhr](https://github.com/kebhr) ||
-| [mikan3rd](https://github.com/mikan3rd) ||
-| [rymiyamoto](https://github.com/rymiyamoto) ||
-| [saboyutaka](https://github.com/saboyutaka) ||
-| [yuik](https://github.com/yu1k) ||
-| [上野 嘉之](https://github.com/44u) ||
-|[Yusaku Ohno](https://twitter.com/YusakuHip)| Frontend |
-| tatsuki26 ([@tatsuki26](https://github.com/tatsuki26)) | Coding |
-| Kouki Okajima ([@Okahill](https://github.com/Okahill)) | Coding |
-| Tomoki Shigeta ([@matoruru](https://github.com/matoruru)) | Coding |
-| [Shun Kawahara](https://twitter.com/kojo_73) ([@shun91](https://github.com/shun91)) | Frontend |
-| [Yuichi Yokoyama](https://twitter.com/dj_yoko) ([@DJYoko](https://github.com/DJYoko)) | Coding |
-| [dafujii](https://twitter.com/dafujii_k) ([@dafujii](https://github.com/dafujii)) | Kaizen |
-| [7iva](https://twitter.com/_7iva) ([@7iva](https://github.com/7iva)) | Translations |
-| Jun Shindo ([@jay-es](https://github.com/jay-es)) | Frontend |
-| [Koki Fukushima](https://github.com/f-koki) ||
-| [mkfsn](https://twitter.com/mkfsn) ([@mkfsn](https://github.com/mkfsn)) | Coding, i18n |
-| [Thien Le Vinh](https://github.com/omygodvt95) | Translation |
-| -add your name here!- | -what did you do?- |
+| Name (link) | GitHub | Twitter | Contribution |
+| --- | --- | --- | --- |
+| Hal Seki (Code for Japan) | [@halsk](https://github.com/halsk) | | Project facilitation |
+| Yu Uno (Cookpad Inc.) | | [@saladdays](https://twitter.com/saladdays) | UI/UX Design |
+| Kenshiro Fujii (Cookpad Inc.) | | [@kenshir0f](https://twitter.com/kenshir0f) | UI Design / Frontend |
+| [Kazuki Imamura (Code for CAT)](https://code4cat.org/) | |  | Coding |
+| mikkame | [@mikkame](https://github.com/mikkame) |  | Backend |
+| Hiroaki Ishii | | [@hiroishi0422](https://twitter.com/hiroishi0422) | Translation |
+| osoken | [@osoken](https://github.com/osoken) | | Coding |
+| yokinist | [@yokinist](https://github.com/yokinist) | | Frontend |
+| Hiroki Komamiya (Yahoo Japan Corp.) | [@hkomamiy](https://github.com/hkomamiy) | | Data Visualization(Design) / Coding |
+| Yuichi Nakamura (Yahoo! JAPAN Corp.) | | [@sonatax](https://twitter.com/sonatax) | Frontend |
+| Akane Suzuki | | | Translation |
+| ocean3fish（Code for YOKOHAMA）| | [@Shishamous](https://twitter.com/Shishamous) | Data Steward |
+| Hayashi Noriko (Code for INZAI / Iinfosign, Inc.) | | [@forestgtree](https://twitter.com/forestgtree) | Flow page Design |
+| potato4d / Takuma HANATANI (LINE / ElevenBack LLC.) | | [@potato4d](https://twitter.com/potato4d) | Frontend / OSS Community Triage |
+| daitasu(Code for Japan / STORES.jp) | | [@daitasu](https://twitter.com/daitasu) | Frontend |
+| amotarao | [@amotarao](https://github.com/amotarao) | | Frontend |
+| Taro Matsuzawa | [@smellman](https://github.com/smellman) | [@smellman](https://twitter.com/smellman) | Coding |
+| [Riki Singh Khorana](https://www.linkedin.com/in/rikilele/) | [@Rikilele](https://github.com/Rikilele) | | Translations / A11y |
+| Koki Kobayashi | | | Translations |
+| Fujita Shu | [@nard-tech](https://github.com/nard-tech) | | Coding, i18n |
+| kaizumaki | [@kaizumaki](https://github.com/kaizumaki) | | |
+| Shigetaka Shirouchi | [@shgtkshruch](https://github.com/shgtkshruch) | | |
+| Kawokas | [@kawoka](https://github.com/kawoka) | | |
+| Spenser Black | [@spenserblack](https://github.com/spenserblack) | | |
+| Jxck | [@Jxck](https://github.com/Jxck) | | |
+| Takuma Hashimoto | [@af12066](https://github.com/af12066) | | |
+| takanakahiko | [@takanakahiko](https://github.com/takanakahiko) | | |
+| DJ Yoko | [@DJYoko](https://github.com/DJYoko) | | |
+| MaySoMusician | [@MaySoMusician](https://github.com/MaySoMusician) | | |
+| Ryo Maeda | [@epaew](https://github.com/epaew) | | |
+| Tatsukichi | [@tatsuki26](https://github.com/tatsuki26) | | |
+| Yusuke Hayashi | [@yhay81](https://github.com/yhay81) | | |
+| ken.okamura | | | |
+| naoki-umeyama | [@naoki-umeyama](https://github.com/naoki-umeyama) | | |
+| Kouki Narumi | [@sunecosuri](https://github.com/sunecosuri) | | |
+| MOCHI*2 | [@fussy113](https://github.com/fussy113) | | |
+| Shun Kawahara | [@shun91](https://github.com/shun91) | | |
+| inductor | [@inductor](https://github.com/inductor) | | |
+| koji-koji | [@koji-koji](https://github.com/koji-koji) | | |
+| nokazn | [@nokazn](https://github.com/nokazn) | | |
+| ya-mori | [@ya-mori](https://github.com/ya-mori) | | |
+| Kenta Yasuoka | [@rozeo](https://github.com/rozeo) | | |
+| Soichi Masuda | [@masuP9](https://github.com/masuP9) | | |
+| dafujii | [@dafujii](https://github.com/dafujii) | | |
+| koizoom1 | [@koizoom1](https://github.com/koizoom1) | | |
+| shotaro aono | [@shotaro](https://github.com/shotaro) | | |
+| なりたけいすけ | [@narikei](https://github.com/narikei) ||
+| Not yet | [@madana-1](https://github.com/madana-1) | | |
+| Takahiro Nakatsu | [@tknakatsu](https://github.com/tknakatsu) | | |
+| purin | [@puriso](https://github.com/puriso) | | |
+| 0Delta | [@0Delta](https://github.com/0Delta) | | |
+| 178inaba | [@178inaba](https://github.com/178inaba) | | |
+| Masaru Oinaga | [@Scstechr](https://github.com/Scstechr) | | |
+| Muneyuki Noguchi | [@mnogu](https://github.com/mnogu) | | |
+| Munieru | [@munierujp](https://github.com/munierujp) | | |
+| Shigeo Kitamura | [@shigeokitamura](https://github.com/shigeokitamura) | | |
+| Shun Sakai | [@sorairolake](https://github.com/sorairolake) | | |
+| Tasuku Suzuki | [@task-jp](https://github.com/task-jp) | | |
+| Timothy Lin | [@timothylin](https://github.com/timothylin) | | |
+| YanaPIIDXer | [@YanaPIIDXer](https://github.com/YanaPIIDXer) | | |
+| kuromoka | [@kuromoka](https://github.com/kuromoka) | | |
+| okawa-h | [@okawa-h](https://github.com/okawa-h) | | |
+| segur | [@segurvita](https://github.com/segurvita) | | |
+| ufoo68 | [@ufoo68](https://github.com/ufoo68) | | |
+| 4geru koichi uchinishi | [@4geru](https://github.com/4geru) | | |
+| Francis | [@francisfuzz](https://github.com/francisfuzz) | | |
+| KatsuyaAkasaka | | | |
+| Keiichi Watanabe | [@keiichiw](https://github.com/keiichiw) | | |
+| Kentaro Ohkouchi | [@nanasess](https://github.com/nanasess) | | |
+| Masatoshi Hanai | [@hanahana0201](https://github.com/hanahana0201) | | |
+| Satoshi KOJIMA | [@skoji](https://github.com/skoji) | | |
+| Shingo INADA | [@inada-s](https://github.com/inada-s) | | |
+| Shinobu Hayashi | [@Shinyaigeek](https://github.com/Shinyaigeek) | | |
+| Shotaro Ishihara | [@upura](https://github.com/upura) | | |
+| TASUKU | [@task-k0414](https://github.com/task-k0414) | | |
+| Takuho NAKANO | [@takotakot](https://github.com/takotakot) | | |
+| Yfuruchin | [@Yfuruchin](https://github.com/Yfuruchin) | | |
+| Yoshihisa Kaino | [@yoshi1125hisa](https://github.com/yoshi1125hisa) | | |
+| akrolayer | [@akrolayer](https://github.com/akrolayer) | | |
+| blue9 | [@cyblue9](https://github.com/cyblue9) | | |
+| kebhr | [@kebhr](https://github.com/kebhr) | | |
+| mikan3rd | [@mikan3rd](https://github.com/mikan3rd) | | |
+| rymiyamoto | [@rymiyamoto](https://github.com/rymiyamoto) | | |
+| saboyutaka | [@saboyutaka](https://github.com/saboyutaka) | | |
+| yuik | [@yu1k](https://github.com/yu1k) | | |
+| 上野 嘉之 | [@44u](https://github.com/44u) ||
+| Yusaku Ohno | | [@YusakuHip](https://twitter.com/YusakuHip)| Frontend |
+| tatsuki26 | [@tatsuki26](https://github.com/tatsuki26) | | Coding |
+| Kouki Okajima | [@Okahill](https://github.com/Okahill) | | Coding |
+| Tomoki Shigeta | [@matoruru](https://github.com/matoruru) | | Coding |
+| Shun Kawahara | [@shun91](https://github.com/shun91) | [@kojo_73](https://twitter.com/kojo_73) | Frontend |
+| Yuichi Yokoyama | [@dj_yoko](https://twitter.com/dj_yoko) | [@DJYoko](https://github.com/DJYoko) | Coding |
+| dafujii | [@dafujii_k](https://twitter.com/dafujii_k) | [@dafujii](https://github.com/dafujii) | Kaizen |
+| 7iva | [@7iva](https://github.com/7iva) | [@7iva](https://twitte@r.com/_7iva) | Translations |
+| Jun Shindo | [@jay-es](https://github.com/jay-es) | | Frontend |
+| Koki Fukushima | [@f-koki](https://github.com/f-koki) | | |
+| mkfsn | [@mkfsn](https://github.com/mkfsn) | [@mkfsn](https://twitter.com/mkfsn) | Coding, i18n |
+| Thien Le Vinh | [@omygodvt95](https://github.com/omygodvt95) | | Translation |
+| -add your name here!- | -GitHub account- | -Twitter account- | -what did you do?- |
 
 ご協力に感謝です！！！
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -103,8 +103,11 @@ Tokyo Covid-19 response site contributors
 | Koki Fukushima | [@f-koki](https://github.com/f-koki) | | |
 | mkfsn | [@mkfsn](https://github.com/mkfsn) | [@mkfsn](https://twitter.com/mkfsn) | Coding, i18n |
 | Thien Le Vinh | [@omygodvt95](https://github.com/omygodvt95) | | Translation |
-| -add your name here!- | -GitHub account- | -Twitter account- | -what did you do?- |
 
 ご協力に感謝です！！！
+
+お名前の掲載をご希望の方は，[#654](https://github.com/tokyo-metropolitan-gov/covid19/issues/654)にコメントをお願いします．
+
+If you want to add your name, please comment on [#654](https://github.com/tokyo-metropolitan-gov/covid19/issues/654).
 
 ![nyan](https://i.gyazo.com/f04e7468ea6e4bb6e87f6817fea980f9.gif)


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #654

## ⛏ 変更内容 / Details of Changes
- GitHub アカウントへのリンクなど，全体的に統一感がないため，テーブルの構造を整理
    -   名前，GitHub，Twitter，役割の4列にした
- 名前を追加したいときの案内（#654 へのリンク）を追加
