### PR TITLE
fix #1745 言語選択プルダウンでクリックできない場所がある

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -69,10 +69,9 @@ export default class LanguageSelector extends Vue {
       width: 100%;
       height: 28px;
       background: transparent;
-      padding-left: 76px;
+      padding-left: 60px;
       color: #333;
-      font-size: 16px;
-      transform: scale(0.75);
+      font-size: 0.85rem;
       transform-origin: center left;
       box-sizing: border-box;
       cursor: pointer;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1745

## 📝 関連する issue / Related Issues
- #1745 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- styleを変更。select要素のwidthを100%のままとし、transformを削除。文字サイズを16px→0.85remにした
- PR 1748の不要ファイルを削除したやりなおしです。

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/4400857/76934656-e0432700-6932-11ea-8d58-95383b200621.png)
- iPhone8 iOS13.3.1上のSafari/ChromeおよびiPad Pro iOS13.3.1 Safari/Chromeにて #1204 を再現しないことを確認。
