### PR TITLE
「心配なときに」新型コロナ外来（帰国者・接触者外来）翻訳差し替え用の翻訳追加

### DIFF
--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -236,6 +236,7 @@
   "受診が必要": "受診が必要",
   "新型コロナ外来（帰国者・接触者外来）": "新型コロナ外来（帰国者・接触者外来）",
   "医師による判断": "医師による判断",
+  "Diagnosis by a doctor at a COVID-19 outpatient facility": "Diagnosis by a doctor at a COVID-19 outpatient facility",
   "検査の必要{ifRequired}": "検査の必要{ifRequired}",
   "あり": "あり",
   "なし": "なし",


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues
#1826
## ⛏ 変更内容 / Details of Changes
- 翻訳の出し分けのために、`locals/ja.json` に特例的に英語の翻訳キーを追加 https://github.com/tokyo-metropolitan-gov/covid19/pull/1842#issuecomment-601542985

## 📸 スクリーンショット / Screenshots
翻訳データの変更なので、見た目の変更はありません。
