### PR TITLE
Language選択の位置を変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -9,13 +9,17 @@
         mdi-menu
       </v-icon>
       <nuxt-link :to="localePath('/')" class="SideNavigation-HeadingLink">
-        <h1 class="SideNavigation-Heading">
+        <h1 class="SideNavigation-Heading sp-flex">
+          <!-- 開発環境に入ったらレイアウトが崩れていたためsp-flex付けました。不要でしたら外します。-->
           <div class="SideNavigation-Logo">
             <img src="/logo.svg" :alt="$t('東京都')" />
           </div>
           {{ $t('新型コロナウイルス感染症') }}<br />{{ $t('対策サイト') }}
         </h1>
       </nuxt-link>
+      <div class="SideNavigation-LanguageMenu sp-none">
+        <LanguageSelector />
+      </div>
     </header>
     <v-divider class="SideNavigation-HeadingDivider" />
     <div class="sp-none" :class="{ open: isNaviOpen }">
@@ -38,9 +42,6 @@
             <v-divider v-show="item.divider" class="SideNavigation-Divider" />
           </v-container>
         </v-list>
-        <div class="SideNavigation-LanguageMenu">
-          <LanguageSelector />
-        </div>
       </nav>
       <v-footer class="SideNavigation-Footer">
         <div class="SideNavigation-SocialLinkContainer">
@@ -236,8 +237,7 @@ export default {
     margin: 12px 0;
   }
   &-LanguageMenu {
-    padding: 0 20px;
-    background: #fff;
+    padding-right: 20px;
   }
   &-Footer {
     padding: 20px;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="MainPage">
+    <LanguageSelector class="mb-3 pc-none" />
     <page-header
       :icon="headerItem.icon"
       :title="headerItem.title"
@@ -28,6 +29,7 @@
 <i18n src="./index.i18n.json"></i18n>
 
 <script>
+import LanguageSelector from '@/components/LanguageSelector.vue'
 import PageHeader from '@/components/PageHeader.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import StaticInfo from '@/components/StaticInfo.vue'
@@ -46,6 +48,7 @@ import AgencyCard from '@/components/cards/AgencyCard.vue'
 
 export default {
   components: {
+    LanguageSelector,
     PageHeader,
     WhatsNew,
     StaticInfo,
@@ -99,6 +102,11 @@ export default {
         padding: 4px 8px;
       }
     }
+  }
+}
+@include largerThan($small) {
+  .pc-none {
+    display: none;
   }
 }
 </style>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue -->

## 📝 関連する issue / Related Issues
- #1177 
- #1525

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 下のほうにあったSideNavigation-LanguageMenu削除
- SideNavigation-LanguageMenuをPCのみheader内に移動、styleも変更
- spはTopページのSideNavigation-HeadingContainer配下にLanguageSelectorを変更
- index.vueにpc-noneの追加、LanguageSelectorにmb-3クラス追加
- 開発環境に入った時点でSideNavigation-HeadingContaineのstyleが崩れていたので修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

# PC改善前
<img width="1397" alt="スクリーンショット 2020-03-15 18 02 09" src="https://user-images.githubusercontent.com/46955104/76701311-72fd7f00-6703-11ea-9a89-270e2ffca2fd.png">

# PC改善後
<img width="1394" alt="スクリーンショット 2020-03-15 20 52 53" src="https://user-images.githubusercontent.com/46955104/76701314-785ac980-6703-11ea-81ac-dd18e244100a.png">

# sp改善前
![ETI1rinWAAA8pGF](https://user-images.githubusercontent.com/46955104/76701324-94f70180-6703-11ea-92bf-023e141353a3.jpeg)

# sp改善後
<img width="344" alt="スクリーンショット 2020-03-15 20 53 33" src="https://user-images.githubusercontent.com/46955104/76701325-99bbb580-6703-11ea-8828-be6b087e1bc5.png">

