### PR TITLE
fix: 新宿区&千代田区の来訪者推移グラフの横軸の日付範囲を変更

### DIFF
--- a/components/VisitorsBarChart.vue
+++ b/components/VisitorsBarChart.vue
@@ -216,14 +216,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         }, {} as any)
     },
     labels() {
-      return Object.keys(this.targetData).map((weekNum: any) => {
+      return Object.keys(this.targetData).map((weekNum: string) => {
+        // 日付範囲は月曜日から金曜日（平日のみ）
         const start = dayjs(this.startDate)
-          .week(weekNum)
-          .startOf('week')
+          .week(parseInt(weekNum, 10))
+          .day(1)
           .format('M/D')
         const end = dayjs(this.startDate)
-          .week(weekNum)
-          .endOf('week')
+          .week(parseInt(weekNum, 10))
+          .day(5)
           .format('M/D')
         return `${start}~${end}`
       })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2114 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 来訪者推移グラフの横軸の日付範囲を月曜日はじまり金曜日おわりに変更

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-03-23 22 47 59](https://user-images.githubusercontent.com/5207601/77323315-65c23f00-6d58-11ea-877a-93f94f8cfea5.png)