### PR TITLE
FORKED_SITES.mdに青森県版を追加

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -7,6 +7,7 @@
 東京都（このサイト）|https://stopcovid19.metro.tokyo.lg.jp|東京都（**公式**）|[tokyo-metropolitan-gov/covid19](https://github.com/tokyo-metropolitan-gov/covid19)|
 [](01)北海道|https://stopcovid19.hokkaido.dev/|JUST道IT（有志団体）|[codeforsapporo/covid19](https://github.com/codeforsapporo/covid19)|
 [](02)青森県|https://covid19.codeforaomori.org|Code for Aomori|[CodeForAomori/covid19](https://github.com/CodeForAomori/covid19)|
+[](02)青森県|https://covid19-aomori.info/|Aomori Hackers（有志団体）|[covid19-aomori/website](https://github.com/covid19-aomori/website)|
 [](07)福島県|https://fukushima-covid19.firebaseapp.com|GDG Fukushima|[donuzium/covid19](https://github.com/donuzium/covid19)|
 [](08)茨城県|https://covid19-ibaraki.netlify.com/|個人|[a01sa01to/covid19-ibaraki](https://github.com/a01sa01to/covid19-ibaraki)|
 [](10)群馬県|https://stopcovid19-gunma.netlify.com/|個人|[SatoshiRC/covid19-gunma](https://github.com/SatoshiRC/covid19-gunma)|


### PR DESCRIPTION
有志で青森県版を作成しました。
https://covid19-aomori.info/

青森県についてはすでに1サイト追加済みでしたがご検討頂けると幸いです。