### PR TITLE
Add Thai (th) language to nuxt i18n config

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -43,6 +43,12 @@ export default {
       iso: 'ko-KR',
       file: 'ko.json'
     },
+    {
+      code: 'th',
+      name: 'ภาษาไทย',
+      iso: 'th-TH',
+      file: 'th.json'
+    },
     // #1126, #872 (comment)
     // ポルトガル語は訳が揃っていないため非表示
     // {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1696 

## ⛏ 変更内容 / Details of Changes
- Add Thai (th) language data to `nuxt-i18n.config.ts`, so it can be selected in the language selector UI
<img width="245" alt="Screenshot 2020-03-18 at 09 05 11" src="https://user-images.githubusercontent.com/128572/76945071-f08ae000-68f9-11ea-883d-8a851074cbbe.png">

- Thai language is now 100% translated in https://www.transifex.com/stopcovid19-tokyo/stopcovid19tokyo/language/th/ and merged in #1963, #2048.

