### PR TITLE
(PR) cssをstylelintのno-descending-specificityに対応させる

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -144,6 +144,8 @@ $default-bdw: 3px;
 $default-boxh: 150px;
 $default-boxdiff: 35px;
 
+// .container > .box > (.group > .box > ...) .pillar > .content
+
 .container {
   width: 100%;
   display: flex;
@@ -161,6 +163,25 @@ $default-boxdiff: 35px;
   ul {
     padding-left: 0;
   }
+}
+
+.pillar {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  text-align: center;
+  width: 100%;
+  border: $default-bdw solid $green-1;
+}
+
+.group {
+  display: flex;
+  flex: 0 0 auto;
+  padding-left: 0;
+  padding-top: $default-bdw;
+  border-top: $default-bdw solid $green-1;
+  border-left: $default-bdw solid $green-1;
 }
 
 .box {
@@ -235,25 +256,6 @@ $default-boxdiff: 35px;
   }
 }
 
-.pillar {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: center;
-  width: 100%;
-  border: $default-bdw solid $green-1;
-}
-
-.group {
-  display: flex;
-  flex: 0 0 auto;
-  padding-left: 0;
-  padding-top: $default-bdw;
-  border-top: $default-bdw solid $green-1;
-  border-left: $default-bdw solid $green-1;
-}
-
 .content {
   min-height: $default-boxh;
   padding: 10px 2px;
@@ -262,10 +264,6 @@ $default-boxdiff: 35px;
   justify-content: flex-end;
   align-items: center;
 
-  > span:not(:last-child) {
-    word-break: break-all;
-  }
-
   > span {
     display: block;
 
@@ -273,6 +271,10 @@ $default-boxdiff: 35px;
 
     &:last-child {
       margin-top: 0.1em;
+    }
+
+    &:not(:last-child) {
+      word-break: break-all;
     }
   }
   span strong {
@@ -293,6 +295,29 @@ $default-boxdiff: 35px;
 }
 
 @mixin override($vw, $bdw, $fz, $boxh, $boxdiff) {
+  .pillar {
+    border-width: px2vw($bdw, $vw);
+  }
+
+  .group {
+    padding-top: px2vw($bdw, $vw);
+    border-top-width: px2vw($bdw, $vw);
+    border-left-width: px2vw($bdw, $vw);
+  }
+
+  .content {
+    > span {
+      @include font-size($fz);
+    }
+    span strong {
+      @include font-size($fz + 2);
+    }
+
+    span.unit {
+      @include font-size($fz);
+    }
+  }
+
   .box {
     &.parent {
       border-top-width: px2vw($bdw, $vw);
@@ -350,29 +375,6 @@ $default-boxdiff: 35px;
     &.recovered {
       margin-left: px2vw($bdw, $vw);
       width: calc(100% / 5 - #{px2vw($bdw, $vw)});
-    }
-  }
-
-  .pillar {
-    border-width: px2vw($bdw, $vw);
-  }
-
-  .group {
-    padding-top: px2vw($bdw, $vw);
-    border-top-width: px2vw($bdw, $vw);
-    border-left-width: px2vw($bdw, $vw);
-  }
-
-  .content {
-    > span {
-      @include font-size($fz);
-    }
-    span strong {
-      @include font-size($fz + 2);
-    }
-
-    span.unit {
-      @include font-size($fz);
     }
   }
 }

--- a/components/ListItem.vue
+++ b/components/ListItem.vue
@@ -105,6 +105,7 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
+/* stylelint-disable no-descending-specificity */
 .ListItem {
   &-Container {
     min-height: 30px;
@@ -202,4 +203,5 @@ svg.isActive {
     fill: $green-1;
   }
 }
+/* stylelint-enable no-descending-specificity */
 </style>

--- a/components/StaticCard.vue
+++ b/components/StaticCard.vue
@@ -106,10 +106,11 @@ export default Vue.extend()
     -moz-osx-font-smoothing: grayscale;
   }
 
+  /* stylelint-disable no-descending-specificity */
   &-Note {
     display: flex;
 
-    span {
+    > span {
       display: block;
 
       &:first-child {
@@ -125,7 +126,7 @@ export default Vue.extend()
       display: flex;
       list-style-type: none;
 
-      span {
+      > span {
         display: block;
 
         &:first-child {
@@ -134,5 +135,6 @@ export default Vue.extend()
       }
     }
   }
+  /* stylelint-enable no-descending-specificity */
 }
 </style>

--- a/components/TestedCasesTable.vue
+++ b/components/TestedCasesTable.vue
@@ -114,6 +114,8 @@ export default Vue.extend({
 $default-bdw: 3px;
 $default-boxh: 150px;
 
+// .container > .box > (.group > .box > ...) .pillar > .content
+
 .container {
   width: 100%;
   display: flex;
@@ -130,6 +132,60 @@ $default-boxh: 150px;
 
   ul {
     padding-left: 0;
+  }
+}
+
+.pillar {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  text-align: center;
+  width: 100%;
+  border: $default-bdw solid $green-1;
+}
+
+.group {
+  display: flex;
+  flex: 0 0 auto;
+  padding-left: 0;
+  padding-top: $default-bdw;
+  border-top: $default-bdw solid $green-1;
+  border-left: $default-bdw solid $green-1;
+}
+
+.content {
+  min-height: $default-boxh;
+  padding: 10px 2px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+
+  > span {
+    display: block;
+
+    @include font-size(16);
+
+    &:last-child {
+      margin-top: 0.1em;
+    }
+
+    &:not(:last-child) {
+      word-break: break-all;
+    }
+  }
+
+  span strong {
+    @include font-size(18);
+  }
+
+  span.unit {
+    @include font-size(16);
+  }
+
+  .small {
+    @include font-size(14);
   }
 }
 
@@ -197,60 +253,6 @@ $default-boxh: 150px;
   }
 }
 
-.pillar {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  flex: 0 0 auto;
-  text-align: center;
-  width: 100%;
-  border: $default-bdw solid $green-1;
-}
-
-.group {
-  display: flex;
-  flex: 0 0 auto;
-  padding-left: 0;
-  padding-top: $default-bdw;
-  border-top: $default-bdw solid $green-1;
-  border-left: $default-bdw solid $green-1;
-}
-
-.content {
-  min-height: $default-boxh;
-  padding: 10px 2px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-
-  > span:not(:last-child) {
-    word-break: break-all;
-  }
-
-  > span {
-    display: block;
-
-    @include font-size(16);
-
-    &:last-child {
-      margin-top: 0.1em;
-    }
-  }
-
-  span strong {
-    @include font-size(18);
-  }
-
-  span.unit {
-    @include font-size(16);
-  }
-
-  .small {
-    @include font-size(14);
-  }
-}
-
 @function px2vw($px, $vw: 0) {
   @if $vw > 0 {
     @return ceil($px / $vw * 100000vw) / 1000;
@@ -260,6 +262,38 @@ $default-boxh: 150px;
 }
 
 @mixin override($vw, $bdw, $fz, $boxh) {
+  .pillar {
+    border-width: px2vw($bdw, $vw);
+  }
+
+  .group {
+    padding-top: px2vw($bdw, $vw);
+    border-top-width: px2vw($bdw, $vw);
+    border-left-width: px2vw($bdw, $vw);
+  }
+
+  .content {
+    span strong {
+      @include font-size($fz + 2);
+    }
+
+    span.unit {
+      @include font-size($fz);
+    }
+
+    > span {
+      @include font-size($fz);
+    }
+
+    .unit {
+      @include font-size($fz - 2);
+    }
+
+    .small {
+      @include font-size($fz - 1);
+    }
+  }
+
   .box {
     &.parent {
       border-top-width: px2vw($bdw, $vw);
@@ -303,38 +337,6 @@ $default-boxh: 150px;
     &.others {
       margin-left: px2vw($bdw, $vw);
       width: calc(100% / 2 - #{px2vw($bdw, $vw)});
-    }
-  }
-
-  .pillar {
-    border-width: px2vw($bdw, $vw);
-  }
-
-  .group {
-    padding-top: px2vw($bdw, $vw);
-    border-top-width: px2vw($bdw, $vw);
-    border-left-width: px2vw($bdw, $vw);
-  }
-
-  .content {
-    > span {
-      @include font-size($fz);
-    }
-
-    span strong {
-      @include font-size($fz + 2);
-    }
-
-    span.unit {
-      @include font-size($fz);
-    }
-
-    .unit {
-      @include font-size($fz - 2);
-    }
-
-    .small {
-      @include font-size($fz - 1);
     }
   }
 }

--- a/components/TextCard.vue
+++ b/components/TextCard.vue
@@ -85,6 +85,7 @@ export default Vue.extend({
       @include body-text();
     }
 
+    // stylelint-disable-next-line no-descending-specificity
     a {
       word-break: break-all;
       color: $link;

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -173,10 +173,6 @@
         text-align: left;
         list-style: none;
 
-        &Item + &Item {
-          margin-top: 14px;
-        }
-
         &Item {
           display: flex;
           align-items: center;
@@ -186,6 +182,10 @@
             width: 30px;
             height: 30px;
           }
+        }
+
+        &Item + &Item {
+          margin-top: 14px;
         }
       }
     }

--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -4,115 +4,119 @@
       {{ $t('お問い合わせ先一覧') }}
     </page-header>
     <div class="Contacts-Card">
-      <v-simple-table class="Contacts-Card-Table">
-        <template v-slot:default>
-          <thead>
-            <tr>
-              <th class="text-center">{{ $t('お問い合わせ内容') }}</th>
-              <th class="text-center">{{ $t('局名') }}</th>
-              <th class="text-center">{{ $t('電話番号') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="content">{{ $t('サイト全般に関すること') }}</td>
-              <td class="bureau">{{ $t('政策企画局') }}</td>
-              <td class="tel"><a href="tel:03-5388-2171">03-5388-2171</a></td>
-            </tr>
-            <tr>
-              <td class="content">
-                {{ $t('サイトの技術面に関すること') }}<br />{{
-                  $t('オープンデータ、オープンソースに関すること')
-                }}
-              </td>
-              <td class="bureau">{{ $t('戦略政策情報推進本部') }}</td>
-              <td class="tel"><a href="tel:03-5320-7930">03-5320-7930</a></td>
-            </tr>
-            <tr>
-              <td class="content">
-                {{ $t('新型コロナウイルス感染症対策本部会議に関すること')
-                }}<br />{{ $t('都庁来庁者データに関すること') }}
-              </td>
-              <td class="bureau">{{ $t('総務局') }}</td>
-              <td class="tel">
-                {{ $t('感染症対策本部会議に関すること') }}<br /><a
-                  href="tel:03-5320-7891"
-                  >03-5388-7891</a
-                ><br />
-                {{ $t('都庁来庁者データに関すること') }}<br /><a
-                  href="tel:03-5388-2319"
-                  >03-5388-2319</a
-                >
-              </td>
-            </tr>
-            <tr>
-              <td class="content">
-                {{ $t('都公式ホームページに関すること') }}<br />{{
-                  $t('都公式SNSアカウントに関すること')
-                }}
-              </td>
-              <td class="bureau">{{ $t('生活文化局') }}</td>
-              <td class="tel">
-                {{ $t('都公式ホームページに関すること') }}<br /><a
-                  href="tel:03-5388-3061"
-                  >03-5388-3061</a
-                ><br />
-                {{ $t('都公式SNSアカウントに関すること') }}<br /><a
-                  href="tel:03-5388-3094"
-                  >03-5388-3094</a
-                >
-              </td>
-            </tr>
-            <tr>
-              <td class="content">
-                {{ $t('中小企業支援、テレワークに関すること') }}
-              </td>
-              <td class="bureau">{{ $t('産業労働局') }}</td>
-              <td class="tel">
-                {{ $t('資金繰りに関すること') }}<br /><a href="tel:03-5320-4877"
-                  >03-5320-4877</a
-                ><br />
-                {{ $t('経営に関すること') }}<br /><a href="tel:03-3251-7881"
-                  >03-3251-7881</a
-                ><br />
-                {{ $t('労働関係に関すること') }}<br /><a href="tel:0570-00-6110"
-                  >0570-00-6110</a
-                >
-              </td>
-            </tr>
-            <tr>
-              <td class="content">
-                {{
-                  $t('新型コロナウイルス感染症の予防・検査・医療に関すること')
-                }}
-              </td>
-              <td class="bureau">{{ $t('福祉保健局') }}</td>
-              <td class="tel">
-                <a href="tel:0570-550-571">0570-550-571</a><br />
-                {{ $t('（新型コロナコールセンター）') }}
-              </td>
-            </tr>
-            <tr>
-              <td class="content">{{ $t('都立学校に関すること') }}</td>
-              <td class="bureau">{{ $t('教育庁') }}</td>
-              <td class="tel"><a href="tel:03-5320-6705">03-5320-6705</a></td>
-            </tr>
-            <tr>
-              <td class="content">{{ $t('スムーズビズに関すること') }}</td>
-              <td class="bureau">{{ $t('都市整備局') }}</td>
-              <td class="tel"><a href="tel:03-5388-3317">03-5388-3317</a></td>
-            </tr>
-            <tr>
-              <td class="content">{{ $t('都営交通に関すること') }}</td>
-              <td class="bureau">{{ $t('交通局') }}</td>
-              <td class="tel">
-                <a href="tel:03-3816-5700">03-3816-5700</a><br />
-                {{ $t('（都営交通お客様センター）') }}
-              </td>
-            </tr>
-          </tbody>
-        </template>
-      </v-simple-table>
+      <table class="Contacts-Card-Table" role="presentation">
+        <thead>
+          <tr>
+            <th class="text-center">{{ $t('お問い合わせ内容') }}</th>
+            <th class="text-center">{{ $t('局名') }}</th>
+            <th class="text-center">{{ $t('電話番号') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('サイト全般に関すること') }}
+            </td>
+            <td class="bureau">{{ $t('政策企画局') }}</td>
+            <td class="tel"><a href="tel:03-5388-2171">03-5388-2171</a></td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('サイトの技術面に関すること') }}<br />{{
+                $t('オープンデータ、オープンソースに関すること')
+              }}
+            </td>
+            <td class="bureau">{{ $t('戦略政策情報推進本部') }}</td>
+            <td class="tel"><a href="tel:03-5320-7930">03-5320-7930</a></td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('新型コロナウイルス感染症対策本部会議に関すること')
+              }}<br />{{ $t('都庁来庁者データに関すること') }}
+            </td>
+            <td class="bureau">{{ $t('総務局') }}</td>
+            <td class="tel">
+              {{ $t('感染症対策本部会議に関すること') }}<br /><a
+                href="tel:03-5320-7891"
+                >03-5388-7891</a
+              ><br />
+              {{ $t('都庁来庁者データに関すること') }}<br /><a
+                href="tel:03-5388-2319"
+                >03-5388-2319</a
+              >
+            </td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('都公式ホームページに関すること') }}<br />{{
+                $t('都公式SNSアカウントに関すること')
+              }}
+            </td>
+            <td class="bureau">{{ $t('生活文化局') }}</td>
+            <td class="tel">
+              {{ $t('都公式ホームページに関すること') }}<br /><a
+                href="tel:03-5388-3061"
+                >03-5388-3061</a
+              ><br />
+              {{ $t('都公式SNSアカウントに関すること') }}<br /><a
+                href="tel:03-5388-3094"
+                >03-5388-3094</a
+              >
+            </td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('中小企業支援、テレワークに関すること') }}
+            </td>
+            <td class="bureau">{{ $t('産業労働局') }}</td>
+            <td class="tel">
+              {{ $t('資金繰りに関すること') }}<br /><a href="tel:03-5320-4877"
+                >03-5320-4877</a
+              ><br />
+              {{ $t('経営に関すること') }}<br /><a href="tel:03-3251-7881"
+                >03-3251-7881</a
+              ><br />
+              {{ $t('労働関係に関すること') }}<br /><a href="tel:0570-00-6110"
+                >0570-00-6110</a
+              >
+            </td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('新型コロナウイルス感染症の予防・検査・医療に関すること') }}
+            </td>
+            <td class="bureau">{{ $t('福祉保健局') }}</td>
+            <td class="tel">
+              <a href="tel:0570-550-571">0570-550-571</a><br />
+              {{ $t('（新型コロナコールセンター）') }}
+            </td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('都立学校に関すること') }}
+            </td>
+            <td class="bureau">{{ $t('教育庁') }}</td>
+            <td class="tel"><a href="tel:03-5320-6705">03-5320-6705</a></td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('スムーズビズに関すること') }}
+            </td>
+            <td class="bureau">{{ $t('都市整備局') }}</td>
+            <td class="tel"><a href="tel:03-5388-3317">03-5388-3317</a></td>
+          </tr>
+          <tr>
+            <td class="content" role="heading" aria-level="3">
+              {{ $t('都営交通に関すること') }}
+            </td>
+            <td class="bureau">{{ $t('交通局') }}</td>
+            <td class="tel">
+              <a href="tel:03-3816-5700">03-3816-5700</a><br />
+              {{ $t('（都営交通お客様センター）') }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -139,19 +143,38 @@ export default Vue.extend({
   &-Card {
     @include card-container();
 
-    padding: 1px; // tr:hover で外枠が消えないように
     &-Table {
+      width: 100%;
+      border-collapse: collapse;
+
       th {
         font-size: 14px !important;
       }
 
-      tr:hover {
-        background: $white !important;
+      td {
+        padding: 0 16px;
+        font-size: 14px;
       }
 
       @include largerThan($medium) {
+        thead tr {
+          height: 48px;
+        }
+
         tbody tr {
           height: 96px;
+        }
+
+        th,
+        tr:not(:last-child) {
+          border-top: none;
+          border-left: none;
+          border-right: none;
+          border-bottom: thin solid rgba(0, 0, 0, 0.12);
+        }
+
+        tr:last-child {
+          border: none;
         }
       }
 
@@ -160,31 +183,33 @@ export default Vue.extend({
           display: none;
         }
 
-        tbody tr {
-          height: auto;
+        tbody {
+          tr {
+            height: auto;
 
-          .content {
-            font-weight: bold;
-            border-bottom: none !important;
-            padding-top: 12px;
-            padding-bottom: 8px;
+            .content {
+              font-weight: bold;
+              border-bottom: none !important;
+              padding-top: 12px;
+              padding-bottom: 8px;
+            }
+
+            .bureau {
+              border-bottom: none !important;
+            }
+
+            .tel {
+              padding-bottom: 12px;
+            }
           }
 
-          .bureau {
-            border-bottom: none !important;
-          }
-
-          .tel {
-            padding-bottom: 12px;
+          tr:not(:last-child) {
+            border-bottom: thin solid rgba(0, 0, 0, 0.12);
           }
         }
 
         td {
           display: block;
-        }
-
-        tbody td {
-          height: auto;
         }
       }
     }

--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -179,12 +179,12 @@ export default Vue.extend({
           }
         }
 
-        tbody td {
-          height: auto;
-        }
-
         td {
           display: block;
+        }
+
+        tbody td {
+          height: auto;
         }
       }
     }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #1965

## 📝 関連する issue / Related Issues

- #1937 経緯
- #1948 stylelint側の修正

## ⛏ 変更内容 / Details of Changes

- stylelintの `no-descending-specificity` ルールに引っかかるcssのうち――
    - 実装に明らかな誤りがあるものは記述順序を入れ替えて修正
        - ~~`contacts`~~ `FlowPcDays`
    - 妥協して適合させるもの（元々当方が制作）は副作用で見通しが悪くなるのをコメントでフォローしつつ修正
        - `ConfirmedCasesTable` `TestedCasesTable`
    - [仕様上回避できない誤爆](https://stylelint.io/user-guide/rules/no-descending-specificity#dom-limitations)は該当箇所を `/* stylelint-disable no-descending-specificity */`
        - `StaticCard` `TextCard`
    - それ以外は現時点の実装を尊重して `/* stylelint-disable no-descending-specificity */`
        - `ListITem`
- ついでに `StaticCard` の注釈を入れ子対応に修正

---

※mergeする際は #1950 と同時を推奨