### PR TITLE
ドキュメントからdev-i18nブランチの記載を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ docker-compose run --rm app yarn install
 
 ### ブランチルール
 
-development, dev-i18n, dev-hotfix 以外は Pull Request は禁止です。  
+development, dev-hotfix 以外は Pull Request は禁止です。
 Pull Request を送る際の branch は、以下のネーミングルールでお願いします。
 
 機能追加系： feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -103,7 +103,6 @@ Pull Request を送る際の branch は、以下のネーミングルールで�
 | ---- | -------- | ---- | ---- |
 | 開発 | development | https://dev-covid19-tokyo.netlify.com/ | base branch。基本はこちらに Pull Requestを送ってください |
 | 緊急適用用 | dev-hotfix | なし | 急ぎ本番に適用するべき修正。管理者から依頼された場合こちらを使ってください |
-| i18n 作業用 | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | テンポラリで使っています |
 | ステージング | staging | https://stg-covid19-tokyo.netlify.com/ | 本番前の最終確認用。管理者以外の Pull Request は禁止です |
 | 本番 | master | https://stopcovid19.metro.tokyo.lg.jp/ | 管理者以外の Pull Request は禁止です |
 

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -35,10 +35,10 @@ If you want to add new language. Please request new language via Transifex syste
 
 ## For developers
 
