### PR TITLE
[i18n] 言語名表記の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![東京都 新型コロナウイルス感染症対策サイト](https://user-images.githubusercontent.com/1301149/75629392-1d19d900-5c25-11ea-843d-2d4376e3a560.png)](https://stopcovid19.metro.tokyo.lg.jp/)
 
-### 日本語 | [English](./README_EN.md) | [Spanish](./README_ES.md) | [Korean](./README_KO.md) | [Chinese (Taiwan)](./README_ZH_TW.md) | [Chinese (Simplified)](./README_ZH_CN.md) | [Vietnamese](./README_VI.md)
+### 日本語 | [English](./README_EN.md) | [Español](./README_ES.md) | [한국어](./README_KO.md) | [繁體中文](./README_ZH_TW.md) | [简体中文](./README_ZH_CN.md) | [Tiếng Việt](./README_VI.md)
 
 ## 貢献の仕方
 Issues にあるいろいろな修正にご協力いただけると嬉しいです。

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -142,12 +142,12 @@ const config: Configuration = {
           },
           {
             code: 'zh-cn',
-            name: '簡体字',
+            name: '简体中文',
             iso: 'zh-CN'
           },
           {
             code: 'zh-tw',
-            name: '繁體字',
+            name: '繁體中文',
             iso: 'zh-TW'
           },
           {
@@ -158,7 +158,6 @@ const config: Configuration = {
           // ,
           // #1126, #872 (comment)
           // ポルトガル語は訳が揃っていないため非表示
-          // 「やさしい日本語」はコンポーネントが崩れるため非表示
           // {
           //   code: 'pt-BR',
           //   name: 'Portuguese',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1512
- close #1103

## ⛏ 変更内容 / Details of Changes
- 現状，言語選択のフォーム内で「簡体字」「繁体字」と表記されている箇所を「简体中文」「繁體中文」に変更
- https://github.com/tokyo-metropolitan-gov/covid19 で表示される各言語版 README へのリンクを，各言語の表記に修正

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-15 13 38 17](https://user-images.githubusercontent.com/23148331/76695404-3fe6cb80-66c2-11ea-9049-ca48581688a4.png)