### PR TITLE
FORKED_SITES.mdへ香川県版サイトを追加しました

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -37,7 +37,7 @@
 [](34)広島県|https://covid19-hiroshima.netlify.com/|個人|[tatsuya1970/covid19](https://github.com/tatsuya1970/covid19)|
 [](35)山口県|https://covid19-yamaguchi.netlify.com|有志|[nishidayoshikatsu/covid19-yamaguchi](https://github.com/nishidayoshikatsu/covid19-yamaguchi)|
 [](37)香川県|https://covid19-kagawa.netlify.com/|学生エンジニア(有志)||
-[](37)香川県|https://covid19-kagawa.jp/|学生エンジニア (有志)|[i15317/covid19](https://github.com/i15317/covid19)|
+[](37)香川県|https://covid19-kagawa.jp/|学生エンジニア (有志)|[i15317/covid19](https://github.com/i15317/covid19) |
 [](38)愛媛県|https://ehime-covid19.com/|ボランティア(有志)|[ehime-covid19/covid19](https://github.com/ehime-covid19/covid19)|
 [](39)高知県|https://covid19-kochi.netlify.com|学生エンジニア(有志)||
 []()九州|https://dev-covid19-kyusyu.netlify.com|九州(有志)|[Code-for-Kyushu/covid19](https://github.com/Code-for-Kyushu/covid19)|

--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -37,6 +37,7 @@
 [](34)広島県|https://covid19-hiroshima.netlify.com/|個人|[tatsuya1970/covid19](https://github.com/tatsuya1970/covid19)|
 [](35)山口県|https://covid19-yamaguchi.netlify.com|有志|[nishidayoshikatsu/covid19-yamaguchi](https://github.com/nishidayoshikatsu/covid19-yamaguchi)|
 [](37)香川県|https://covid19-kagawa.netlify.com/|学生エンジニア(有志)||
+[](37)香川県|https://covid19-kagawa.jp/|学生エンジニア (有志)|[i15317/covid19](https://github.com/i15317/covid19)|
 [](38)愛媛県|https://ehime-covid19.com/|ボランティア(有志)|[ehime-covid19/covid19](https://github.com/ehime-covid19/covid19)|
 [](39)高知県|https://covid19-kochi.netlify.com|学生エンジニア(有志)||
 []()九州|https://dev-covid19-kyusyu.netlify.com|九州(有志)|[Code-for-Kyushu/covid19](https://github.com/Code-for-Kyushu/covid19)|


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
既に香川県には #1919 でFORKED_SITES.mdされたサイトが存在しますが、本サイトの掲載もご検討いただけますと幸いです。

## 👏 解決する issue / Resolved Issues
- close #2455

## 📝 関連する issue / Related Issues
- #2455 (マージ内容)
- #1919 (既存の香川県サイト)

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- FORKED_SITES.md に covid19-kagawa.jp を追加しました。


## 📸 スクリーンショット / Screenshots
### 追加内容(FORKED_SITES.md)
![image](https://user-images.githubusercontent.com/28642008/77763284-2e1c0580-707e-11ea-9cc8-4f14e46be4ac.png)

### サイトトップ
![image](https://user-images.githubusercontent.com/28642008/77762752-58b98e80-707d-11ea-9418-037de7f2d775.png)
