### PR TITLE
多言語化が不要のときに多言語対応選択メニューを非表示にする

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -33,7 +33,10 @@
 
       <nav class="SideNavigation-Menu">
         <MenuList :items="items" @click="$emit('closeNavi', $event)" />
-        <div class="SideNavigation-Language">
+        <div
+          v-if="this.$i18n.locales.length > 1"
+          class="SideNavigation-Language"
+        >
           <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
             {{ $t('多言語対応選択メニュー') }}
           </label>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1896 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `nuxt-i18n.config.ts` に記述されている、多言語化対象言語が1つのみの場合、サイドメニューの多言語対応選択メニューを非表示にする

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42484226/77137157-1d80f380-6ab0-11ea-949f-4ff4b4bf4b37.png)
