### PR TITLE
vue-i18nのplaces syntaxをslots synaxに変更

### DIFF
--- a/components/SourceLink.vue
+++ b/components/SourceLink.vue
@@ -2,18 +2,14 @@
   <div class="SourceLink">
     <div>{{ header }}</div>
     <i18n path="出典: {source}" tag="div" :for="linkString">
-      <a
-        place="source"
-        class="SourceLink"
-        :href="url"
-        target="_blank"
-        rel="noopener"
-      >
-        {{ linkString }}
-        <v-icon class="ExternalLinkIcon" size="15">
-          mdi-open-in-new
-        </v-icon>
-      </a>
+      <template v-slot:source>
+        <a class="SourceLink" :href="url" target="_blank" rel="noopener">
+          {{ linkString }}
+          <v-icon class="ExternalLinkIcon" size="15">
+            mdi-open-in-new
+          </v-icon>
+        </a>
+      </template>
     </i18n>
   </div>
 </template>

--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -24,9 +24,11 @@
         tag="span"
         path="{advisory}による相談結果"
       >
-        <span :class="$style.TitleLarge" place="advisory">
-          {{ $t('新型コロナ受診相談窓口') }}
-        </span>
+        <template v-slot:advisory>
+          <span :class="$style.TitleLarge">
+            {{ $t('新型コロナ受診相談窓口') }}
+          </span>
+        </template>
       </i18n>
     </h3>
     <div :class="[$style.Outer, $style.OuterLower]">

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -15,14 +15,17 @@
       <div>
         <p>
           <i18n path="{duration}続いている">
-            <i18n
-              tag="span"
-              place="duration"
-              path="{day}日以上"
-              :class="$style.FlowRowEmphasis"
-            >
-              <span :class="$style.FlowRowEmphasisDay" place="day">4</span>
-            </i18n>
+            <template v-slot:duration>
+              <i18n
+                tag="span"
+                path="{day}日以上"
+                :class="$style.FlowRowEmphasis"
+              >
+                <template v-slot:day>
+                  <span :class="$style.FlowRowEmphasisDay">4</span>
+                </template>
+              </i18n>
+            </template>
           </i18n>
         </p>
       </div>
@@ -35,9 +38,11 @@
             path="{cold}のような症状"
             :class="$style.FlowRowConditionSmall"
           >
-            <span :class="$style.FlowRowConditionLarge" place="cold">
-              {{ $t('風邪') }}
-            </span>
+            <template v-slot:cold>
+              <span :class="$style.FlowRowConditionLarge">
+                {{ $t('風邪') }}
+              </span>
+            </template>
           </i18n>
         </p>
         <img
@@ -54,11 +59,15 @@
             :class="$style.FlowRowConditionSmall"
             path="発熱{temperature}"
           >
-            <i18n tag="span" place="temperature" path="{tempNum}以上">
-              <span :class="$style.FlowRowConditionLarge" place="tempNum">
-                {{ $t('37.5℃') }}
-              </span>
-            </i18n>
+            <template v-slot:temperature>
+              <i18n tag="span" path="{tempNum}以上">
+                <template v-slot:tempNum>
+                  <span :class="$style.FlowRowConditionLarge">
+                    {{ $t('37.5℃') }}
+                  </span>
+                </template>
+              </i18n>
+            </template>
           </i18n>
         </p>
         <img
@@ -122,14 +131,17 @@
       <div>
         <p>
           <i18n path="{duration}続いている">
-            <i18n
-              tag="span"
-              place="duration"
-              path="{day}日程度"
-              :class="$style.FlowRowEmphasis"
-            >
-              <span :class="$style.FlowRowEmphasisDay" place="day">2</span>
-            </i18n>
+            <template v-slot:duration>
+              <i18n
+                tag="span"
+                path="{day}日程度"
+                :class="$style.FlowRowEmphasis"
+              >
+                <template v-slot:day>
+                  <span :class="$style.FlowRowEmphasisDay">2</span>
+                </template>
+              </i18n>
+            </template>
           </i18n>
         </p>
       </div>

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -2,9 +2,11 @@
   <div :class="$style.flowContainer">
     <h3 :class="$style.sectionTitle">
       <i18n path="新型コロナ外来 {advice} と判断された場合" tag="p">
