### PR TITLE
TypeScript: Vue.extend に統一

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -23,20 +23,30 @@
 </template>
 
 <script lang="ts">
-import { Vue, Component } from 'vue-property-decorator'
+import Vue from 'vue'
 import EarthIcon from '@/static/earth.svg'
 import SelectMenuIcon from '@/static/selectmenu.svg'
 
-@Component({
-  components: { EarthIcon, SelectMenuIcon }
-})
-export default class LanguageSelector extends Vue {
-  currentLocaleCode: string = this.$root.$i18n.locale
-
-  handleChangeLanguage() {
-    this.$root.$i18n.setLocale(this.currentLocaleCode)
-  }
+type LocalData = {
+  currentLocaleCode: string
 }
+
+export default Vue.extend({
+  components: {
+    EarthIcon,
+    SelectMenuIcon
+  },
+  data(): LocalData {
+    return {
+      currentLocaleCode: this.$root.$i18n.locale
+    }
+  },
+  methods: {
+    handleChangeLanguage() {
+      this.$root.$i18n.setLocale(this.currentLocaleCode)
+    }
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -17,7 +17,7 @@
           v-if="isExternal(item.link)"
           role="img"
           aria-hidden="false"
-          :aria-label="this.$t('別タブで開く')"
+          :aria-label="$t('別タブで開く')"
           class="MenuList-ExternalIcon"
           size="12"
         >

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -17,7 +17,7 @@
           v-if="isExternal(item.link)"
           role="img"
           aria-hidden="false"
-          aria-label="別タブで開く"
+          :aria-label="this.$t('別タブで開く')"
           class="MenuList-ExternalIcon"
           size="12"
         >

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -32,64 +32,67 @@
 </template>
 
 <script lang="ts">
-import { Vue, Prop, Component } from 'vue-property-decorator'
+import Vue, { PropType } from 'vue'
 import CovidIcon from '@/static/covid.svg'
 import ParentIcon from '@/static/parent.svg'
 
-type menuItem = {
+type MenuItem = {
   icon?: string
   title: string
   link: string
   divider?: boolean
 }
 
-@Component({
-  components: { CovidIcon, ParentIcon }
-})
-export default class MenuList extends Vue {
-  @Prop({ required: true }) items!: menuItem[]
-
-  linkTag(link: menuItem['link']) {
-    return this.isExternal(link) ? 'a' : 'nuxt-link'
-  }
-
-  linkAttrs(link: menuItem['link']) {
-    return this.isExternal(link)
-      ? {
-          href: link,
-          target: '_blank',
-          rel: 'noopener',
-          class: 'MenuList-Link'
-        }
-      : {
-          to: link,
-          router: true,
-          class: 'MenuList-Link'
-        }
-  }
-
-  prefixIconTag(icon: menuItem['icon']) {
-    return icon ? (icon.startsWith('mdi') ? 'v-icon' : icon) : null
-  }
-
-  prefixIconAttrs(icon: menuItem['icon']) {
-    return icon
-      ? icon.startsWith('mdi')
+export default Vue.extend({
+  components: {
+    CovidIcon,
+    ParentIcon
+  },
+  props: {
+    items: {
+      type: Array as PropType<MenuItem[]>,
+      required: true
+    }
+  },
+  methods: {
+    linkTag(link: MenuItem['link']) {
+      return this.isExternal(link) ? 'a' : 'nuxt-link'
+    },
+    linkAttrs(link: MenuItem['link']) {
+      return this.isExternal(link)
         ? {
-            size: 20,
-            class: 'MenuList-MdIcon'
+            href: link,
+            target: '_blank',
+            rel: 'noopener',
+            class: 'MenuList-Link'
           }
         : {
-            'aria-hidden': true,
-            class: 'MenuList-SvgIcon'
+            to: link,
+            router: true,
+            class: 'MenuList-Link'
           }
-      : null
+    },
+    prefixIconTag(icon: MenuItem['icon']) {
+      return icon ? (icon.startsWith('mdi') ? 'v-icon' : icon) : null
+    },
+    prefixIconAttrs(icon: MenuItem['icon']) {
+      return icon
+        ? icon.startsWith('mdi')
+          ? {
+              size: 20,
+              class: 'MenuList-MdIcon'
+            }
+          : {
+              'aria-hidden': true,
+              class: 'MenuList-SvgIcon'
+            }
+        : null
+    },
+    isExternal(path: MenuItem['link']): boolean {
+      return /^https?:\/\//.test(path)
+    }
   }
-
-  isExternal(path: menuItem['link']): boolean {
-    return /^https?:\/\//.test(path)
-  }
-}
+})
 </script>
 
 <style lang="scss" scoped>

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -8,10 +8,7 @@
     >
       <component :is="linkTag(item.link)" v-bind="linkAttrs(item.link)">
         <span v-if="item.icon" class="MenuList-Icon">
-          <component
-            :is="prefixIconTag(item.icon)"
-            v-bind="prefixIconAttrs(item.icon)"
-          >
+          <component :is="iconTag(item.icon)" v-bind="iconAttrs(item.icon)">
             {{ item.icon }}
           </component>
         </span>
@@ -72,10 +69,10 @@ export default Vue.extend({
             class: 'MenuList-Link'
           }
     },
-    prefixIconTag(icon: MenuItem['icon']) {
+    iconTag(icon: MenuItem['icon']) {
       return icon ? (icon.startsWith('mdi') ? 'v-icon' : icon) : null
     },
-    prefixIconAttrs(icon: MenuItem['icon']) {
+    iconAttrs(icon: MenuItem['icon']) {
       return icon
         ? icon.startsWith('mdi')
           ? {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "nuxt": "^2.11.0",
     "nuxt-i18n": "^6.6.0",
     "vue-chartjs": "^3.5.0",
-    "vue-property-decorator": "^8.4.0",
     "vue-scrollto": "^2.17.1",
     "vue-spinner": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -11610,11 +11610,6 @@ vue-chartjs@^3.5.0:
   resolved "https://registry.yarnpkg.com/vue-chartjs/-/vue-chartjs-3.5.0.tgz#edd0c2be94c521bcbc5357c24afb9f3560855f84"
   integrity sha512-yWNhG3B6g6lvYqNInP0WaDWNZG/SNb6XnltkjR0wYC5pmLm6jvdiotj8er7Mui8qkJGfLZe6ULjrZdHWjegAUg==
 
-vue-class-component@^7.1.0:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.3.tgz#a5b1abd53513a72ad51098752e2dedd499807cca"
-  integrity sha512-oEqYpXKaFN+TaXU+mRLEx8dX0ah85aAJEe61mpdoUrq0Bhe/6sWhyZX1JjMQLhVsHAkncyhedhmCdDVSasUtDw==
-
 vue-client-only@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/vue-client-only/-/vue-client-only-2.0.0.tgz#ddad8d675ee02c761a14229f0e440e219de1da1c"
@@ -11681,13 +11676,6 @@ vue-no-ssr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz#875f3be6fb0ae41568a837f3ac1a80eaa137b998"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
-
-vue-property-decorator@^8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/vue-property-decorator/-/vue-property-decorator-8.4.0.tgz#f4e641f84ca51a7b4721e236392a1efbb6eac00b"
-  integrity sha512-0o85LJSTLZvDaB7IXfmpONfAQZ7NgScFvptFSrlFFSsScR716muJb3mMFojNnKC3Vpm7CM4PsmHNdk30uuNpag==
-  dependencies:
-    vue-class-component "^7.1.0"
 
 vue-router@^3.1.3:
   version "3.1.6"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2096 
- close #0

## 📝 関連する issue / Related Issues
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 33個中2コンポーネントでしか使われていない vue-property-decorator を削除
- 対象コンポーネントに i18n 対応漏れがあったので同時に修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
