### PR TITLE
[WIP] グラフの横スクロール 試作

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -357,6 +357,16 @@ export default Vue.extend({
 
   &-CardText {
     margin: 16px 0;
+    position: relative;
+    overflow: hidden;
+    > div:first-child {
+      overflow-x: scroll;
+    }
+    > div:nth-child(2) {
+      position: absolute;
+      top: 0;
+      pointer-events: none;
+    }
   }
 
   &-Description {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -16,6 +16,15 @@
       :chart-data="displayData"
       :options="displayOption"
       :height="240"
+      :width="800"
+    />
+    <bar-header
+      :style="{ display: canvas ? 'block' : 'none' }"
+      :chart-id="chartId"
+      :chart-data="displayData"
+      :options="displayOptionHeader"
+      :height="240"
+      :width="800"
     />
     <v-data-table
       :style="{ top: '-9999px', position: canvas ? 'fixed' : 'static' }"
@@ -74,6 +83,21 @@ type Computed = {
     }[]
   }
   displayOption: {
+    tooltips: {
+      displayColors: boolean
+      callbacks: {
+        label(tooltipItem: any): string
+        title(tooltipItem: any[], data: any): string | undefined
+      }
+    }
+    responsive: boolean
+    maintainAspectRatio: boolean
+    legend: {
+      display: boolean
+    }
+    scales: object
+  }
+  displayOptionHeader: {
     tooltips: {
       displayColors: boolean
       callbacks: {
@@ -235,7 +259,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             }
           }
         },
-        responsive: true,
+        responsive: false,
         maintainAspectRatio: false,
         legend: {
           display: false
@@ -331,6 +355,114 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
+      }
+      return options
+    },
+    displayOptionHeader() {
+      const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      const options = {
+        tooltips: {
+          displayColors: false,
+          callbacks: {
+            label(tooltipItem: any) {
+              const labelText = `${parseInt(
+                tooltipItem.value
+              ).toLocaleString()} ${unit}`
+              return labelText
+            },
+            title(tooltipItem: any, data: any) {
+              return data.labels[tooltipItem[0].index]
+            }
+          }
+        },
+        responsive: false,
+        maintainAspectRatio: false,
+        legend: {
+          display: false
+        },
+        scales: {
+          xAxes: [
+            {
+              id: 'day',
+              stacked: true,
+              gridLines: {
+                display: false
+              },
+              ticks: {
+                fontSize: 9,
+                maxTicksLimit: 20,
+                fontColor: 'transparent',
+                maxRotation: 0,
+                minRotation: 0,
+                callback: (label: string) => {
+                  return label.split('/')[1]
+                }
+              }
+            },
+            {
+              id: 'month',
+              stacked: true,
+              gridLines: {
+                drawOnChartArea: false,
+                drawTicks: false, // true -> false
+                drawBorder: false,
+                tickMarkLength: 10
+              },
+              ticks: {
+                fontSize: 11,
+                fontColor: 'transparent', // #808080
+                padding: 13, // 3 + 10(tickMarkLength) + 9(day:fontSize) * 1.2(tick default line-height)
+                fontStyle: 'bold',
+                gridLines: {
+                  display: true
+                },
+                callback: (label: string) => {
+                  const monthStringArry = [
+                    'Jan',
+                    'Feb',
+                    'Mar',
+                    'Apr',
+                    'May',
+                    'Jun',
+                    'Jul',
+                    'Aug',
+                    'Sep',
+                    'Oct',
+                    'Nov',
+                    'Dec'
+                  ]
+                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
+                  return month + '月'
+                }
+              },
+              type: 'time',
+              time: {
+                unit: 'month'
+              }
+            }
+          ],
+          yAxes: [
+            {
+              location: 'bottom',
+              stacked: true,
+              gridLines: {
+                display: true,
+                drawOnChartArea: false,
+                color: '#E5E5E5' // #E5E5E5
+              },
+              ticks: {
+                suggestedMin: 0,
+                maxTicksLimit: 8,
+                fontColor: '#808080', // #808080
+                suggestedMax: scaledTicksYAxisMax
+              }
+            }
+          ]
+        },
+        animation: {
+          duration: 0
+        }
       }
       return options
     },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -20,7 +20,7 @@
     />
     <bar-header
       :style="{ display: canvas ? 'block' : 'none' }"
-      :chart-id="chartId"
+      :chart-id="`${chartId}-header`"
       :chart-data="displayData"
       :options="displayOptionHeader"
       :height="240"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -422,23 +422,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const unit = this.unit
       const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options = {
-        tooltips: {
-          displayColors: false,
-          callbacks: {
-            label(tooltipItem: any) {
-              const labelText = `${parseInt(
-                tooltipItem.value
-              ).toLocaleString()} ${unit}`
-              return labelText
-            },
-            title(tooltipItem: any, data: any) {
-              return data.labels[tooltipItem[0].index]
-            }
-          }
-        },
         responsive: false,
         maintainAspectRatio: false,
         legend: {
@@ -475,7 +460,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 11,
                 fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength) + 9(day:fontSize) * 1.2(tick default line-height)
+                padding: 13, // 3 + 10(tickMarkLength)
                 fontStyle: 'bold',
                 gridLines: {
                   display: true
@@ -523,14 +508,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             }
           ]
         },
