### PR TITLE
ja.json 以外のlocalesファイルを commit 不可にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "sh pre-commit.sh && lint-staged"
     }
   },
   "dependencies": {

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# ref: https://qiita.com/ryounagaoka/items/3e7a1b44d43ad0547d4f
+
+unchangeable_files=(
+  ^assets/locales/en.json
+  ^assets/locales/ja-Hira.json
+  ^assets/locales/ko.json
+  ^assets/locales/pt_BR.json
+  ^assets/locales/th.json
+  ^assets/locales/vi.json
+  ^assets/locales/zh_CM.json
+  ^assets/locales/zh_TW.json
+)
+
+containsElement () {
+  local e
+  for e in "${@:2}"; do [[ "$1" =~ $e ]] && return 0; done
+  return 1
+}
+
+for FILE in `git diff --cached --name-status $against -- | cut -c3-`; do
+  if containsElement $FILE "${unchangeable_files[@]}"; then
+    echo "$FILE"
+    CHANGE_DETECTED=1
+  fi
+done
+
+if [ "$CHANGE_DETECTED" ]; then
+  echo "Failed to commit because of modification of files above."
+  exit 1
+fi


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2016

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
- husky の pre-commit hook で `assets/locales/ja.json` 以外のファイルを commit したら弾くようにしました
- Transifex で変更を commit する際に husky を使っていないことを前提に実装しています

## 📸 スクリーンショット / Screenshots
`assets/locales/en.json` の変更をコミットした際のコマンドログです。
```
$ git status 
On branch feat/prevent-local-commit
Your branch is up to date with 'origin/feat/prevent-local-commit'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   assets/locales/en.json

no changes added to commit (use "git add" and/or "git commit -a")
$ git add . 
$ git commit
husky > pre-commit (node v10.19.0)
assets/locales/en.json
Failed to commit because of modification of files above.
husky > pre-commit hook failed (add --no-verify to bypass)
````