### PR TITLE
refs #1925 Add alt attribute to <img> tags

### DIFF
--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -69,6 +69,7 @@
               :class="$style.AdvisoryTelephoneIcon"
               src="/flow/phone-24px.svg"
               aria-hidden="true"
+              :alt="$t('電話番号')"
             />
             03-5320-4592
           </a>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -113,7 +113,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/pregnant_woman-24px.svg"
               aria-hidden="true"
-              img=" "
+              alt=" "
             />
             {{ $t('妊娠中の方') }}
           </li>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -6,8 +6,7 @@
           <img
             :class="$style.FlowRowRowThreeGeneralIcon"
             src="/flow/accessibility-24px.svg"
-            aria-hidden="true"
-            :alt="$t('一般の方')"
+            aria-hdden="true"
           />
           {{ $t('一般の方') }}
         </p>
@@ -72,7 +71,6 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
-          :alt="$t('強いだるさ')"
         />
       </div>
       <div :class="$style.FlowRowCondition">
@@ -81,7 +79,6 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
-          :alt="$t('息苦しさ')"
         />
       </div>
     </div>
@@ -93,7 +90,6 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/directions_walk-24px.svg"
               aria-hidden="true"
-              :alt="$t('ご高齢な方')"
             />
             {{ $t('ご高齢な方') }}
           </li>
@@ -102,7 +98,6 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/accessible-24px.svg"
               aria-hidden="true"
-              :alt="$t('基礎疾患のある方')"
             />
             {{ $t('基礎疾患のある方') }}
           </li>
@@ -111,7 +106,6 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/pregnant_woman-24px.svg"
               aria-hidden="true"
-              :alt="$t('妊娠中の方')"
             />
             {{ $t('妊娠中の方') }}
           </li>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -7,6 +7,7 @@
             :class="$style.FlowRowRowThreeGeneralIcon"
             src="/flow/accessibility-24px.svg"
             aria-hidden="true"
+            :alt="$t('一般の方')"
           />
           {{ $t('一般の方') }}
         </p>
@@ -71,6 +72,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          :alt="$t('強いだるさ')"
         />
       </div>
       <div :class="$style.FlowRowCondition">
@@ -79,6 +81,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          :alt="$t('息苦しさ')"
         />
       </div>
     </div>
@@ -90,6 +93,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/directions_walk-24px.svg"
               aria-hidden="true"
+              :alt="$t('ご高齢な方')"
             />
             {{ $t('ご高齢な方') }}
           </li>
@@ -98,6 +102,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/accessible-24px.svg"
               aria-hidden="true"
+              :alt="$t('基礎疾患のある方')"
             />
             {{ $t('基礎疾患のある方') }}
           </li>
@@ -106,6 +111,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/pregnant_woman-24px.svg"
               aria-hidden="true"
+              :alt="$t('妊娠中の方')"
             />
             {{ $t('妊娠中の方') }}
           </li>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -6,7 +6,7 @@
           <img
             :class="$style.FlowRowRowThreeGeneralIcon"
             src="/flow/accessibility-24px.svg"
-            aria-hdden="true"
+            aria-hidden="true"
           />
           {{ $t('一般の方') }}
         </p>

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -7,6 +7,7 @@
             :class="$style.FlowRowRowThreeGeneralIcon"
             src="/flow/accessibility-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('一般の方') }}
         </p>
@@ -43,6 +44,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          alt=" "
         />
       </div>
       <div :class="$style.FlowRowCondition">
@@ -63,6 +65,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          alt=" "
         />
       </div>
       <div :class="$style.FlowRowCondition">
@@ -71,6 +74,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          alt=" "
         />
       </div>
       <div :class="$style.FlowRowCondition">
@@ -79,6 +83,7 @@
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
           aria-hidden="true"
+          alt=" "
         />
       </div>
     </div>
@@ -90,6 +95,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/directions_walk-24px.svg"
               aria-hidden="true"
+              alt=" "
             />
             {{ $t('ご高齢な方') }}
           </li>
@@ -98,6 +104,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/accessible-24px.svg"
               aria-hidden="true"
+              alt=" "
             />
             {{ $t('基礎疾患のある方') }}
           </li>
@@ -106,6 +113,7 @@
               :class="$style.FlowRowRowThreeCareTargetListItemIcon"
               src="/flow/pregnant_woman-24px.svg"
               aria-hidden="true"
+              img=" "
             />
             {{ $t('妊娠中の方') }}
           </li>

--- a/components/flow/FlowPcHospitalized.vue
+++ b/components/flow/FlowPcHospitalized.vue
@@ -5,6 +5,7 @@
         :class="$style.FlowPcHospitalizedHeadingIcon"
         src="/flow/hotel-24px.svg"
         aria-hidden="true"
+        alt=" "
       />
       {{ $t('入院となります') }}
     </p>

--- a/components/flow/FlowPcHospitalized.vue
+++ b/components/flow/FlowPcHospitalized.vue
@@ -5,7 +5,6 @@
         :class="$style.FlowPcHospitalizedHeadingIcon"
         src="/flow/hotel-24px.svg"
         aria-hidden="true"
-        :alt="$t('入院となります')"
       />
       {{ $t('入院となります') }}
     </p>

--- a/components/flow/FlowPcHospitalized.vue
+++ b/components/flow/FlowPcHospitalized.vue
@@ -5,6 +5,7 @@
         :class="$style.FlowPcHospitalizedHeadingIcon"
         src="/flow/hotel-24px.svg"
         aria-hidden="true"
