### PR TITLE
Fix markdown syntax error in README in zh_CN

### DIFF
--- a/docs/zh_CN/README.md
+++ b/docs/zh_CN/README.md
@@ -67,7 +67,7 @@ $ yarn install
 **使用 docker compose 时**
 ```bash
 $ docker-compose run --rm app yarn install
-``
+```
 
 ### VSCode + Remote Containers 的开发环境
 


### PR DESCRIPTION
Markdownのコードブロック構文として終了は \` が3つ必要ですが、zh_CNの最後のコードブロックが \` が1つ抜けてたため、Markdownのレンダリングがその後のコードじゃない部分までコードとしてレンダリングしてしまっている

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2416 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- コードブロックを終了させる \` の数を3つに修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

| before | after |
|---|---|
| ![スクリーンショット 2020-03-27 13 08 39](https://user-images.githubusercontent.com/3942121/77721115-3d269780-702d-11ea-8b51-7cf6d88a0a23.png) | ![スクリーンショット 2020-03-27 13 15 34](https://user-images.githubusercontent.com/3942121/77721133-444da580-702d-11ea-8aaf-75665201286a.png) |