### PR TITLE
noscript時はローディングのオーバーレイを非表示

### DIFF
--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -6,6 +6,9 @@
         .loader {
           display: none;
         }
+        .v-overlay {
+          display: none;
+        }
       </style>
       <div class="noscript-heading">
         <img src="/logo.svg" :alt="$t('東京都')" />


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1907 

## ⛏ 変更内容 / Details of Changes
* JavaScriptオフ時はローディング画面のオーバーレイ背景を非表示
    * `<noscript>` 内の `<style>` で `.v-overlay` に `display: none` を指定
* 上述の修正内容で #1907 記載の両件とも修正された

## 確認済事項（いずれも yarn dev のローカルWebサーバで確認）

* jsオンでアクセスした際
    * ローディングアニメーションが表示される
    * アニメーションの背景は白塗り（アニメーション中はコンテンツは非表示）
* jsオフでアクセスした際
    * 従来どおりの表示（下記SS）
* jsオンでシェア用のURLにアクセスした際
    * ローディングアニメーション非表示
    * グラフ等は問題なく表示
    * og:image に有効なURLが設定されている
* 上記 og:image にアクセス
    * 対応する画像が表示される

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-20 17 57 24](https://user-images.githubusercontent.com/4785040/77149279-8ed29d80-6ad4-11ea-8748-8668bd51d896.png)

（モーダルウインドウ内の要素の前後関係が不適切なのは従来より存在する別バグ）