### PR TITLE
フォントカラーのコントラスト確保

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -1,12 +1,12 @@
 // ==================
 // color
-$green-1: #00A040;
+$green-1: #008830;
 $green-2: #00B849;
 $green-3: #00D154;
 $green-4: #00EB5E;
 $gray-1: #333333;
 $gray-2: #4D4D4D;
-$gray-3: #808080;
+$gray-3: #707070;
 $gray-4: #D9D9D9;
 $gray-5: #F8F9FA;
 $white: #FFFFFF;

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -70,7 +70,7 @@
 .note {
   padding: 8px;
   font-size: 12px;
-  color: #808080;
+  color: $gray-3;
 }
 </style>
 

--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -3,7 +3,6 @@
     <v-btn
       class="PrinterButton"
       outlined
-      color="#00a040"
       href="/print/flow"
       target="_blank"
       @mouseover="mouseover"

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -219,7 +219,7 @@ export default {
   &-Heading {
     margin-top: 8px;
     font-size: 13px;
-    color: #898989;
+    color: #707070;
     padding: 0.5em 0;
     text-decoration: none;
     @include lessThan($small) {


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #1086 

## ⛏ 変更内容 / Details of Changes
- フォントのカラーについて違和感のない範囲でコントラスト向上

## 📸 スクリーンショット / Screenshots
![フォントのコントラスト向上](https://user-images.githubusercontent.com/32133/76695763-6c9ce200-66c6-11ea-861d-d5e39e642f39.png)
