### PR TITLE
「オープンデータを入手」の文言を変更できるよう component の設計を変更する

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -1,5 +1,11 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :url="url"
+    :source="source"
+  >
     <template v-slot:button>
       <span />
     </template>
@@ -112,6 +118,10 @@ export default Vue.extend({
       default: () => {}
     },
     url: {
+      type: String,
+      default: ''
+    },
+    source: {
       type: String,
       default: ''
     }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -32,7 +32,7 @@
               target="_blank"
               rel="noopener"
             >
-              {{ $t('オープンデータを入手') }}
+              {{ source }}
               <v-icon
                 class="ExternalLinkIcon"
                 size="15"
@@ -180,6 +180,10 @@ export default Vue.extend({
       default: ''
     },
     url: {
+      type: String,
+      default: ''
+    },
+    source: {
       type: String,
       default: ''
     }

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -1,5 +1,11 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date" :url="url">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :url="url"
+    :source="source"
+  >
     <template v-slot:description>
       <slot name="description" />
     </template>
@@ -105,6 +111,7 @@ type Props = {
   date: string
   unit: string
   url: string
+  source: string
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -145,6 +152,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     url: {
       type: String,
+      default: ''
+    },
+    source: {
+      type: String,
+      required: false,
       default: ''
     }
   },

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -8,6 +8,7 @@
       :date="Data.patients.date"
       :info="sumInfoOfPatients"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+      :source="$t('オープンデータを入手')"
     />
   </v-col>
 </template>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -8,6 +8,7 @@
       :date="Data.patients.date"
       :unit="$t('人')"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
+      :source="$t('オープンデータを入手')"
     />
   </v-col>
 </template>

--- a/components/cards/ConsultationDeskReportsNumberCard.vue
+++ b/components/cards/ConsultationDeskReportsNumberCard.vue
@@ -8,6 +8,7 @@
       :date="Data.querents.date"
       :unit="$t('件.reports')"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000070'"
+      :source="$t('オープンデータを入手')"
     />
     <!-- 件.reports = 窓口相談件数 -->
   </v-col>

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -8,6 +8,7 @@
       :date="Data.contacts.date"
       :unit="$t('件.reports')"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000071'"
+      :source="$t('オープンデータを入手')"
     />
     <!-- 件.reports = 窓口相談件数 -->
   </v-col>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2295

## ⛏ 変更内容 / Details of Changes
- 「オープンデータを入手」の文言を変更できるよう component の設計を変更
    - component 内に「オープンデータを入手」をベタ書きするのではなく，component を使う別の component 内で文言を指定する形に変更
    - 派生した repositroy で文言を変更したいため
    - 純粋なリファクタであり UI の変更はしない
