### PR TITLE
tabindex設定を「陽性患者の属性」のテーブルのみとする

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -4,7 +4,6 @@
       <span />
     </template>
     <v-data-table
-      id="confirmedCasesData"
       :headers="chartData.headers"
       :items="chartData.datasets"
       :items-per-page="-1"
@@ -12,7 +11,7 @@
       :height="240"
       :fixed-header="true"
       :mobile-breakpoint="0"
-      class="cardTable"
+      class="cardTable displayedTable"
     />
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
@@ -117,7 +116,7 @@ export default Vue.extend({
     }
   },
   mounted() {
-    const tables = document.querySelectorAll('#confirmedCasesData table')
+    const tables = document.querySelectorAll('.displayedTable table')
     tables.forEach(table => {
       table.setAttribute('tabindex', '0')
     })

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -4,6 +4,7 @@
       <span />
     </template>
     <v-data-table
+      id="confirmedCasesData"
       :headers="chartData.headers"
       :items="chartData.datasets"
       :items-per-page="-1"
@@ -116,9 +117,9 @@ export default Vue.extend({
     }
   },
   mounted() {
-    const elementList = document.querySelectorAll('.sortable span')
-    elementList.forEach(element => {
-      element.setAttribute('tabindex', '0')
+    const tables = document.querySelectorAll('#confirmedCasesData table')
+    tables.forEach(table => {
+      table.setAttribute('tabindex', '0')
     })
   }
 })

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -4,6 +4,7 @@
       <span />
     </template>
     <v-data-table
+      :ref="'displayedTable'"
       :headers="chartData.headers"
       :items="chartData.datasets"
       :items-per-page="-1"
@@ -11,7 +12,7 @@
       :height="240"
       :fixed-header="true"
       :mobile-breakpoint="0"
-      class="cardTable displayedTable"
+      class="cardTable"
     />
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
@@ -116,8 +117,11 @@ export default Vue.extend({
     }
   },
   mounted() {
-    const tables = document.querySelectorAll('.displayedTable table')
-    tables.forEach(table => {
+    const vTables = this.$refs.displayedTable as Vue
+    const vTableElement = vTables.$el
+    const tables = vTableElement.querySelectorAll('table')
+
+    tables.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,12 +71,6 @@ export default Vue.extend({
   },
   mounted() {
     this.loading = false
-    const elementList = document.querySelectorAll(
-      '.v-data-table__wrapper table'
-    )
-    elementList.forEach(element => {
-      element.setAttribute('tabindex', '0')
-    })
   },
   methods: {
     openNavigation(): void {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2066

## 📝 関連する issue / Related Issues
- #1443

## ⛏ 変更内容 / Details of Changes
- すべてのテーブルにtabindex設定するのをやめて「陽性患者の属性」のテーブルのみ設定とした。
- 表示されているテーブル用のclass（displayedTable）を追加して絞り込みを行っている。
- 画面表示上の変更はなし

