### PR TITLE
[/flow] (PR) PC版で矢印の示す順番にコンテンツがスクリーンリーダーで読み上げられない

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -146,3 +146,22 @@ $z-index-map: (
     }
   }
 }
+
+// ===================
+// Visually Hidden (for screen reader)
+// https://github.com/ampproject/amphtml/blob/2e9a940e78df8de38a6c06a0772aeaa4839a24d1/css/ampshared.css#L164-L204
+
+@mixin visually-hidden() {
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 4px !important;
+  height: 4px !important;
+  opacity: 0 !important;
+  overflow: hidden !important;
+  border: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  display: block !important;
+  visibility: visible !important;
+}

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -126,14 +126,7 @@ export default Vue.extend({
 
 @include largerThan($medium) {
   .only-sp {
-    clip: rect(1px, 1px, 1px, 1px);
-    clip-path: inset(50%);
-    height: 1px;
-    width: 1px;
-    margin: -1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
+    @include visually-hidden;
   }
 
   .only-pc {

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -25,7 +25,7 @@
           </v-icon>
         </a>
       </div>
-      <div class="only-pc">
+      <div class="only-pc" aria-hidden="true">
         <flow-pc />
       </div>
       <div class="only-sp">
@@ -126,7 +126,14 @@ export default Vue.extend({
 
 @include largerThan($medium) {
   .only-sp {
-    display: none;
+    clip: rect(1px, 1px, 1px, 1px);
+    clip-path: inset(50%);
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
   }
 
   .only-pc {
@@ -135,10 +142,6 @@ export default Vue.extend({
 }
 
 @include lessThan($medium) {
-  .only-sp {
-    display: block;
-  }
-
   .only-pc {
     display: none;
   }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #1440 

## ⛏ 変更内容 / Details of Changes

- スクリーンリーダーが常にSP版を参照するように修正
- PC版は常に `aria-hidden="true"`
- SP版は表示対象外のブレークポイントでも `display:none` ではなく Visually Hidden とする
    - Visually Hidden の内容は [AMP Project のもの](https://github.com/ampproject/amphtml/blob/2e9a940e78df8de38a6c06a0772aeaa4839a24d1/css/ampshared.css#L164-L204) を使用
    - `variables.scss` に専用mixinを用意
    - 現時点では `PrinterButton.vue` にもVisually Hiddenが存在する模様（範囲外のため作業はせず）