### PR TITLE
日本語以外の翻訳ファイルの変更をコミットした際のエラーメッセージを修正

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -26,6 +26,6 @@ for FILE in `git diff --cached --name-status $against -- | cut -c3-`; do
 done
 
 if [ "$CHANGE_DETECTED" ]; then
-  echo "Failed to commit because of modification of files above."
+  echo "Failed to commit because of the modification of the files above. {lang}.json files are only allowed to edit from Transifex. See issue #1985 for the details. "
   exit 1
 fi


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2016

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
- 日本語以外の翻訳ファイルの変更をコミットした際のエラーメッセージをわかりやすくしました

## 📸 スクリーンショット / Screenshots
`assets/locales/en.json` を変更した際のコマンドログです。
```
$ git status
On branch fix/pre-commit-error-mssage
Your branch is up to date with 'origin/fix/pre-commit-error-mssage'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   assets/locales/en.json

no changes added to commit (use "git add" and/or "git commit -a")
$ git add .
$ git commit
husky > pre-commit (node v10.19.0)
assets/locales/en.json
Failed to commit because of the modification of the files above. {lang}.json files are only allowed to edit from Transifex. See issue #1985 for the details.
husky > pre-commit hook failed (add --no-verify to bypass)
```