### PR TITLE
埋め込み用コードダイアログのz-index修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -420,7 +420,7 @@ export default Vue.extend({
         border-radius: 8px;
         text-align: left;
         font-size: 1rem;
-        z-index: 1;
+        z-index: 2;
 
         > * {
           padding: 4px 0;


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2472

## ⛏ 変更内容 / Details of Changes
- マップ右下のアイコンの上にダイアログが表示されるようにz-indexの値を修正

## 📸 スクリーンショット / Screenshots
<img width="613" alt="スクリーンショット 2020-03-28 4 15 14" src="https://user-images.githubusercontent.com/548508/77792109-1f981300-70ab-11ea-95f3-f6256c0ff86b.png">

