### PR TITLE
fix: 「心配なときに」新型コロナ外来（帰国者・接触者外来）翻訳差し替え

### DIFF
--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -13,7 +13,8 @@
     </div>
     <div :class="$style.Row">
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
-        <p :class="$style.Outpatient">
+        <!-- 英訳の場合は非表示にする -->
+        <p v-if="$i18n.locale !== 'en'" :class="$style.Outpatient">
           {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
         </p>
         <p :class="$style.Judge">

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -13,13 +13,19 @@
     </div>
     <div :class="$style.Row">
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
-        <!-- 英訳の場合は非表示にする -->
-        <p v-if="$i18n.locale !== 'en'" :class="$style.Outpatient">
-          {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
-        </p>
-        <p :class="$style.Judge">
-          {{ $t('医師による判断') }}
-        </p>
+        <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
+          <p :class="$style.Outpatient">
+            {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
+          </p>
+          <p :class="$style.Judge">
+            {{ $t('医師による判断') }}
+          </p>
+        </template>
+        <template v-else>
+          <p :class="$style.Judge">
+            {{ $t('Diagnosis by a doctor at a COVID-19 outpatient facility') }}
+          </p>
+        </template>
       </div>
     </div>
     <div :class="$style.TwoRow">
@@ -40,6 +46,16 @@
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  computed: {
+    langsWithoutOutpatient() {
+      return ['en']
+    }
+  }
+}
+</script>
 
 <style module lang="scss">
 .Container {

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -15,7 +15,8 @@
       </span>
     </i18n>
     <p :class="$style.decision">
-      <span :class="$style.fzSmall">
+      <!-- 英訳の場合は非表示にする -->
+      <span v-if="$i18n.locale !== 'en'" :class="$style.fzSmall">
         {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
       </span>
       <span :class="[$style.fzLarge, $style.break]">{{

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -15,13 +15,19 @@
       </span>
     </i18n>
     <p :class="$style.decision">
-      <!-- 英訳の場合は非表示にする -->
-      <span v-if="$i18n.locale !== 'en'" :class="$style.fzSmall">
-        {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
-      </span>
-      <span :class="[$style.fzLarge, $style.break]">{{
-        $t('医師による判断')
-      }}</span>
+      <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
+        <span :class="$style.fzSmall">
+          {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
+        </span>
+        <span :class="[$style.fzLarge, $style.break]">{{
+          $t('医師による判断')
+        }}</span>
+      </template>
+      <template v-else>
+        <span :class="[$style.fzLarge, $style.break]">
+          {{ $t('Diagnosis by a doctor at a COVID-19 outpatient facility') }}
+        </span>
+      </template>
     </p>
     <div :class="[$style.rectContainer, $style.double]">
       <a
@@ -150,6 +156,11 @@ export default {
     House,
     Arrow,
     GreenArrow
+  },
+  computed: {
+    langsWithoutOutpatient() {
+      return ['en']
+    }
   }
 }
 </script>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1826

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 英訳のみ「新型コロナ外来（帰国者・接触者外来）」を非表示にする
- `ja.json` に英語の翻訳キーを追加 https://github.com/tokyo-metropolitan-gov/covid19/pull/1842#issuecomment-601539597

## 📸 スクリーンショット / Screenshots
| | Before   | After   | 
| ---- | ---- | ---- |
| PC  |  ![スクリーンショット 2020-03-19 15 18 33](https://user-images.githubusercontent.com/5207601/77037631-19dc6680-69f5-11ea-874e-d5240de4361f.png)  | ![スクリーンショット 2020-03-19 15 17 55](https://user-images.githubusercontent.com/5207601/77037648-1f39b100-69f5-11ea-9ab2-36bfb412559d.png) |
| SP  |  ![スクリーンショット 2020-03-19 15 18 26](https://user-images.githubusercontent.com/5207601/77037686-32e51780-69f5-11ea-9d6a-7e0797dd33fb.png) |  ![スクリーンショット 2020-03-19 15 18 06](https://user-images.githubusercontent.com/5207601/77037701-40020680-69f5-11ea-9fea-c89e004c1f6c.png)
