### PR TITLE
FORKED_SITES.md の岩手県版の URLを https://iwate.stopcovid19.jp/ へ変更

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -8,7 +8,7 @@
 [](01)北海道|https://stopcovid19.hokkaido.dev/|JUST道IT（有志団体）|[codeforsapporo/covid19](https://github.com/codeforsapporo/covid19)|
 [](02)青森県|https://covid19.codeforaomori.org|Code for Aomori|[CodeForAomori/covid19](https://github.com/CodeForAomori/covid19)|
 [](02)青森県|https://covid19-aomori.info/|Aomori Hackers（有志団体）|[covid19-aomori/website](https://github.com/covid19-aomori/website)|
-[](03)岩手県|https://covid19-iwate.netlify.com/|有志|[MeditationDuck/covid19](https://github.com/MeditationDuck/covid19)|
+[](03)岩手県|https://iwate.stopcovid19.jp/|有志|[MeditationDuck/covid19](https://github.com/MeditationDuck/covid19)|
 [](04)宮城県|https://miyagi.stopcovid19.jp/|Code for Shiogama|[code4shiogama/covid19-miyagi](https://github.com/code4shiogama/covid19-miyagi)|
 [](07)福島県|https://fukushima-covid19.firebaseapp.com|GDG Fukushima|[donuzium/covid19](https://github.com/donuzium/covid19)|
 [](08)茨城県|https://covid19-ibaraki.netlify.com/|個人|[a01sa01to/covid19-ibaraki](https://github.com/a01sa01to/covid19-ibaraki)|


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2486 

## ⛏ 変更内容 / Details of Changes
- FORKED_SITES.md の岩手県版の URLを https://iwate.stopcovid19.jp/ へ変更