-        animation: {
-          duration: 0
-        },
-        plugins: [
-          {
-            fill: {}
-          }
-        ]
+        animation: false
       }
       return options
     },

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -1,19 +1,14 @@
 import Vue, { PropType } from 'vue'
-import { ChartData, ChartOptions, Chart } from 'chart.js'
-import { Doughnut, Bar, mixins, generateChart } from 'vue-chartjs'
+import { ChartData, ChartOptions } from 'chart.js'
+import { Doughnut, Bar, mixins } from 'vue-chartjs'
 import { Plugin } from '@nuxt/types'
 
 type ChartVCData = { chartData: ChartData }
 type ChartVCMethod = {
   renderChart(chartData: ChartData, options: ChartOptions): void
-  addPlugin(plugin: any): void
 }
 type ChartVCComputed = unknown
 type ChartVCProps = { options: Object }
-
-Chart.defaults.barHeader = Chart.defaults.bar
-Chart.controllers.barHeader = Chart.controllers.bar
-const BarHeader = generateChart('bar-header', 'barHeader')
 
 const VueChartPlugin: Plugin = () => {
   const { reactiveProp } = mixins
@@ -47,60 +42,6 @@ const VueChartPlugin: Plugin = () => {
         }
       },
       mounted(): void {
-        this.renderChart(this.chartData, this.options)
-      }
-    }
-  )
-
-  Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
-    'barHeader',
-    {
-      extends: BarHeader,
-      mixins: [reactiveProp],
-      props: {
-        options: {
-          type: Object,
-          default: () => {}
-        }
-      },
-      mounted(): void {
-        this.addPlugin({
-          id: 'fill',
-          beforeDraw(chartInstance: any) {
-            const { ctx } = chartInstance.chart
-
-            // プロットエリアマスク用
-            ctx.fillStyle = '#fff'
-            ctx.fillRect(
-              0,
-              0,
-              chartInstance.chartArea.left,
-              chartInstance.chartArea.bottom + 1
-            )
-
-            // 横軸マスク用
-            const gradient = ctx.createLinearGradient(
-              0,
-              0,
-              chartInstance.chartArea.left,
-              0
-            )
-            gradient.addColorStop(0, 'rgba(255,255,255,1)')
-            gradient.addColorStop(1, 'rgba(255,255,255,0)')
-            ctx.fillStyle = gradient
-            ctx.fillRect(
-              0,
-              chartInstance.chartArea.bottom + 1,
-              chartInstance.chartArea.left,
-              chartInstance.height - chartInstance.chartArea.bottom - 1
-            )
-          }
-          /*
-          afterRender: function(chartInstance: any) {
-            console.log('afterRender')
-          }
-          */
-        })
         this.renderChart(this.chartData, this.options)
       }
     }

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -1,14 +1,19 @@
 import Vue, { PropType } from 'vue'
-import { ChartData, ChartOptions } from 'chart.js'
-import { Doughnut, Bar, mixins } from 'vue-chartjs'
+import { ChartData, ChartOptions, Chart } from 'chart.js'
+import { Doughnut, Bar, mixins, generateChart } from 'vue-chartjs'
 import { Plugin } from '@nuxt/types'
 
 type ChartVCData = { chartData: ChartData }
 type ChartVCMethod = {
   renderChart(chartData: ChartData, options: ChartOptions): void
+  addPlugin(plugin: any): void
 }
 type ChartVCComputed = unknown
 type ChartVCProps = { options: Object }