-        <strong place="advice">
-          {{ $t('受診が不要') }}
-        </strong>
+        <template v-slot:advice>
+          <strong>
+            {{ $t('受診が不要') }}
+          </strong>
+        </template>
       </i18n>
     </h3>
     <div :class="$style.actionContainer">
@@ -30,10 +32,12 @@
       </ul>
       <div :class="$style.nextAction">
         <i18n path="{getWorse}{advisory}に相談" :class="$style.content">
-          <span place="getWorse">{{ $t('症状が良くならない場合は') }}</span>
-          <strong place="advisory">{{
-            $t('新型コロナ受診相談窓口（日本語のみ）')
-          }}</strong>
+          <template v-slot:getWorse>
+            <span>{{ $t('症状が良くならない場合は') }}</span>
+          </template>
+          <template v-slot:advisory>
+            <strong>{{ $t('新型コロナ受診相談窓口（日本語のみ）') }}</strong>
+          </template>
         </i18n>
       </div>
     </div>

--- a/components/flow/FlowPcPast.vue
+++ b/components/flow/FlowPcPast.vue
@@ -2,14 +2,13 @@
   <section :class="$style.Flow">
     <div :class="$style.FlowHeading">
       <i18n path="{past}の出来ごとと症状" tag="span">
-        <i18n
-          :class="$style.FlowLText"
-          tag="span"
-          path="発症前{two}週間以内"
-          place="past"
-        >
-          <span :class="$style.FlowNum" place="two">2</span>
-        </i18n>
+        <template v-slot:past>
+          <i18n :class="$style.FlowLText" tag="span" path="発症前{two}週間以内">
+            <template v-slot:two>
+              <span :class="$style.FlowNum">2</span>
+            </template>
+          </i18n>
+        </template>
       </i18n>
     </div>
     <div :class="$style.FlowInner">
@@ -23,9 +22,11 @@
             path="{closeContact}をした方"
             :class="$style.FlowPerson"
           >
-            <em :class="$style.FlowLine" place="closeContact">
-              {{ $t('濃厚接触') }}
-            </em>
+            <template v-slot:closeContact>
+              <em :class="$style.FlowLine">
+                {{ $t('濃厚接触') }}
+              </em>
+            </template>
           </i18n>
         </template>
         <template v-else>
@@ -34,9 +35,11 @@
             path="{closeContact}をした方"
             :class="$style.FlowPerson"
           >
-            <em :class="$style.FlowLine" place="closeContact">
-              {{ $t('濃厚接触') }}
-            </em>
+            <template v-slot:closeContact>
+              <em :class="$style.FlowLine">
+                {{ $t('濃厚接触') }}
+              </em>
+            </template>
           </i18n>
           <span :class="$style.FlowTitle">
             {{ $t('「新型コロナウイルス感染者」と') }}
@@ -53,12 +56,16 @@
             :class="$style.FlowPerson"
             path="{you} か {closeContact}をした方"
           >
-            <em :class="$style.FlowLine" place="you">
-              {{ $t('ご本人') }}
-            </em>
-            <em :class="$style.FlowLine" place="closeContact">
-              {{ $t('濃厚接触') }}
-            </em>
+            <template v-slot:you>
+              <em :class="$style.FlowLine">
+                {{ $t('ご本人') }}
+              </em>
+            </template>
+            <template v-slot:closeContact>
+              <em :class="$style.FlowLine">
+                {{ $t('濃厚接触') }}
+              </em>
+            </template>
           </i18n>
         </template>
         <template v-else>
