### PR TITLE
Revert "千代田区と新宿区のグラフを削除"

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -30,6 +30,8 @@
       <consultation-desk-reports-number-card />
       <metro-card />
       <agency-card />
+      <shinjuku-visitors-card />
+      <chiyoda-visitors-card />
     </v-row>
   </div>
 </template>
@@ -53,6 +55,8 @@ import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDe
 import MetroCard from '@/components/cards/MetroCard.vue'
 import AgencyCard from '@/components/cards/AgencyCard.vue'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
+import ShinjukuVisitorsCard from '@/components/cards/ShinjukuVisitorsCard.vue'
+import ChiyodaVisitorsCard from '@/components/cards/ChiyodaVisitorsCard.vue'
 
 export default Vue.extend({
   components: {
@@ -68,7 +72,9 @@ export default Vue.extend({
     TelephoneAdvisoryReportsNumberCard,
     ConsultationDeskReportsNumberCard,
     MetroCard,
-    AgencyCard
+    AgencyCard,
+    ShinjukuVisitorsCard,
+    ChiyodaVisitorsCard
   },
   data() {
     const data = {


### PR DESCRIPTION
Reverts tokyo-metropolitan-gov/covid19#2166