### PR TITLE
埋め込み用コードを表示するSVGアイコンにフォーカスできるようにする

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -85,7 +85,7 @@
               </button>
             </div>
           </div>
-          <div class="DataView-Share-Opener" @click="toggleShareMenu">
+          <button class="DataView-Share-Opener" @click="toggleShareMenu">
             <svg
               width="14"
               height="16"
@@ -100,7 +100,7 @@
                 fill="#808080"
               />
             </svg>
-          </div>
+          </button>
         </div>
       </div>
     </div>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -51,6 +51,22 @@
         </div>
 
         <div v-if="this.$route.query.embed != 'true'" class="Footer-Right">
+          <button class="DataView-Share-Opener" @click="toggleShareMenu">
+            <svg
+              width="14"
+              height="16"
+              viewBox="0 0 14 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M7.59999 3.5H9.5L7 0.5L4.5 3.5H6.39999V11H7.59999V3.5ZM8.5 5.75H11.5C11.9142 5.75 12.25 6.08579 12.25 6.5V13.5C12.25 13.9142 11.9142 14.25 11.5 14.25H2.5C2.08579 14.25 1.75 13.9142 1.75 13.5V6.5C1.75 6.08579 2.08579 5.75 2.5 5.75H5.5V4.5H2.5C1.39543 4.5 0.5 5.39543 0.5 6.5V13.5C0.5 14.6046 1.39543 15.5 2.5 15.5H11.5C12.6046 15.5 13.5 14.6046 13.5 13.5V6.5C13.5 5.39543 12.6046 4.5 11.5 4.5H8.5V5.75Z"
+                fill="#808080"
+              />
+            </svg>
+          </button>
           <div v-if="displayShare" class="DataView-Share-Buttons py-2">
             <div class="Close-Button">
               <v-icon @click="closeShareMenu">
@@ -85,22 +101,6 @@
               </button>
             </div>
           </div>
-          <button class="DataView-Share-Opener" @click="toggleShareMenu">
-            <svg
-              width="14"
-              height="16"
-              viewBox="0 0 14 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                fill-rule="evenodd"
-                clip-rule="evenodd"
-                d="M7.59999 3.5H9.5L7 0.5L4.5 3.5H6.39999V11H7.59999V3.5ZM8.5 5.75H11.5C11.9142 5.75 12.25 6.08579 12.25 6.5V13.5C12.25 13.9142 11.9142 14.25 11.5 14.25H2.5C2.08579 14.25 1.75 13.9142 1.75 13.5V6.5C1.75 6.08579 2.08579 5.75 2.5 5.75H5.5V4.5H2.5C1.39543 4.5 0.5 5.39543 0.5 6.5V13.5C0.5 14.6046 1.39543 15.5 2.5 15.5H11.5C12.6046 15.5 13.5 14.6046 13.5 13.5V6.5C13.5 5.39543 12.6046 4.5 11.5 4.5H8.5V5.75Z"
-                fill="#808080"
-              />
-            </svg>
-          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1862

## ⛏ 変更内容 / Details of Changes
- 埋め込み用コードのダイアログを開くsvgタグをラップするdivタグをbuttonタグに変更した
-- divタグだとブラウザのフォーカスが当たらないため
- buttonタグをダイアログの手前に移動した
-- 既存の実装のままだとダイアログ表示後、フォーカスを戻す必要があったため

## 📸 スクリーンショット / Screenshots
![github](https://user-images.githubusercontent.com/548508/77082508-82e8cc00-6a3f-11ea-8ae5-d46f3bbfc0e9.gif)
