### PR TITLE
「検査陽性者の状況」がやさしいにほんごの場合に崩れている

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -192,7 +192,7 @@ export default Vue.extend({
   }
 }
 .box {
-  $box-height: 170px;
+  $box-height: 200px;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -346,21 +346,21 @@ export default Vue.extend({
 
 // variables.scss Breakpoints: huge
 @include lessThan(1440) {
-  @include variation(1440, 3, 14, 180, 35);
+  @include variation(1440, 3, 14, 210, 45);
 }
 
 // Vuetify Breakpoints: Large
 @include lessThan(1263) {
-  @include variation(1263, 2, 12, 150, 24);
+  @include variation(1263, 2, 12, 240, 60);
 }
 
 // Vuetify Breakpoints: Small
 @include lessThan(959) {
-  @include variation(960, 4, 16, 250, 40);
+  @include variation(960, 4, 16, 360, 60);
 }
 
 // Vuetify Breakpoints: Extra Small
 @include lessThan(599) {
-  @include variation(600, 3, 14, 200, 35);
+  @include variation(600, 3, 14, 240, 40);
 }
 </style>

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -361,6 +361,6 @@ export default Vue.extend({
 
 // Vuetify Breakpoints: Extra Small
 @include lessThan(599) {
-  @include variation(600, 3, 14, 240, 40);
+  @include variation(600, 3, 14, 360, 90);
 }
 </style>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1698 

## 📝 関連する issue / Related Issues
#1520 （追記しました、メンションありがとうございます）

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 各画面サイズに対応するboxの高さを調整
  - 数値を変更して、感覚で調整しています。日本語の場合でも不自然に高さが高くなりすぎないように配慮していますが、若干余白が大きくなっています。他に良い方法があるかもしれません。

## 📸 スクリーンショット / Screenshots
▼修正前-iPhoneX-やさしいにほんご
<img width="751" alt="修正前-iPhoneX-やさしいにほんご" src="https://user-images.githubusercontent.com/19996540/76857086-9bc77500-68b9-11ea-8886-ded80dd63f0d.png">

▼修正後-iPhoneX-やさしいにほんご
<img width="376" alt="修正後-iPhoneX-やさしいにほんご" src="https://user-images.githubusercontent.com/19996540/76857100-a3871980-68b9-11ea-882c-0d77304d4da4.png">

▼修正後-iPhoneX-日本語
<img width="357" alt="修正後-iPhoneX-日本語" src="https://user-images.githubusercontent.com/19996540/76857120-a97cfa80-68b9-11ea-8166-2429ffaddc62.png">

▼修正後-iPhone5-SE-やさしいにほんご
<img width="402" alt="修正後-iPhone5-SE-やさしいにほんご" src="https://user-images.githubusercontent.com/19996540/76857132-aeda4500-68b9-11ea-83bc-10897655d8b3.png">