@@ -67,18 +74,22 @@
             :class="[$style.FlowPerson, $style.FlowPersonS]"
             path="travel history from {area}"
           >
-            <em :class="$style.FlowLine" place="area">
-              {{ $t('COVID-19 prevalent area') }}
-            </em>
+            <template v-slot:area>
+              <em :class="$style.FlowLine">
+                {{ $t('COVID-19 prevalent area') }}
+              </em>
+            </template>
           </i18n>
           <i18n
             tag="span"
             :class="[$style.FlowPerson, $style.FlowPersonS]"
             path="been {inCloseContact} with returnees"
           >
-            <em :class="$style.FlowLine" place="inCloseContact">
-              {{ $t('in close contact') }}
-            </em>
+            <template v-slot:inCloseContact>
+              <em :class="$style.FlowLine">
+                {{ $t('in close contact') }}
+              </em>
+            </template>
           </i18n>
         </template>
       </div>
@@ -105,11 +116,15 @@
         <span :class="$style.FlowText">{{ $t('かつ') }}</span>
         <em :class="$style.FlowSymptom">
           <i18n tag="span" :class="$style.FlowTextSm" path="発熱{temperature}">
-            <i18n tag="span" path="{tempNum}以上" place="temperature">
-              <span :class="$style.FlowTemperature" place="tempNum">
-                {{ $t('37.5℃') }}
-              </span>
-            </i18n>
+            <template v-slot:temperature>
+              <i18n tag="span" path="{tempNum}以上">
+                <template v-slot:tempNum>
+                  <span :class="$style.FlowTemperature">
+                    {{ $t('37.5℃') }}
+                  </span>
+                </template>
+              </i18n>
+            </template>
           </i18n>
           <img
             :class="$style.FlowSymptomIcon"

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -6,9 +6,11 @@
         tag="p"
         path="新型コロナ外来 {advice} と判断された場合"
       >
-        <span :class="$style.Emphasis" place="advice">
-          {{ $t('受診が必要') }}
-        </span>
+        <template v-slot:advice>
+          <span :class="$style.Emphasis">
+            {{ $t('受診が必要') }}
+          </span>
+        </template>
       </i18n>
     </div>
     <div :class="$style.Row">
@@ -32,14 +34,18 @@
       <div :class="[$style.Card, $style.CardGreen]">
         <p :class="$style.CardGreenText">
           <i18n path="検査の必要{ifRequired}">
-            <span place="ifRequired">{{ $t('あり') }}</span>
+            <template v-slot:ifRequired>
+              <span>{{ $t('あり') }}</span>
+            </template>
           </i18n>
         </p>
       </div>
       <div :class="[$style.Card, $style.CardWhite]">
         <p :class="$style.CardWhiteText">
           <i18n path="検査の必要{ifRequired}">
-            <span place="ifRequired">{{ $t('なし') }}</span>
+            <template v-slot:ifRequired>
+              <span>{{ $t('なし') }}</span>
+            </template>
           </i18n>
         </p>
       </div>

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -145,9 +145,7 @@
           <i18n path="{getWorse}{advisory}に相談">
             <template v-slot:getWorse>
               <i18n path="症状が良くならない場合は">
-                <span place="getWorse">{{
-                  $t('症状が良くならない場合は')
-                }}</span>
+                <span>{{ $t('症状が良くならない場合は') }}</span>
               </i18n>
             </template>
             <template v-slot:advisory>

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -143,6 +143,13 @@
       <div :class="[$style.rect, $style.consult]">
         <p>
           <i18n path="{getWorse}{advisory}に相談">
