### PR TITLE
環境変数を.env.<env-name>ファイルに記述して@nuxtjs/dotenvで読み込む

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+GENERATE_ENV=development

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+GENERATE_ENV=production

--- a/config/development.ts
+++ b/config/development.ts
@@ -1,3 +1,0 @@
-module.exports = {
-  GENERATE_ENV: 'development'
-}

--- a/config/production.ts
+++ b/config/production.ts
@@ -1,3 +1,0 @@
-module.exports = {
-  GENERATE_ENV: 'production'
-}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,11 +2,9 @@ import { Configuration } from '@nuxt/types'
 const purgecss = require('@fullhuman/postcss-purgecss')
 const autoprefixer = require('autoprefixer')
 const environment = process.env.NODE_ENV || 'development'
-const envSet = require(`./config/${environment}.ts`)
 
 const config: Configuration = {
   mode: 'universal',
-  env: envSet,
   /*
    ** Headers of the page
    */
@@ -127,7 +125,7 @@ const config: Configuration = {
     '@nuxtjs/axios',
     '@nuxtjs/pwa',
     // Doc: https://github.com/nuxt-community/dotenv-module
-    '@nuxtjs/dotenv',
+    ['@nuxtjs/dotenv', { filename: `.env.${environment}` }],
     [
       'nuxt-i18n',
       {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1538

## 📝 関連する issue / Related Issues
- #1536
- #1537

## ⛏ 変更内容 / Details of Changes
- 環境変数を`config/<env-name>.ts`ファイルではなく`.env.<env-name>ファイル`に記述する
- `@nuxtjs/dotenv`モジュールのオプションで、ビルド時の環境によって読み込む`.env.<env-name>`ファイルを切り替える

## 参考リンク / See also
- [nuxt-community/dotenv-module: Loads your .env file into your application context](https://github.com/nuxt-community/dotenv-module)
