### PR TITLE
多言語選択メニューをランドマーク内に移動

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -30,14 +30,13 @@
 
       <nav class="SideNavigation-Menu">
         <MenuList :items="items" @click="$emit('closeNavi', $event)" />
+        <div class="SideNavigation-Language">
+          <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
+            {{ $t('多言語対応選択メニュー') }}
+          </label>
+          <LanguageSelector />
+        </div>
       </nav>
-
-      <div class="SideNavigation-Language">
-        <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
-          {{ $t('多言語対応選択メニュー') }}
-        </label>
-        <LanguageSelector />
-      </div>
 
       <footer class="SideNavigation-Footer">
         <div class="SideNavigation-Social">


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1854 

## 📝 関連する issue / Related Issues
- #65

## ⛏ 変更内容 / Details of Changes
- 多言語選択メニューを```nav```内に移動しました。表示上の影響はありません。
