### PR TITLE
「埋め込み用コード」ポップアップ内のボタンにaria-labelを付与

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -78,7 +78,7 @@
             @click="stopClosingShareMenu"
           >
             <div class="Close-Button">
-              <v-icon @click="closeShareMenu">
+              <v-icon :aria-label="$t('閉じる')" @click="closeShareMenu">
                 mdi-close
               </v-icon>
             </div>
@@ -89,6 +89,7 @@
               <v-icon
                 v-if="isCopyAvailable()"
                 class="EmbedCode-Copy"
+                :aria-label="$t('クリップボードにコピー')"
                 @click="copyEmbedCode"
               >
                 far fa-clipboard
@@ -97,36 +98,53 @@
             </div>
 
             <div class="Buttons">
-              <button @click="line">
+              <button
+                :aria-label="$t('Lineで{title}のグラフをシェア', { title })"
+                @click="line"
+              >
                 <picture>
                   <source
                     srcset="/line.webp"
                     type="image/webp"
                     class="icon-resize line"
                   />
-                  <img src="/line.png" class="icon-resize line" />
+                  <img src="/line.png" alt="LINE" class="icon-resize line" />
                 </picture>
               </button>
 
-              <button @click="twitter">
+              <button
+                :aria-label="$t('Twitterで{title}のグラフをシェア', { title })"
+                @click="twitter"
+              >
                 <picture>
                   <source
                     srcset="/twitter.webp"
                     type="image/webp"
                     class="icon-resize twitter"
                   />
-                  <img src="/twitter.png" class="icon-resize twitter" />
+                  <img
+                    src="/twitter.png"
+                    alt="Twitter"
+                    class="icon-resize twitter"
+                  />
                 </picture>
               </button>
 
-              <button @click="facebook">
+              <button
+                :aria-label="$t('facebookで{title}のグラフをシェア', { title })"
+                @click="facebook"
+              >
                 <picture>
                   <source
                     srcset="/facebook.webp"
                     type="image/webp"
                     class="icon-resize facebook"
                   />
-                  <img src="/facebook.png" class="icon-resize facebook" />
+                  <img
+                    src="/facebook.png"
+                    alt="facebook"
+                    class="icon-resize facebook"
+                  />
                 </picture>
               </button>
             </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2012

## 📝 関連する issue / Related Issues
- #65

## ⛏ 変更内容 / Details of Changes
- 各ボタンに適当と思われるaria-labelを付与した。
- テキストはi18nテキストを呼ぶようにした。
- ついでにSNSアイコンにalt付与

## 📸 スクリーンショット / Screenshots
![capture12](https://user-images.githubusercontent.com/32133/77220816-2c86a500-6b87-11ea-9b9f-5d7bd8b38b7b.png)

