### PR TITLE
fix: グラフのカラー修正

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -31,6 +31,7 @@ import VueI18n from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
+import { triple as colors } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -114,7 +115,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   computed: {
     displayData() {
-      const colors = ['#008b41', '#63c765', '#a6e29f']
       const borderColor = '#ffffff'
       const borderWidth = [
         { left: 0, top: 1, right: 0, bottom: 0 },

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -30,6 +30,7 @@ import Vue from 'vue'
 import { ChartOptions, ChartData } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
+import { triple as colors } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -121,7 +122,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   computed: {
     displayData() {
-      const colors: string[] = ['#a6e29f', '#63c765', '#008b41']
       const datasets = this.chartData.labels!.map((label, i) => {
         return {
           label,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -28,6 +28,7 @@ import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import { single as color } from '@/utils/colors'
 
 type Data = {
   dataKind: 'transition' | 'cumulative'
@@ -165,7 +166,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: '#00B849',
+              backgroundColor: color,
               borderWidth: 0
             }
           ]
@@ -179,7 +180,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: '#00B849',
+            backgroundColor: color,
             borderWidth: 0
           }
         ]

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -34,6 +34,7 @@ import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import { double as colors } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -163,7 +164,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayData() {
-      const colorArray = ['#00A040', '#00D154']
       const borderColor = '#ffffff'
       const borderWidth = [
         { left: 0, top: 1, right: 0, bottom: 0 },
@@ -176,7 +176,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return {
               label: this.items[index],
               data: item,
-              backgroundColor: colorArray[index],
+              backgroundColor: colors[index],
               borderColor,
               borderWidth: borderWidth[index]
             }
@@ -189,7 +189,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           return {
             label: this.items[index],
             data: this.cumulative(item),
-            backgroundColor: colorArray[index],
+            backgroundColor: colors[index],
             borderColor,
             borderWidth: borderWidth[index]
           }

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,0 +1,4 @@
+export const single: string = '#006400'
+export const double: string[] = ['#006400', '#1B75BC']
+export const triple: string[] = ['#00441B', '#006400', '#1B75BC']
+export const quadruple: string[] = ['#00441B', '#006400', '#1B75BC', '#505B00']


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1838

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
-  https://github.com/tokyo-metropolitan-gov/covid19/issues/1172#issuecomment-600979679 で検討されてきたカラーをもとに、色を管理するファイルを追加
- グラフの色置き換えました

## 📸 スクリーンショット / Screenshots
### Before
![localhost_3000_(iPad Pro) (1)](https://user-images.githubusercontent.com/5207601/77040167-c2d99000-69fa-11ea-8122-311437b79ea5.png)

### After
![localhost_3000_(iPad Pro)](https://user-images.githubusercontent.com/5207601/77040177-c53bea00-69fa-11ea-9b0f-6bf455df194a.png)
