### PR TITLE
refs #1928 Remove unexpected duplicate property

### DIFF
--- a/components/flow/flow_sp.scss
+++ b/components/flow/flow_sp.scss
@@ -47,7 +47,6 @@
     position: relative;
     &::before {
       content: '';
-      position: absolute;
       margin: auto;
       width: px2vw(50);
       height: px2vw(50);


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1928

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
重複していたCSSのプロパティを削除した

## 📸 スクリーンショット / Screenshots
スマートフォンでの表示が乱れない事を確認した
<img width="612" alt="スクリーンショット 2020-03-20 18 44 51" src="https://user-images.githubusercontent.com/6235307/77152365-2affa300-6adb-11ea-9ee3-6be47576d9e1.png">

