### PR TITLE
患者の年代が「不明」の場合は「陽性患者の属性」にも「不明」と表示する

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -51,6 +51,8 @@ export default {
 
       if (row['年代'] === '10歳未満') {
         row['年代'] = this.$t('10歳未満')
+      } else if (row['年代'] === '不明') {
+        row['年代'] = this.$t('不明')
       } else {
         const age = row['年代'].substring(0, 2)
         row['年代'] = this.$t('{age}代', { age })


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2310

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- data.jsonの患者データで年代が「不明」の場合は「陽性患者の属性」にも「不明」と表示するように変更

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### 修正後
![image](https://user-images.githubusercontent.com/42484226/77545632-0eee6e00-6eee-11ea-9f26-073ab72c3ebb.png)
### 修正前
![image](https://user-images.githubusercontent.com/42484226/77545743-3e04df80-6eee-11ea-8082-059c45ff52e8.png)
