### PR TITLE
(PR) parentでURLが折り返されない

### DIFF
--- a/components/StaticCard.vue
+++ b/components/StaticCard.vue
@@ -15,6 +15,7 @@ export default Vue.extend()
   @include card-container();
   padding: 20px;
   margin-bottom: 20px;
+  overflow-wrap: break-word;
   > *:not(:first-child) {
     margin-top: 1.2em;
   }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #1871

## ⛏ 変更内容 / Details of Changes

- `StaticCard` コンポーネントのコンテナに `overflow-wrap: break-word` を追加

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/3162324/77101765-2dbab380-6a5b-11ea-99f8-0aa1a6f3338f.png)