### PR TITLE
スクリーンリーダー向け隠しtableの列見出しの修正

### DIFF
--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -317,5 +317,6 @@
   "クリップボードにコピー": "クリップボードにコピー",
   "LINEで{title}のグラフをシェア": "LINEで{title}のグラフをシェア",
   "Twitterで{title}のグラフをシェア": "Twitterで{title}のグラフをシェア",
-  "facebookで{title}のグラフをシェア": "facebookで{title}のグラフをシェア"
+  "facebookで{title}のグラフをシェア": "facebookで{title}のグラフをシェア",
+  "日付": "日付"
 }

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -71,7 +71,7 @@ type Computed = {
   }
   displayOption: ChartOptions
   tableHeaders: {
-    text: string
+    text: VueI18n.TranslateResult
     value: string
   }[]
   tableData: {

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -20,6 +20,7 @@
       :hide-default-footer="true"
       :height="240"
       :fixed-header="true"
+      :disable-sort="true"
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
@@ -231,7 +232,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'text' },
+        { text: this.$t('日付'), value: 'text' },
         ...this.displayData.datasets.map((text, value) => {
           return { text: text.label, value: String(value) }
         })

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -41,6 +41,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { TranslateResult } from 'vue-i18n'
 import { ChartOptions, ChartData } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
@@ -65,7 +66,7 @@ type Computed = {
     }[]
   }
   tableHeaders: {
-    text: string
+    text: TranslateResult
     value: string
   }[]
   tableData: {

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -20,6 +20,7 @@
       :hide-default-footer="true"
       :height="240"
       :fixed-header="true"
+      :disable-sort="true"
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
@@ -170,7 +171,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'text' },
+        { text: this.$t('日付'), value: 'text' },
         ...this.chartData.labels!.map((text, value) => {
           return { text: text as string, value: String(value) }
         })

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -23,9 +23,9 @@
       :items="tableData"
       :items-per-page="-1"
       :hide-default-footer="true"
-      :hide-default-header="true"
       :height="240"
       :fixed-header="true"
+      :disable-sort="true"
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
@@ -343,7 +343,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'text' },
+        { text: this.$t('日付'), value: 'text' },
         { text: this.title, value: '0' }
       ]
     },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -42,6 +42,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { TranslateResult } from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
@@ -90,7 +91,7 @@ type Computed = {
   }
   scaledTicksYAxisMax: number
   tableHeaders: {
-    text: string
+    text: TranslateResult
     value: string
   }[]
   tableData: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -96,7 +96,7 @@ type Computed = {
     }[]
   }
   tableHeaders: {
-    text: string
+    text: TranslateResult
     value: string
   }[]
   tableData: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -37,6 +37,7 @@
       :hide-default-footer="true"
       :height="240"
       :fixed-header="true"
+      :disable-sort="true"
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
@@ -242,7 +243,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'text' },
+        { text: this.$t('日付'), value: 'text' },
         ...this.items.map((text, value) => {
           return { text, value: String(value) }
         })

--- a/components/VisitorsBarChart.vue
+++ b/components/VisitorsBarChart.vue
@@ -62,6 +62,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import { TranslateResult } from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import dayjs from 'dayjs'
 import 'dayjs/locale/en'
@@ -97,7 +98,7 @@ type Computed = {
   labels: string[]
   standardValue: number
   tableHeaders: {
-    text: string
+    text: TranslateResult
     value: string
   }[]
   tableData: {

--- a/components/VisitorsBarChart.vue
+++ b/components/VisitorsBarChart.vue
@@ -32,6 +32,7 @@
       :hide-default-footer="true"
       :height="240"
       :fixed-header="true"
+      :disable-sort="true"
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
@@ -269,7 +270,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     tableHeaders() {
       return [
-        { text: '', value: 'header' },
+        { text: this.$t('日付'), value: 'header' },
         { text: this.title, value: 'visitor' }
       ]
     },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2049 

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- スクリーンリーダー向け隠しtableの列見出しを修正
  - 列見出し(header)を表示していなかったものは表示させる
    - TimeBarChart.vue
  - 列見出しtextの最適化
    - 日付の列には「日付」
    - データ列には各データ項目のラベル
  - 列見出しtextのノイズ除去
    - `aria-label`に不要なsortに関するラベルを表示させないようにする

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### Before
![th_before](https://user-images.githubusercontent.com/1453889/77331265-d4f16080-6d63-11ea-8ec5-2852b8146a6b.png)

### After
![th_after](https://user-images.githubusercontent.com/1453889/77331288-dcb10500-6d63-11ea-978b-32b5ad2f7a35.png)