+
+Chart.defaults.barHeader = Chart.defaults.bar
+Chart.controllers.barHeader = Chart.controllers.bar
+const BarHeader = generateChart('bar-header', 'barHeader')
 
 const VueChartPlugin: Plugin = () => {
   const { reactiveProp } = mixins
@@ -42,6 +47,60 @@ const VueChartPlugin: Plugin = () => {
         }
       },
       mounted(): void {
+        this.renderChart(this.chartData, this.options)
+      }
+    }
+  )
+
+  Vue.component<ChartVCData, ChartVCMethod, ChartVCComputed, ChartVCProps>(
+    'barHeader',
+    {
+      extends: BarHeader,
+      mixins: [reactiveProp],
+      props: {
+        options: {
+          type: Object,
+          default: () => {}
+        }
+      },
+      mounted(): void {
+        this.addPlugin({
+          id: 'fill',
+          beforeDraw(chartInstance: any) {
+            const { ctx } = chartInstance.chart
+
+            // プロットエリアマスク用
+            ctx.fillStyle = '#fff'
+            ctx.fillRect(
+              0,
+              0,
+              chartInstance.chartArea.left,
+              chartInstance.chartArea.bottom + 1
+            )
+
+            // 横軸マスク用
+            const gradient = ctx.createLinearGradient(
+              0,
+              0,
+              chartInstance.chartArea.left,
+              0
+            )
+            gradient.addColorStop(0, 'rgba(255,255,255,1)')
+            gradient.addColorStop(1, 'rgba(255,255,255,0)')
+            ctx.fillStyle = gradient
+            ctx.fillRect(
+              0,
+              chartInstance.chartArea.bottom + 1,
+              chartInstance.chartArea.left,
+              chartInstance.height - chartInstance.chartArea.bottom - 1
+            )
+          }
+          /*
+          afterRender: function(chartInstance: any) {
+            console.log('afterRender')
+          }
+          */
+        })
         this.renderChart(this.chartData, this.options)
       }
     }


### PR DESCRIPTION
※不要になり次第こちらでcloseします

## 📝 関連する issue / Related Issues

- #316
- #636

## ⛏ 変更内容 / Details of Changes

- 与件
    - 縦軸を固定表示しプロットエリアと横軸だけ横スクロールさせる
- 方針
    - 「本体グラフから縦軸以外の要素を透明化ないし削除し、プロットエリアより左側に背景色を入れたマスク用グラフ」を作って本体グラフの上に重ねる
    - マウス・タッチは `pointer-events: none;` で透過させる

### 8d1a14b の実装

- TimeBarChartのみ
- `plugins/vue-chart.ts`
    - `bar` を継承した `barHeader` を定義
    - `ChartVCMethod` に `addPlugin` 用の記述を追加
    - マスク用背景の描画を `addPlugin` で実装
- `components/TimeBarChart.vue`
    - マスク用グラフ `barHeader` を `bar` の下に追加
    - `barHeader` 専用のoptionsを追加
    - スクロールの動作確認のためにグラフの幅を固定しresponsiveを解除
- `components/DataView.vue`
    - マスクとスクロールの動作確認のための仮スタイルを追記

#### 今後必要と思われるもの

- `vue-chart.ts` からanyを消す
- `barHeader` の描画負荷を最小化するためにoptionsから不要な項目を削除する
    - 文字などで色をtransparentにして残さないとズレるものがある
    - tooltipなどは不要
    - typeを用意する必要あり
- マスク用グラフが使うダミーデータを用意する
    - `scaledTicksYAxisMax` で縦軸の内容を本体グラフと合わせる必要があるため、本体グラフの用のデータから最大値を抽出すればいいはず
- `vue-chart.ts` に書いているpluginをコンポーネント側（今回なら`TimeBarChart.vue`）に記述する方法があるかも知れない
    - それが可能なら `vue-chart.ts` は弄らずに済み、マスク用グラフもoptionsだけ変えたbarで行ける
    - ~~どこかで `<bar (中略) :plugins="pluginName" />` のような記述を見た、`inline plugin`？~~ 
 3943efc で（恐らく）解決
- 本体グラフの横幅の仕様決定と実装
- 見た目の調整
    - 初期状態を最新のデータが表示された状態にする
    - スクロール可能であることを示すなんらかの表現（ #1001 のような）
- a11y
- TimeBarChart以外に展開
    - https://github.com/tokyo-metropolitan-gov/covid19/pull/636#issuecomment-602040301 の2

## 📸 スクリーンショット / Screenshots

![animation](https://user-images.githubusercontent.com/3162324/77291196-1d3b5f00-6d21-11ea-861e-8e13b3b9d0ad.gif)

![image](https://user-images.githubusercontent.com/3162324/77297358-7b217400-6d2c-11ea-9ed8-7a21ab4c19d8.png)
