### PR TITLE
「陽性物数」を「陽性者数」に置換

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -8,7 +8,7 @@
             <br />({{ $t('累計') }})
           </span>
           <span>
-            <strong>{{ 陽性物数 }}</strong>
+            <strong>{{ 陽性者数 }}</strong>
             <span :class="$style.unit">{{ $t('人') }}</span>
           </span>
         </div>
@@ -88,7 +88,7 @@ export default Vue.extend({
       type: Number,
       required: true
     },
-    陽性物数: {
+    陽性者数: {
       type: Number,
       required: true
     },

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -35,7 +35,7 @@ type DataType = {
 
 type ConfirmedCasesType = {
   検査実施人数: number
-  陽性物数: number
+  陽性者数: number
   入院中: number
   軽症中等症: number
   重症: number
@@ -51,7 +51,7 @@ type ConfirmedCasesType = {
 export default (data: DataType) => {
   const formattedData: ConfirmedCasesType = {
     検査実施人数: data.value,
-    陽性物数: data.children[0].value,
+    陽性者数: data.children[0].value,
     入院中: data.children[0].children[0].value,
     軽症中等症: data.children[0].children[0].children[0].value,
     重症: data.children[0].children[0].children[1].value,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2208 

## ⛏ 変更内容 / Details of Changes
- `components/ConfirmedCasesTable.vue`, `utils/formatConfirmedCases.ts` のコード内に「陽性物数」という文字列（明らかに「陽性者数」の誤り）が現れるため正しいものに置換する
- UI の変更はない