### PR TITLE
新型コロナウイルス感染症にかかる相談窓口について」をカッコ内の文字列にリンクさせるよう変更

### DIFF
--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -42,9 +42,9 @@ export default {
             this.$t('各保健所にご相談ください'),
             '<a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">' +
               this.$t(
-                '「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）' +
-                  '</a>'
-              )
+                '「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）'
+              ) +
+              '</a>'
           ].join('<br />')
         },
         {

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -40,8 +40,9 @@ export default {
           title: `2. ${this.$t('感染症を疑う場合の対応')}`,
           body: [
             this.$t('各保健所にご相談ください'),
-            this.$t('「新型コロナウイルス感染症にかかる相談窓口について」'),
-            '<a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html</a>'
+            this.$t(
+              '<a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）</a>'
+            )
           ].join('<br />')
         },
         {

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -40,9 +40,11 @@ export default {
           title: `2. ${this.$t('感染症を疑う場合の対応')}`,
           body: [
             this.$t('各保健所にご相談ください'),
-            this.$t(
-              '<a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）</a>'
-            )
+            '<a href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html" target="_blank" rel="noopener">' +
+              this.$t(
+                '「新型コロナウイルス感染症にかかる相談窓口について」（東京都福祉保健局）' +
+                  '</a>'
+              )
           ].join('<br />')
         },
         {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- [/parent] URLを直接表示せずに、リンク先タイトルにリンクしたほうが良さそう #1077
- close #1077

## ⛏ 変更内容 / Details of Changes
- /parentの「新型コロナウイルス感染症にかかる相談窓口について」がURLリンクになっているが、カッコ内の文字列にリンクさせるよう変更。

## 📸 スクリーンショット / Screenshots
修正前
<img width="1430" alt="スクリーンショット 2020-03-15 22 15 49" src="https://user-images.githubusercontent.com/22170902/76702226-975d5980-670b-11ea-8b48-ea7017a59f11.png">

修正後
<img width="1433" alt="スクリーンショット 2020-03-15 22 15 41" src="https://user-images.githubusercontent.com/22170902/76702223-93c9d280-670b-11ea-9d9e-308713a56975.png">