### PR TITLE
DataSelectorのstyleをblockからinline-blockに修正

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -7,7 +7,7 @@
       <data-selector
         v-model="dataKind"
         :target-id="chartId"
-        :style="{ display: canvas ? 'block' : 'none' }"
+        :style="{ display: canvas ? 'inline-block' : 'none' }"
       />
     </template>
     <bar

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -19,7 +19,7 @@
       <data-selector
         v-model="dataKind"
         :target-id="chartId"
-        :style="{ display: canvas ? 'block' : 'none' }"
+        :style="{ display: canvas ? 'inline-block' : 'none' }"
       />
     </template>
     <bar


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1938 

## 📝 関連する issue / Related Issues
- #1443 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 通常時（javascriptがon）のスタイルを `block` から `inline-block` に修正

なにやら「日別」「累計」の切り替え時、グラフに数値が反映されるのが遅くなったような気がします。確認お願いします！