### PR TITLE
(PR) サイドバークリック時の下線

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -216,10 +216,9 @@ export default Vue.extend({
 <style lang="scss" scoped>
 .SideNavigation {
   position: relative;
-  height: 100%;
-  background: $white;
-  box-shadow: 0 0 2px rgba(0, 0, 0, 0.15);
-
+  @include lessThan($small) {
+    box-shadow: 0 0 2px rgba(0, 0, 0, 0.15);
+  }
   &:focus {
     outline: 1px dotted $gray-3;
   }
@@ -333,7 +332,6 @@ export default Vue.extend({
 
 .SideNavigation-Body {
   padding: 0 20px 20px;
-  background-color: $white;
   @include lessThan($small) {
     display: none;
     padding: 0 36px 36px;
@@ -371,7 +369,6 @@ export default Vue.extend({
 
 .SideNavigation-Footer {
   padding-top: 20px;
-  background-color: $white;
 }
 
 .SideNavigation-Social {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -197,6 +197,10 @@ export default Vue.extend({
   }
 }
 
+.naviContainer {
+  background-color: $white;
+}
+
 @include lessThan($small) {
   .naviContainer {
     position: sticky;


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #2083 

## ⛏ 変更内容 / Details of Changes

- cssを調整
    - サイドバー内の複数の要素に散らばっていたサイドバーの背景色を `.naviContainer` に一本化
    - `.SideNavigation` の `height: 100%` を削除
    - `.SideNavigation` の `box-shadow` をSP時のみ表示に変更
- 補足
    - `.SideNavigation` に `height: 100%` が設定された状態でfocus時のoutlineが設定されたため、 サイドバー内でスクロールが発生する状態かつスクロールした状態でサイドバーにフォーカスすると `.SideNavigation` の下側のoutlineが中途半端な位置に表示されていた
    - このPRでは逆にサイドバーにスクロールが発生しない状態でサイドバーにフォーカスすると最後の項目の下にoutlineが表示されるようになる（下記スクショ参照）
        - 実際にフォーカスしている領域と外観（outline）の関係が正しいため、こちらが本来の動作だと思われる

## 📸 スクリーンショット / Screenshots

![image](https://user-images.githubusercontent.com/3162324/77257182-11668300-6cb6-11ea-883a-0752a25f2bb2.png)