+            <template v-slot:getWorse>
+              <i18n path="症状が良くならない場合は">
+                <span place="getWorse">{{
+                  $t('症状が良くならない場合は')
+                }}</span>
+              </i18n>
+            </template>
             <template v-slot:advisory>
               <strong :class="$style.advisory">
                 {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -1,18 +1,22 @@
 <template>
   <div :class="[$style.container, $style.according]">
     <i18n tag="div" :class="$style.heading" path="{advisory}による相談結果">
-      <span :class="[$style.fzLarge, $style.break]" place="advisory">
-        {{ $t('新型コロナ受診相談窓口') }}
-      </span>
+      <template v-slot:advisory>
+        <span :class="[$style.fzLarge, $style.break]">
+          {{ $t('新型コロナ受診相談窓口') }}
+        </span>
+      </template>
     </i18n>
     <i18n
       tag="p"
       :class="$style.diag"
       path="新型コロナ外来 {advice} と判断された場合"
     >
-      <span :class="[$style.fzXLLarge, $style.break]" place="advice">
-        {{ $t('受診が必要') }}
-      </span>
+      <template v-slot:advice>
+        <span :class="[$style.fzXLLarge, $style.break]">
+          {{ $t('受診が必要') }}
+        </span>
+      </template>
     </i18n>
     <p :class="$style.decision">
       <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
@@ -37,9 +41,11 @@
       >
         <p>
           <i18n path="検査の必要{ifRequired}">
-            <span :class="[$style.fzXLarge, $style.break]" place="ifRequired">
-              {{ $t('なし') }}
-            </span>
+            <template v-slot:ifRequired>
+              <span :class="[$style.fzXLarge, $style.break]">
+                {{ $t('なし') }}
+              </span>
+            </template>
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
@@ -53,9 +59,11 @@
       >
         <p>
           <i18n path="検査の必要{ifRequired}">
-            <span :class="[$style.fzXLarge, $style.break]" place="ifRequired">
-              {{ $t('あり') }}
-            </span>
+            <template v-slot:ifRequired>
+              <span :class="[$style.fzXLarge, $style.break]">
+                {{ $t('あり') }}
+              </span>
+            </template>
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
@@ -113,9 +121,11 @@
       :class="[$style.diag, $style.hr]"
       path="新型コロナ外来 {advice} と判断された場合"
     >
-      <span :class="[$style.break, $style.fzXLLarge]" place="advice">
-        {{ $t('受診が不要') }}
-      </span>
+      <template v-slot:advice>
+        <span :class="[$style.break, $style.fzXLLarge]">
+          {{ $t('受診が不要') }}
+        </span>
+      </template>
     </i18n>
     <div :class="[$style.rectContainer, $style.double]">
       <div :class="[$style.rect, $style.solution]">
@@ -133,10 +143,11 @@
       <div :class="[$style.rect, $style.consult]">
         <p>
           <i18n path="{getWorse}{advisory}に相談">
-            <i18n place="getWorse" path="症状が良くならない場合は" />
-            <strong :class="$style.advisory" place="advisory">
-              {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
-            </strong>
+            <template v-slot:advisory>
+              <strong :class="$style.advisory">
+                {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
+              </strong>
+            </template>
           </i18n>
         </p>
       </div>

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -24,22 +24,27 @@
       <li :class="$style.symptom">
         <span>
           <i18n path="{cold}のような症状">
-            <span :class="$style.ConditionsItemLarger" place="cold">
-              {{ $t('風邪') }}
-            </span>
+            <template v-slot:cold>
+              <span :class="$style.ConditionsItemLarger">
+                {{ $t('風邪') }}
+              </span>
+            </template>
           </i18n>
         </span>
       </li>
       <li :class="$style.symptom">
         <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <i18n
-            tag="span"
-            path="{tempNum}以上"
-            place="temperature"
-            :class="[$style.break, $style.fzRegular]"
-          >
-            <span :class="$style.temp" place="tempNum">{{ $t('37.5℃') }}</span>
-          </i18n>
+          <template v-slot:temperature>
+            <i18n
+              tag="span"
+              path="{tempNum}以上"
+              :class="[$style.break, $style.fzRegular]"
+            >
+              <template v-slot:tempNum>
+                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+              </template>
+            </i18n>
+          </template>
         </i18n>
       </li>
       <li :class="$style.symptom">
@@ -52,14 +57,17 @@
 
     <p :class="$style.duration">
       <i18n path="{duration}続いている">
-        <i18n
-          :class="[$style.underline, $style.fzLarge]"
-          tag="span"
-          place="duration"
-          path="{day}日程度"
-        >
-          <strong :class="$style.fzNumeric" place="day">2</strong>
-        </i18n>
+        <template v-slot:duration>
+          <i18n
+            :class="[$style.underline, $style.fzLarge]"
+            tag="span"
+            path="{day}日程度"
+          >
+            <template v-slot:day>
+              <strong :class="$style.fzNumeric">2</strong>
+            </template>
+          </i18n>
+        </template>
       </i18n>
     </p>
 

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -10,22 +10,25 @@
       <li :class="$style.symptom">
         <span>
           <i18n path="{cold}のような症状">
-            <span :class="$style.ConditionsItemLarger" place="cold">{{
-              $t('風邪')
-            }}</span>
+            <template v-slot:cold>
+              <span :class="$style.ConditionsItemLarger">{{ $t('風邪') }}</span>
+            </template>
           </i18n>
         </span>
       </li>
       <li :class="$style.symptom">
         <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <i18n
-            tag="span"
-            path="{tempNum}以上"
-            place="temperature"
-            :class="[$style.break, $style.fzRegular]"
-          >
-            <span :class="$style.temp" place="tempNum">{{ $t('37.5℃') }}</span>
-          </i18n>
+          <template v-slot:temperature>
+            <i18n
+              tag="span"
+              path="{tempNum}以上"
+              :class="[$style.break, $style.fzRegular]"
+            >
+              <template v-slot:tempNum>
+                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+              </template>
+            </i18n>
+          </template>
         </i18n>
       </li>
       <li :class="$style.symptom">
@@ -37,14 +40,17 @@
     </ul>
     <p :class="$style.duration">
       <i18n path="{duration}続いている">
-        <i18n
-          :class="[$style.underline, $style.fzLarge]"
-          tag="span"
-          place="duration"
-          path="{day}日以上"
-        >
-          <strong :class="$style.fzNumeric" place="day">4</strong>
-        </i18n>
+        <template v-slot:duration>
+          <i18n
+            :class="[$style.underline, $style.fzLarge]"
+            tag="span"
+            path="{day}日以上"
+          >
+            <template v-slot:day>
+              <strong :class="$style.fzNumeric">4</strong>
+            </template>
+          </i18n>
+        </template>
       </i18n>
     </p>
     <a

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -2,14 +2,13 @@
   <div :class="$style.container">
     <p :class="$style.heading">
       <i18n path="{past}の出来ごとと症状" tag="span">
-        <i18n
-          :class="$style.fzLarge"
-          tag="span"
-          path="発症前{two}週間以内"
-          place="past"
-        >
-          <span :class="$style.fzNumeric" place="two">2</span>
-        </i18n>
+        <template v-slot:past>
+          <i18n :class="$style.fzLarge" tag="span" path="発症前{two}週間以内">
+            <template v-slot:two>
+              <span :class="$style.fzNumeric">2</span>
+            </template>
+          </i18n>
+        </template>
       </i18n>
     </p>
     <p :class="$style.type">
@@ -22,9 +21,9 @@
           path="{closeContact}をした方"
           :class="[$style.behavior, $style.fzXLarge]"
         >
-          <em :class="$style.underline" place="closeContact">{{
-            $t('濃厚接触')
-          }}</em>
+          <template v-slot:closeContact>
+            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+          </template>
         </i18n>
       </template>
       <template v-else>
@@ -33,9 +32,9 @@
           path="{closeContact}をした方"
           :class="[$style.behavior, $style.fzXLarge]"
         >
-          <em :class="$style.underline" place="closeContact">{{
-            $t('濃厚接触')
-          }}</em>
+          <template v-slot:closeContact>
+            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+          </template>
         </i18n>
         <span :class="$style.source">{{
           $t('「新型コロナウイルス感染者」と')
@@ -63,10 +62,12 @@
           :class="[$style.behavior, $style.fzXLarge]"
           path="{you} か {closeContact}をした方"
         >
-          <em :class="$style.underline" place="you">{{ $t('ご本人') }}</em>
-          <em :class="$style.underline" place="closeContact">{{
-            $t('濃厚接触')
-          }}</em>
+          <template v-slot:you>
+            <em :class="$style.underline">{{ $t('ご本人') }}</em>
+          </template>
+          <template v-slot:closeContact>
+            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+          </template>
         </i18n>
       </template>
       <template v-else>
@@ -75,18 +76,20 @@
           :class="[$style.behavior, $style.fzRegular]"
           path="travel history from {area}"
         >
-          <em :class="$style.underline" place="area">{{
-            $t('COVID-19 prevalent area')
-          }}</em>
+          <template v-slot:area>
+            <em :class="$style.underline">{{
+              $t('COVID-19 prevalent area')
+            }}</em>
+          </template>
         </i18n>
         <i18n
           tag="span"
           :class="[$style.behavior, $style.fzXLarge]"
           path="been {inCloseContact} with returnees"
         >
-          <em :class="$style.underline" place="inCloseContact">{{
-            $t('in close contact')
-          }}</em>
+          <template v-slot:inCloseContact>
+            <em :class="$style.underline">{{ $t('in close contact') }}</em>
+          </template>
         </i18n>
       </template>
     </p>
@@ -99,14 +102,17 @@
       </p>
       <p :class="$style.symptom">
         <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <i18n
-            tag="span"
-            path="{tempNum}以上"
-            place="temperature"
-            :class="[$style.break, $style.fzRegular]"
-          >
-            <span :class="$style.temp" place="tempNum">{{ $t('37.5℃') }}</span>
-          </i18n>
+          <template v-slot:temperature>
+            <i18n
+              tag="span"
+              path="{tempNum}以上"
+              :class="[$style.break, $style.fzRegular]"
+            >
+              <template v-slot:tempNum>
+                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+              </template>
+            </i18n>
+          </template>
         </i18n>
       </p>
     </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -176,14 +176,15 @@
         tag="p"
         path="本サイトで公表しているデータは、{catalogWebsite}より誰でも自由にダウンロードが可能です。（データは順次追加予定です）"
       >
-        <a
-          href="https://portal.data.metro.tokyo.lg.jp/"
-          target="_blank"
-          rel="noopener"
-          place="catalogWebsite"
-        >
-          {{ $t('東京都オープンデータカタログサイト') }}
-        </a>
+        <template v-slot:catalogWebsite>
+          <a
+            href="https://portal.data.metro.tokyo.lg.jp/"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ $t('東京都オープンデータカタログサイト') }}
+          </a>
+        </template>
       </i18n>
     </StaticCard>
     <StaticCard>
@@ -195,14 +196,15 @@
           )
         }}
         <i18n path="詳しくは、{githubRepo}をご確認ください。">
-          <a
-            href="https://github.com/tokyo-metropolitan-gov/covid19"
-            target="_blank"
-            rel="noopener"
-            place="githubRepo"
-          >
-            {{ $t('GitHub リポジトリ') }}
-          </a>
+          <template v-slot:githubRepo>
+            <a
+              href="https://github.com/tokyo-metropolitan-gov/covid19"
+              target="_blank"
+              rel="noopener"
+            >
+              {{ $t('GitHub リポジトリ') }}
+            </a>
+          </template>
         </i18n>
       </p>
     </StaticCard>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2470

## ⛏ 変更内容 / Details of Changes
- vue-i18nのplaces syntaxをslots syntaxに変更
  - `place`プロパティがついている要素を、`v-slot`プロパティを定義した`template`タグでラップ

## 📸 スクリーンショット / Screenshots
表示上の変更はありません。