### PR TITLE
プルリクエスト作成時にGitHub Actionsでstylelintを実行

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -17,3 +17,14 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           eslint_flags: './**/*.{vue,ts,js}'
+  stylelint:
+    name: check_stylelint_error
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: stylelint review
+        uses: reviewdog/action-stylelint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          stylelint_input: '**/*.{css,scss,vue}'


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1616

## 📝 関連する issue / Related Issues
- #1600

## ⛏ 変更内容 / Details of Changes
- ESLintと同様に、プルリクエスト作成時にGitHub Actionsでstylelintを実行する

## 動作確認
https://github.com/munierujp-sandbox/covid19 で動作確認しました。

## プルリクエスト作成時の挙動
### sylelintのルールがないとき（現在の`development`ブランチの状態）
- stylelintが実行される
- stylelintによるリントが成功する

![スクリーンショット 2020-03-16 23 49 00](https://user-images.githubusercontent.com/20086673/76770187-ddd0b800-67e0-11ea-9ffc-9c36366527b6.png)

https://github.com/munierujp-sandbox/covid19/pull/4

### sylelintのルールがあり、違反しているファイルがあるとき
- stylelintが実行される
- stylelintによるリントが失敗する

![スクリーンショット 2020-03-16 23 49 06](https://user-images.githubusercontent.com/20086673/76770210-e6c18980-67e0-11ea-9a47-9eb3b6e8ca26.png)

https://github.com/munierujp-sandbox/covid19/pull/3