### PR TITLE
Vuetr のエラーが出ないよう，NoScript コンポーネントに export の記述を追加する

### DIFF
--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -57,3 +57,11 @@
   color: rgba(0, 0, 0, 0.87);
 }
 </style>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  //
+})
+</script>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1664

## ⛏ 変更内容 / Details of Changes
- #1664 記載の通り，`components/NoScript.vue` が原因で，VSCode で `layouts/default.vue` を開いたときに Vuetr による警告（cf. スクリーンショット）が表示されるため，警告が出ないよう NoScript に export の設定を追加する．

**参考**: https://github.com/vuejs/vetur/issues/1187#issuecomment-593568605

## 📸 スクリーンショット / Screenshots
<img width="1003" alt="スクリーンショット 2020-03-17 02 07 47" src="https://user-images.githubusercontent.com/23148331/76783203-c996b600-67f4-11ea-9bcd-0e17ddd16dce.png">
