### PR TITLE
Revert "新宿のグラフを外す"

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,6 +30,7 @@
       <consultation-desk-reports-number-card />
       <metro-card />
       <agency-card />
+      <shinjuku-visitors-card />
     </v-row>
   </div>
 </template>
@@ -53,6 +54,7 @@ import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDe
 import MetroCard from '@/components/cards/MetroCard.vue'
 import AgencyCard from '@/components/cards/AgencyCard.vue'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
+import ShinjukuVisitorsCard from '@/components/cards/ShinjukuVisitorsCard.vue'
 
 export default Vue.extend({
   components: {
@@ -68,7 +70,8 @@ export default Vue.extend({
     TelephoneAdvisoryReportsNumberCard,
     ConsultationDeskReportsNumberCard,
     MetroCard,
-    AgencyCard
+    AgencyCard,
+    ShinjukuVisitorsCard
   },
   data() {
     const data = {


### PR DESCRIPTION
Reverts tokyo-metropolitan-gov/covid19#1977

リリースしたので、開発のために戻します。