### PR TITLE
StaticInfoのhrefが空欄になっている問題を修正

### DIFF
--- a/components/StaticInfo.vue
+++ b/components/StaticInfo.vue
@@ -1,10 +1,5 @@
 <template>
-  <component
-    :is="isInternalLink ? 'nuxt-link' : 'a'"
-    :to="isInternalLink ? url : ''"
-    :href="isInternalLink ? '' : url"
-    class="StaticInfo"
-  >
+  <component :is="linkTag" v-bind="linkAttrs">
     <span>{{ text }}</span>
     <div v-if="btnText" class="StaticInfo-Button">
       <span>
@@ -33,6 +28,14 @@ export default Vue.extend({
     }
   },
   computed: {
+    linkTag(): string {
+      return this.isInternalLink ? 'nuxt-link' : 'a'
+    },
+    linkAttrs(): any {
+      return this.isInternalLink
+        ? { to: this.url, class: 'StaticInfo' }
+        : { href: this.url, class: 'StaticInfo' }
+    },
     isInternalLink(): boolean {
       return !/^https?:\/\//.test(this.url)
     }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1762 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `isInternalLink`の結果によって異なる引数を`<component>`に渡す
  - `components/MenuList.vue` の実装を参考にしました https://github.com/tokyo-metropolitan-gov/covid19/blob/bc5ce63af59df57ac573f509a5f425ede820f349/components/MenuList.vue

他に`href`が空欄になっているところはなさそうでしたが、もし見つかればこのPRで修正します。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### 変更後
![image](https://user-images.githubusercontent.com/42484226/77143319-49a76f00-6ac6-11ea-8fdc-1c1c4cf2d098.png)
### 変更前
![image](https://user-images.githubusercontent.com/42484226/77143341-5af07b80-6ac6-11ea-901f-927b67ff92b5.png)
