### PR TITLE
「陽性患者の属性」のテーブルのキーボード操作向上

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -20,6 +20,6 @@ img {
   }
 }
 
-a:focus {
+*:focus {
   outline: dotted $gray-3 1px;
 }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -12,6 +12,7 @@
       :fixed-header="true"
       :mobile-breakpoint="0"
       class="cardTable"
+      tabindex="0"
     />
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
@@ -69,6 +70,9 @@
         }
       }
     }
+    &:focus {
+      outline: dotted $gray-3 1px;
+    }
   }
 }
 
@@ -111,6 +115,12 @@ export default Vue.extend({
       type: String,
       default: ''
     }
+  },
+  mounted() {
+    const elementList = document.querySelectorAll('.sortable span')
+    elementList.forEach(element => {
+      element.setAttribute('tabIndex', '0')
+    })
   }
 })
 </script>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -76,7 +76,7 @@
             @click="stopClosingShareMenu"
           >
             <div class="Close-Button">
-              <v-icon @click="closeShareMenu">
+              <v-icon :aria-label="$t('閉じる')" @click="closeShareMenu">
                 mdi-close
               </v-icon>
             </div>
@@ -86,6 +86,7 @@
             <div class="EmbedCode">
               <v-icon
                 v-if="isCopyAvailable()"
+                :aria-label="$t('コードをクリップボードにコピー')"
                 class="EmbedCode-Copy"
                 @click="copyEmbedCode"
               >
@@ -95,16 +96,24 @@
             </div>
 
             <div class="Buttons">
-              <button @click="line">
-                <img src="/line.png" class="icon-resize line" />
+              <button :aria-label="$t('LINEで共有')" @click="line">
+                <img src="/line.png" alt="LINE" class="icon-resize line" />
               </button>
 
-              <button @click="twitter">
-                <img src="/twitter.png" class="icon-resize twitter" />
+              <button :aria-label="$t('Twitterで共有')" @click="twitter">
+                <img
+                  src="/twitter.png"
+                  alt="Twitter"
+                  class="icon-resize twitter"
+                />
               </button>
 
-              <button @click="facebook">
-                <img src="/facebook.png" class="icon-resize facebook" />
+              <button :aria-label="$t('Facebookで共有')" @click="facebook">
+                <img
+                  src="/facebook.png"
+                  alt="Facebook"
+                  class="icon-resize facebook"
+                />
               </button>
             </div>
           </div>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -402,6 +402,16 @@ export default Vue.extend({
           display: flex;
           justify-content: flex-end;
           color: $gray-3;
+
+          button {
+            border-radius: 50%;
+            border: 1px solid #fff;
+
+            &:focus {
+              border: 1px dotted #707070;
+              outline: none;
+            }
+          }
         }
 
         > .EmbedCode {
@@ -419,6 +429,16 @@ export default Vue.extend({
             right: 0.3em;
             color: $gray-3;
           }
+
+          button {
+            border-radius: 50%;
+            border: solid 1px #eee;
+
+            &:focus {
+              border: 1px dotted #707070;
+              outline: none;
+            }
+          }
         }
 
         > .Buttons {
@@ -428,11 +448,7 @@ export default Vue.extend({
 
           .icon-resize {
             border-radius: 50%;
-            width: 30px;
-            height: 30px;
             font-size: 30px;
-            margin-left: 4px;
-            margin-right: 4px;
 
             &.twitter {
               color: #fff;
@@ -445,6 +461,19 @@ export default Vue.extend({
 
             &.line {
               color: #1cb127;
+            }
+          }
+
+          button {
+            width: 30px;
+            height: 30px;
+            margin-left: 4px;
+            margin-right: 4px;
+
+            &:focus {
+              border-radius: 50%;
+              border: 1px dotted #707070;
+              outline: none;
             }
           }
         }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -76,7 +76,7 @@
             @click="stopClosingShareMenu"
           >
             <div class="Close-Button">
-              <v-icon :aria-label="$t('閉じる')" @click="closeShareMenu">
+              <v-icon @click="closeShareMenu">
                 mdi-close
               </v-icon>
             </div>
@@ -86,7 +86,6 @@
             <div class="EmbedCode">
               <v-icon
                 v-if="isCopyAvailable()"
-                :aria-label="$t('コードをクリップボードにコピー')"
                 class="EmbedCode-Copy"
                 @click="copyEmbedCode"
               >
@@ -96,24 +95,16 @@
             </div>
 
             <div class="Buttons">
-              <button :aria-label="$t('LINEで共有')" @click="line">
-                <img src="/line.png" alt="LINE" class="icon-resize line" />
+              <button @click="line">
+                <img src="/line.png" class="icon-resize line" />
               </button>
 
-              <button :aria-label="$t('Twitterで共有')" @click="twitter">
-                <img
-                  src="/twitter.png"
-                  alt="Twitter"
-                  class="icon-resize twitter"
-                />
+              <button @click="twitter">
+                <img src="/twitter.png" class="icon-resize twitter" />
               </button>
 
-              <button :aria-label="$t('Facebookで共有')" @click="facebook">
-                <img
-                  src="/facebook.png"
-                  alt="Facebook"
-                  class="icon-resize facebook"
-                />
+              <button @click="facebook">
+                <img src="/facebook.png" class="icon-resize facebook" />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #1978

## 📝 関連する issue / Related Issues
- #1155 （ちょっと解決まで至っているか不安）
- #65

## ⛏ 変更内容 / Details of Changes
- テーブルとテーブル見出しに tabIndex="0" を設定する。
- リンク以外の要素のフォーカスのアウトラインについて設定を統一する。

## 📸 スクリーンショット / Screenshots

### 「埋め込み用コード」ほかフォーカス時のアウトラインを統一
![capture08](https://user-images.githubusercontent.com/32133/77185570-f8729c00-6b14-11ea-887f-eb72748f252f.png)

### テーブルにもフォーカスが当たるように「tabIndex="0"」を設定
![capture09](https://user-images.githubusercontent.com/32133/77185569-f8729c00-6b14-11ea-9b4b-66b8129b5bab.png)

### テーブルの見出しに「tabIndex="0"」を設定
![capture10](https://user-images.githubusercontent.com/32133/77185568-f7416f00-6b14-11ea-847e-4db708e31e12.png)

