### PR TITLE
fix: postcss-loader の warning を修正

### DIFF
--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -105,10 +105,12 @@ export default {
 }
 
 .Outer {
+  $grid-gap: 12px;
+
   display: grid;
-  grid-gap: 12px;
 
   &Upper {
+    grid-gap: $grid-gap;
     grid-template-columns: 70% 30%;
     -ms-grid-columns: 70% 12px 30%;
     grid-template-rows: repeat(3, auto);
@@ -145,6 +147,7 @@ export default {
   }
 
   &Lower {
+    grid-gap: $grid-gap;
     grid-template-columns: repeat(2, calc(50% - 6px));
     -ms-grid-columns: calc(50% - 6px) 12px calc(50% - 6px);
     grid-template-rows: repeat(3, auto);


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2307

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- postcss-loader の warning を修正しました
- `grid-gap` を ` grid-template-*` と同じセレクタで宣言するようにしました

## 📸 スクリーンショット / Screenshots
`yarn dev` でサーバーを起動した際に warning が出力されなくなりました。

```sh
$ yarn dev
yarn run v1.22.0
$ cross-env NODE_ENV=development nuxt-ts
start Loading module
ℹ PurgeCSS is not enabled because you are in dev mode

   ╭─────────────────────────────────────────────╮
   │                                             │
   │   Nuxt.js v2.11.0                           │
   │   Running in development mode (universal)   │
   │                                             │
   │   Listening on: http://localhost:3000/      │
   │                                             │
   ╰─────────────────────────────────────────────╯

ℹ Preparing project for development
ℹ Initial build may take a while
✔ Builder initialized
✔ Nuxt files generated

✔ Client
  Compiled successfully in 38.12s

✔ Server
  Compiled successfully in 33.19s

ℹ Starting type checking service...
ℹ Using 1 worker with 2048MB memory limit
ℹ No type errors found
ℹ Version: typescript 3.8.3
ℹ Time: 6785ms
ℹ Waiting for file changes
ℹ Memory usage: 995 MB (RSS: 1.8 GB)
```