-If you have something new texts which needs translation, please add the strings to `../assets/locales/ja.json` and make a pull request to `dev-i18n`branch. You can use same string for key and value.
+If you have something new texts which needs translation, please add the strings to `../assets/locales/ja.json` and make a pull request to `development`branch. You can use same string for key and value.
 
 We are using [nuxt-i18n](https://github.com/nuxt-community/nuxt-i18n) as a translation system. Please refer [their document](https://nuxtjs.org/examples/i18n/) to know how to use the library.
 
 When you need to get translated text immediately, please ask to push the latest changes from Transifex in the #covid19 channel in Code for Japan Slack (see [our respos](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/docs/en/CONTRIBUTING.md#how-to-participate-in-communications)).
 
-After the text was translated, an organizer will apply new resources on the `dev-i18n` branch.
+After the text was translated, an organizer will apply new resources on the `development` branch.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -90,7 +90,7 @@ and then the development site (https://dev-covid19-tokyo.netlify.com/) will be a
 
 ### Branch rules
 
-Pull Request is allowed only for `development`, `dev-i18n` and `dev-hotfix`.  
+Pull Request is allowed only for `development` and `dev-hotfix`.
 Please use the following naming rules for the branch when sending a Pull Request.
 
 Feature implementation: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -101,7 +101,6 @@ Hotfix commit: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | Development | development | https://dev-covid19-tokyo.netlify.com/ | base branch. Basically send a Pull Request here |
 | Hotfix branch | dev-hotfix | None | Fixes that should be applied to production in haste. Use this if requested by the administrator |
-| i18n working branch | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | Temporarily used |
 | Staging | staging | https://stg-covid19-tokyo.netlify.com/ | For final confirmation before production. Non-admin pull requests are prohibited |
 Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Pull Requests other than Administrators are prohibited |
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -81,7 +81,7 @@ y luego el sitio de desarrollo (https://dev-covid19-tokyo.netlify.com/) también
 
 ### Branch rules
 
-Pull Request is allowed only for `development`, `dev-i18n` and `dev-hotfix`.  
+Pull Request is allowed only for `development` and `dev-hotfix`.
 Please use the following naming rules for the branch when sending a Pull Request.
 
 Feature implementation: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -92,7 +92,6 @@ Hotfix commit: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | Development | development | https://dev-covid19-tokyo.netlify.com/ | base branch. Basically send a Pull Request here |
 | Hotfix branch | dev-hotfix | None | Fixes that should be applied to production in haste. Use this if requested by the administrator |
-| i18n working branch | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | Temporarily used |
 | Staging | staging | https://stg-covid19-tokyo.netlify.com/ | For final confirmation before production. Non-admin pull requests are prohibited |
 Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Pull Requests other than Administrators are prohibited |
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -86,7 +86,7 @@ et le site development (https://dev-covid19-tokyo.netlify.com/) est aussi mis-à
 
 ### Regles sur les branches
 
-Les Pull Request sont permises seulement sur `development`, `dev-i18n`, et `dev-hotfix`.  
+Les Pull Request sont permises seulement sur `development`, et `dev-hotfix`.
 Veuillez utiliser le schema suivant pour nommer vos Pull Request:
 
 Nouvelle feature: feature/#{ISSUE_ID}-#{nom_de_la_branche}  
@@ -98,7 +98,6 @@ Hotfix: hotfix/#{ISSUE_ID}-{nom_de_la_branche}
 | ---- | -------- | ---- | ---- |
 | Development | development | https://dev-covid19-tokyo.netlify.com/ | Branche de base. Faites votre Pull Request ici. |
 | Hotfix branch | dev-hotfix | None | Fixs qui devraient etre appliques a l'environnement de production rapidement. Utilisez cette branche si demande par l'administrateur. |
-| i18n working branch | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | Branche temporaire. |
 | Staging | staging | https://stg-covid19-tokyo.netlify.com/ | Pour confirmation avant production. Pull request d'utilisateurs non-admin sont defendues. |
 Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Pull request d'utilisateurs non-admin sont defendues. |
 

--- a/docs/ko/README.md
+++ b/docs/ko/README.md
@@ -88,7 +88,7 @@ $ docker-compose run --rm app yarn install
 
 ### 브랜치(Branch) 규칙
 
-풀 리퀘스트(Pull Request)는 오직 `development`, `dev-i18n`, `dev-hotfix`에서만 가능합니다.
+풀 리퀘스트(Pull Request)는 오직 `development`, `dev-hotfix`에서만 가능합니다.
 만약, 풀 리퀘스트(Pull Request)를 전달할 때 다음의 네이밍(naming) 규칙를 따라 사용해주시기 바랍니다.
 
 기능 구현: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -99,7 +99,6 @@ $ docker-compose run --rm app yarn install
 | ---- | -------- | ---- | ---- |
 | 개발 | development | https://dev-covid19-tokyo.netlify.com/ | 기본 브랜치(branch). 기본은 여기로 풀 리퀘스트를 전달하세요.|
 | 핫픽스(hotfix) 브랜치 | dev-hotfix | 없음 | 급하게 프로덕션(production)에 적용해야하는 수정사항용 브랜치입니다. 관리자가 요청한 경우에 사용하세요. |
-| i18n 작업용 브랜치 | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | 임시로 사용됩니다. |
 | 스테이징(Staging) | staging | https://stg-covid19-tokyo.netlify.com/ | 프로덕션(production) 적용 전에 최종 확인용 브랜치입니다. 관리자가 아닌 풀 리퀘스트(Pull Request)는 금지입니다. |
 | 프로덕션(Production) | master | https://stopcovid19.metro.tokyo.lg.jp/ | 관리자 이외의 풀 리퀘스트(Pull Request)는 금지입니다. |
 

--- a/docs/th/README.md
+++ b/docs/th/README.md
@@ -82,7 +82,7 @@ $ docker-compose run --rm app yarn install
 
 ### กฎการใช้ branch
 
-pull request เปิดรับได้ที่ `development`, `dev-i18n` และ `dev-hotfix` เท่านั้น
+pull request เปิดรับได้ที่ `development` และ `dev-hotfix` เท่านั้น
 โปรดตั้งชื่อ branch ดังนี้
 
 การสร้างฟีเจอร์: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -93,7 +93,6 @@ hotfix commit: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | Development | development | http://dev-covid19-tokyo.netlify.com/ | branch หลัก ใช้ในการรับ pull request |
 | Hotfix branch | dev-hotfix | None | Branch สำหรับ hotfix ของ production - ใช้ในกรณีที่ admin อนุญาตแล้วเท่านั้น |
-| i18n working branch | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | ใช้ชั่วคราว |
 | Staging | staging | https://stg-covid19-tokyo.netlify.com/ | ใช้สำหรับ staging ทดสอบตัวปรับปรุง ก่อน deploy ลง production - ห้ามสร้าง pull request ยกเว้นจาก admin เอง |
 | Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | ห้ามสร้าง pull request ยกเว้นจาก admin เอง |
 

--- a/docs/vi/README.md
+++ b/docs/vi/README.md
@@ -77,7 +77,7 @@ Khi nhánh `development` được cập nhật, file HTML sẽ tự động đư
 
 ### Branch rules
 
-Pull Request is allowed only for `development`, `dev-i18n` and `dev-hotfix`.  
+Pull Request is allowed only for `development` and `dev-hotfix`.
 Please use the following naming rules for the branch when sending a Pull Request.
 
 Feature implementation: feature/#{ISSUE_ID}-#{branch_title_name}
@@ -88,7 +88,6 @@ Hotfix commit: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | Development | development | https://dev-covid19-tokyo.netlify.com/ | base branch. Basically send a Pull Request here |
 | Hotfix branch | dev-hotfix | None | Fixes that should be applied to production in haste. Use this if requested by the administrator |
-| i18n working branch | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | Temporarily used |
 | Staging | staging | https://stg-covid19-tokyo.netlify.com/ | For final confirmation before production. Non-admin pull requests are prohibited |
 Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Pull Requests other than Administrators are prohibited |
 

--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -57,7 +57,7 @@ $ docker-compose up --build
 
 ### 判断生产环境/其他环境
 
-`process.env.GENERATE_ENV` 这个值在生产环境为 `'production'` 除此之外为 `'development'` 。  
+`process.env.GENERATE_ENV` 这个值在生产环境为 `'production'` 除此之外为 `'development'` 。
 如果只想要在测试环境中运行的话，请使用这个值作为参考。
 
 ### 发布到 Staging环境以及正式环境的方法
@@ -70,7 +70,7 @@ $ docker-compose up --build
 
 ### 规则
 
-只允许推送 Pull Request 到 `development` 、 `dev-i18n` 和 `dev-hotfix` 分支。
+只允许推送 Pull Request 到 `development`  和 `dev-hotfix` 分支。
 在推送 Pull Request 时，请按照以下命名规则为您的分支命名：
 
 新增功能: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -81,7 +81,6 @@ Hotfix: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | 开发 | development | https://dev-covid19-tokyo.netlify.com/ | 基本上请推送 Pull Request 到这里 |
 | 紧急修复 | dev-hotfix | 无 | 对正式版的紧急修复。在管理员的要求下使用。 |
-| i18n 工作用 | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | 暂时使用 |
 | 正式版预览 | staging | https://stg-covid19-tokyo.netlify.com/ | 对于正式版发布前的最终确认，禁止管理员以外的人推送 Pull Request。 |
 | 正式版 | master | https://stopcovid19.metro.tokyo.lg.jp/ | 禁止管理员以外的人推送 Pull Request |
 #### 系统所使用的分支

--- a/docs/zh_TW/README.md
+++ b/docs/zh_TW/README.md
@@ -87,7 +87,7 @@ $ docker-compose run --rm app yarn install
 
 ### 分支規則
 
-只允許推送 Pull Request 到 `development` 、 `dev-i18n` 跟 `dev-hotfix` 。  
+只允許推送 Pull Request 到 `development`  跟 `dev-hotfix` 。
 在推送 Pull Request 時，請依照以下命名規則為您的分支命名
 
 新增功能: feature/#{ISSUE_ID}-#{branch_title_name}  
@@ -98,7 +98,6 @@ Hotfix: hotfix/#{ISSUE_ID}-{branch_title_name}
 | ---- | -------- | ---- | ---- |
 | 開發 | development | https://dev-covid19-tokyo.netlify.com/ | 基本上請推送 Pull Request 到這裡 |
 | 緊急修復 | dev-hotfix | 無 | 對於正式版的緊急修復。 在管理員的要求下使用。 |
-| i18n 工作用 | dev-i18n | https://i18n-covid-tokyo.netlify.com/ | 暫時使用 |
 | 正式版預覽 | staging | https://stg-covid19-tokyo.netlify.com/ | 對於正式版釋出前的最終確認，禁止管理員以外的人推送 Pull Request。 |
 | 正式版 | master | https://stopcovid19.metro.tokyo.lg.jp/ | 禁止管理員以外的人推送 Pull Request |
 #### 系統所使用的分支

--- a/docs/zh_TW/TRANSLATION.md
+++ b/docs/zh_TW/TRANSLATION.md
@@ -35,10 +35,10 @@ Transifex 有很多有用的功能，像是字典功能，如果您覺得好用�
 
 ## 給開發者
 
-如果你有新增文字需要翻譯，請把字串加到 `../assets/locales/ja.json` 並推送 Pull Request 到 `dev-i18n` 分支。 您可以用相同字串作為 key 和 value 。
+如果你有新增文字需要翻譯，請把字串加到 `../assets/locales/ja.json` 並推送 Pull Request 到 `development` 分支。 您可以用相同字串作為 key 和 value 。
 
 我們正在使用 [nuxt-i18n](https://github.com/nuxt-community/nuxt-i18n) 作為翻譯引擎。請參考 [他們的文件](https://nuxtjs.org/examples/i18n/) 來了解如何使用這個函式庫（Library）。
 
 如果你急需這個文字的翻譯的話，請在 Code for Japan Slack (查看 [教學](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/docs/zh_TW/CONTRIBUTING.md#%E5%A6%82%E4%BD%95%E5%8F%83%E8%88%87%E4%BA%A4%E6%B5%81)) 的 #covid19 頻道中，要求從 Transifex 推送最新的更新。 
 
-文字翻譯過後，組織者會把新的資源檔套用到 `dev-i18n` 分支上。
+文字翻譯過後，組織者會把新的資源檔套用到 `development` 分支上。


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2127 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 各国のREADME.mdに記載されていた`dev-i18n`に関する記述を削除した
- TRANSLATION.mdの翻訳のマージ先を`dev-i18n`から`development`

## 📸 スクリーンショット / Screenshots

- ドキュメントの修正のため省略
