### PR TITLE
開発サーバでaxeのチェックを無効にするコマンドを追加

### DIFF
--- a/.env.dev-no-axe
+++ b/.env.dev-no-axe
@@ -1,2 +1,2 @@
 GENERATE_ENV=development
-VUE_AXE=true
+VUE_AXE=false

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "cross-env NODE_ENV=development nuxt-ts",
+    "dev-no-axe": "cross-env NODE_ENV=dev-no-axe nuxt-ts",
     "build": "nuxt-ts build",
     "start": "cross-env NODE_ENV=production nuxt-ts start",
     "generate:deploy": "cross-env NODE_ENV=production nuxt-ts generate",

--- a/plugins/axe.ts
+++ b/plugins/axe.ts
@@ -1,6 +1,9 @@
 import Vue from 'vue'
 
-if (process.env.NODE_ENV !== 'production') {
+const NODE_ENV = process.env.NODE_ENV
+const VUE_AXE = process.env.VUE_AXE
+
+if (NODE_ENV === 'development' && VUE_AXE === 'true') {
   const VueAxe = require('vue-axe')
   const AXE_LOCALE_JA = require('axe-core/locales/ja.json')
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2027 

## ⛏ 変更内容 / Details of Changes
- 画面の構成要素が増え、開発時axeによるアクセシビリティチェックが非常に重くなってきているため、チェックを無効にするモードを追加した。
- 以下コマンドでaxeを無効にした開発サーバが立ち上がります。
  ` yarn dev-no-axe`

かなりアクセシビリティ関連の課題は減ってきているのでデフォルトを無効にしておくことも可能だが、できるだけ多くの方に課題を早期に発見していただきたいとも思っています。
ご意見いただけると幸いです。