### PR TITLE
(PR) X軸の文字列の角度が揃っていない

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -258,7 +258,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontSize: 9,
                 maxTicksLimit: 20,
                 fontColor: '#808080',
-                minRotation: 0
+                maxRotation: 0
               },
               type: 'time',
               time: {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #2385

## ⛏ 変更内容 / Details of Changes

- `TimeBarChart` のX軸ラベル（日付）に `maxRotation: 0` を設定
    - `minRotation: 0` を削除（標準で0のため不要）
- 検査実施件数に使われている `TimeStackedBarChart` は現時点で `maxRotation: 0` となっているため、`TimeBarChart` のmin～は自動補完の暴走等による誤植の可能性あり
