### PR TITLE
積み上げ棒グラフにborderColorとborderWidthを設定

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -48,6 +48,8 @@ type Computed = {
       label: string
       data: number[]
       backgroundColor: string
+      borderColor: string
+      borderWidth: object
     }[]
   }
   displayOption: any
@@ -119,7 +121,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           return {
             label: this.agencies[index] as string,
             data: item.data,
-            backgroundColor: colors[index] as string
+            backgroundColor: colors[index] as string,
+            borderColor: '#ffffff',
+            borderWidth: {left: 0, top: 2, right: 0, bottom: 0}
           }
         })
       }

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -117,8 +117,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const colors = ['#008b41', '#63c765', '#a6e29f']
       const borderColor = '#ffffff'
       const borderWidth = [
-        { left: 0, top: 2, right: 0, bottom: 0 },
-        { left: 0, top: 2, right: 0, bottom: 0 },
+        { left: 0, top: 1, right: 0, bottom: 0 },
+        { left: 0, top: 1, right: 0, bottom: 0 },
         { left: 0, top: 0, right: 0, bottom: 0 }
       ]
       return {

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -115,6 +115,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   computed: {
     displayData() {
       const colors = ['#008b41', '#63c765', '#a6e29f']
+      const borderColor = '#ffffff'
+      const borderWidth = [
+        { left: 0, top: 2, right: 0, bottom: 0 },
+        { left: 0, top: 2, right: 0, bottom: 0 },
+        { left: 0, top: 0, right: 0, bottom: 0 }
+      ]
       return {
         labels: this.chartData.labels as string[],
         datasets: this.chartData.datasets.map((item, index) => {
@@ -122,8 +128,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             label: this.agencies[index] as string,
             data: item.data,
             backgroundColor: colors[index] as string,
-            borderColor: '#ffffff',
-            borderWidth: {left: 0, top: 2, right: 0, bottom: 0}
+            borderColor,
+            borderWidth: borderWidth[index]
           }
         })
       }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -61,7 +61,8 @@ type Computed = {
       label: string
       data: number[]
       backgroundColor: string
-      borderWidth: number
+      borderColor: string
+      borderWidth: object
     }[]
   }
   options: {
@@ -163,6 +164,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayData() {
       const colorArray = ['#00A040', '#00D154']
+      const borderColor = '#ffffff'
+      const borderWidth = {left: 0, top: 2, right: 0, bottom: 0}
       if (this.dataKind === 'transition') {
         return {
           labels: this.labels,
@@ -171,7 +174,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               label: this.items[index],
               data: item,
               backgroundColor: colorArray[index],
-              borderWidth: 0
+              borderColor: borderColor,
+              borderWidth: borderWidth
             }
           })
         }
@@ -183,7 +187,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             label: this.items[index],
             data: this.cumulative(item),
             backgroundColor: colorArray[index],
-            borderWidth: 0
+            borderColor: borderColor,
+            borderWidth: borderWidth
           }
         })
       }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -165,7 +165,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayData() {
       const colorArray = ['#00A040', '#00D154']
       const borderColor = '#ffffff'
-      const borderWidth = {left: 0, top: 2, right: 0, bottom: 0}
+      const borderWidth = [
+        { left: 0, top: 2, right: 0, bottom: 0 },
+        { left: 0, top: 0, right: 0, bottom: 0 }
+      ]
       if (this.dataKind === 'transition') {
         return {
           labels: this.labels,
@@ -174,8 +177,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               label: this.items[index],
               data: item,
               backgroundColor: colorArray[index],
-              borderColor: borderColor,
-              borderWidth: borderWidth
+              borderColor,
+              borderWidth: borderWidth[index]
             }
           })
         }
@@ -187,8 +190,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             label: this.items[index],
             data: this.cumulative(item),
             backgroundColor: colorArray[index],
-            borderColor: borderColor,
-            borderWidth: borderWidth
+            borderColor,
+            borderWidth: borderWidth[index]
           }
         })
       }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -166,7 +166,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const colorArray = ['#00A040', '#00D154']
       const borderColor = '#ffffff'
       const borderWidth = [
-        { left: 0, top: 2, right: 0, bottom: 0 },
+        { left: 0, top: 1, right: 0, bottom: 0 },
         { left: 0, top: 0, right: 0, bottom: 0 }
       ]
       if (this.dataKind === 'transition') {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1730 

## 📝 関連する issue / Related Issues
- #1172 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- AgencyBarChartとTimeStackedBarChartにborderColorとborderWidthを設定

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-18 17 36 43](https://user-images.githubusercontent.com/14883063/76941527-901e9180-693f-11ea-84d0-a6d862892937.png)
![スクリーンショット 2020-03-18 17 36 54](https://user-images.githubusercontent.com/14883063/76941545-96147280-693f-11ea-9c91-566c973ae892.png)
![スクリーンショット 2020-03-18 17 37 14](https://user-images.githubusercontent.com/14883063/76941570-9f054400-693f-11ea-8156-685a50b75bc3.png)