+        :alt="$t('入院となります')"
       />
       {{ $t('入院となります') }}
     </p>

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -14,6 +14,7 @@
             :class="$style.actionsListIcon"
             src="/flow/house-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('自宅で安静に過ごす') }}
         </li>
@@ -22,6 +23,7 @@
             :class="$style.actionsListIcon"
             src="/flow/apartment-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('一般の医療機関を受診') }}
         </li>

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -14,7 +14,6 @@
             :class="$style.actionsListIcon"
             src="/flow/house-24px.svg"
             aria-hidden="true"
-            :alt="$t('自宅で安静に過ごす')"
           />
           {{ $t('自宅で安静に過ごす') }}
         </li>
@@ -23,7 +22,6 @@
             :class="$style.actionsListIcon"
             src="/flow/apartment-24px.svg"
             aria-hidden="true"
-            :alt="$t('一般の医療機関を受診')"
           />
           {{ $t('一般の医療機関を受診') }}
         </li>

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -14,6 +14,7 @@
             :class="$style.actionsListIcon"
             src="/flow/house-24px.svg"
             aria-hidden="true"
+            :alt="$t('自宅で安静に過ごす')"
           />
           {{ $t('自宅で安静に過ごす') }}
         </li>
@@ -22,6 +23,7 @@
             :class="$style.actionsListIcon"
             src="/flow/apartment-24px.svg"
             aria-hidden="true"
+            :alt="$t('一般の医療機関を受診')"
           />
           {{ $t('一般の医療機関を受診') }}
         </li>

--- a/components/flow/FlowPcPast.vue
+++ b/components/flow/FlowPcPast.vue
@@ -89,6 +89,7 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
         </em>
         <span :class="$style.FlowText">{{ $t('または') }}</span>
@@ -98,6 +99,7 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
         </em>
         <span :class="$style.FlowText">{{ $t('かつ') }}</span>
@@ -113,6 +115,7 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
         </em>
       </div>

--- a/components/flow/FlowPcPast.vue
+++ b/components/flow/FlowPcPast.vue
@@ -89,7 +89,6 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
-            :alt="$t('発熱')"
           />
         </em>
         <span :class="$style.FlowText">{{ $t('または') }}</span>
@@ -99,7 +98,6 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
-            :alt="$t('呼吸器症状')"
           />
         </em>
         <span :class="$style.FlowText">{{ $t('かつ') }}</span>

--- a/components/flow/FlowPcPast.vue
+++ b/components/flow/FlowPcPast.vue
@@ -89,6 +89,7 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            :alt="$t('発熱')"
           />
         </em>
         <span :class="$style.FlowText">{{ $t('または') }}</span>
@@ -98,6 +99,7 @@
             :class="$style.FlowSymptomIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            :alt="$t('呼吸器症状')"
           />
         </em>
         <span :class="$style.FlowText">{{ $t('かつ') }}</span>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -5,6 +5,7 @@
         :class="$style.Box1Icon"
         src="/flow/flow_arrow.svg"
         aria-hidden="true"
+        alt=" "
       />
       <div :class="$style.RowItems">
         <div :class="$style.RowItemsHeader">
@@ -12,6 +13,7 @@
             :class="$style.RowItemsHeaderIcon"
             src="/flow/sentiment_very_dissatisfied-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('不安に思う方') }}
         </div>
@@ -22,6 +24,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('微熱') }}
         </div>
@@ -30,6 +33,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('軽い咳') }}
         </div>
@@ -38,6 +42,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            alt=" "
           />
           {{ $t('感染の不安') }}
         </div>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -12,7 +12,6 @@
             :class="$style.RowItemsHeaderIcon"
             src="/flow/sentiment_very_dissatisfied-24px.svg"
             aria-hidden="true"
-            :alt="$t('不安に思う方')"
           />
           {{ $t('不安に思う方') }}
         </div>
@@ -23,7 +22,6 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
-            :alt="$t('微熱')"
           />
           {{ $t('微熱') }}
         </div>
@@ -32,7 +30,6 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
-            :alt="$t('軽い咳')"
           />
           {{ $t('軽い咳') }}
         </div>
@@ -41,7 +38,6 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
-            :alt="$t('感染の不安')"
           />
           {{ $t('感染の不安') }}
         </div>

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -12,6 +12,7 @@
             :class="$style.RowItemsHeaderIcon"
             src="/flow/sentiment_very_dissatisfied-24px.svg"
             aria-hidden="true"
+            :alt="$t('不安に思う方')"
           />
           {{ $t('不安に思う方') }}
         </div>
@@ -22,6 +23,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            :alt="$t('微熱')"
           />
           {{ $t('微熱') }}
         </div>
@@ -30,6 +32,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            :alt="$t('軽い咳')"
           />
           {{ $t('軽い咳') }}
         </div>
@@ -38,6 +41,7 @@
             :class="$style.CheckBoxIcon"
             src="/flow/check_circle-24px.svg"
             aria-hidden="true"
+            :alt="$t('感染の不安')"
           />
           {{ $t('感染の不安') }}
         </div>
@@ -58,6 +62,7 @@
             :class="$style.TelLinkIcon"
             src="/flow/phone-24px.svg"
             aria-hidden="true"
+            :alt="$t('電話番号')"
           />
           0570-550571
         </a>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #1925

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
`img`タグに`alt`属性を追加した。
なお、以下の文字列に隣り合った`img`タグへの`alt`属性は追加できていないので、`closes`を付けていません。
- `components/flow/FlowPcDays.vue`
   - 風邪のような症状
   - 発熱 37.5℃ 以上
- `components/flow/FlowPcPast.vue`: 発熱 37.5℃ 以上

## 📸 スクリーンショット / Screenshots
なし