### PR TITLE
お知らせの外部リンクアイコンが改行しないようにする

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -85,12 +85,13 @@ export default {
 
   &-item {
     &-anchor {
-      display: inline-flex;
+      display: inline-block;
       text-decoration: none;
       margin: 5px;
       font-size: 14px;
 
       @include lessThan($medium) {
+        display: flex;
         flex-wrap: wrap;
       }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1528

## 📝 関連する issue / Related Issues
- #804

## ⛏ 変更内容 / Details of Changes
- お知らせの外部リンクアイコンが改行しないようにする

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-03-15 20 48 03](https://user-images.githubusercontent.com/5207601/76700792-76423c00-66fe-11ea-9f15-a24cb1360255.png)

### After
![スクリーンショット 2020-03-15 20 47 35](https://user-images.githubusercontent.com/5207601/76700795-79d5c300-66fe-11ea-86c8-b4a4df40f38c.png)
