### PR TITLE
[改善]グラフのTwitterシェア時にグラフ,サイト名称等を追加

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -175,7 +175,17 @@ export default class DataView extends Vue {
   }
 
   twitter() {
-    const url = 'https://twitter.com/intent/tweet?url=' + this.permalink(true)
+    const url =
+      'https://twitter.com/intent/tweet?text=' +
+      this.title +
+      ' / ' +
+      this.$t('東京都') +
+      this.$t('新型コロナウイルス感染症') +
+      this.$t('対策サイト') +
+      '&url=' +
+      this.permalink(true) +
+      '&' +
+      'hashtags=StopCovid19JP'
     window.open(url)
   }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1628 

## ⛏ 変更内容 / Details of Changes
- before: グラフをTwitterする時にデフォルトではURLのみだった
- after: グラフをTwitterする時に以下の情報をデフォルトで入力された状態にした
  - グラフ名称
  - サイト名
  - URL
  - ハッシュタグ( `#StopCovid19JP` )

## 📸 スクリーンショット / Screenshots
#### 言語設定が日本語の場合
[![Image from Gyazo](https://i.gyazo.com/df1c6bd10864a8f103a047a4354aec73.png)](https://gyazo.com/df1c6bd10864a8f103a047a4354aec73)

#### 言語設定が英語の場合
[![Image from Gyazo](https://i.gyazo.com/2ee8ae575ad17030736ebbeace797d7f.png)](https://gyazo.com/2ee8ae575ad17030736ebbeace797d7f)

### 備考
グラフ名称とサイト名の間を ` | ` でやろうとしたらうまく読み取れずTwitterシェア画面でエラーが起きてしまうので ` / ` にした
[![Image from Gyazo](https://i.gyazo.com/512b8a0edbb1ff99fe1976077fed0f05.png)](https://gyazo.com/512b8a0edbb1ff99fe1976077fed0f05)