### PR TITLE
(PR) 日本語以外の言語設定をしたブラウザで、ローディング画面で止まる問題(#1585)の再発

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,7 +8,10 @@
         <span>{{ $t('最終更新') }} </span>
         <time :datetime="updatedAt">{{ Data.lastUpdate }}</time>
       </div>
-      <div v-if="!['ja', 'ja-basic'].includes($i18n.locale)" class="Annotation">
+      <div
+        v-show="!['ja', 'ja-basic'].includes($i18n.locale)"
+        class="Annotation"
+      >
         <span>{{ $t('注釈') }} </span>
       </div>
     </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2430

## 📝 関連する issue / Related Issues
- #1585 
- PR #1622 

## ⛏ 変更内容 / Details of Changes
- `v-if` を `v-show` に変更
- #1622 では `components/PageHeader.vue` に変更を加えていたようですが、現在の development では当該コードは `pages/index.vue` にあるため、そちらに変更を加えました。
