### PR TITLE
DockerfileのCOPY命令の送信先のパスを絶対パスに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM node:10.19-alpine
 
-WORKDIR /app
+ENV PROJECT_ROOTDIR /app
 
-COPY package.json yarn.lock ./
+WORKDIR $PROJECT_ROOTDIR
+
+COPY package.json yarn.lock $PROJECT_ROOTDIR
 
 RUN yarn install
 
-COPY . .
+COPY . $PROJECT_ROOTDIR
 
 EXPOSE 3000
 ENV HOST 0.0.0.0


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #1989

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `Dockerfile`の`COPY`命令の`<dest>`を絶対パスに変更
- `WORKDIR`も含めて共通のパスを使用するので、パスを変数で定義するように変更