### PR TITLE
個別グラフページが、Facebook Graph API Explorer でエラー

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -81,7 +81,15 @@ export default Vue.extend({
     }
   },
   head(): MetaInfo {
-    const { htmlAttrs } = this.$nuxtI18nSeo()
+    const { htmlAttrs, meta } = this.$nuxtI18nSeo()
+    const ogLocale =
+      meta && meta.length > 0
+        ? meta[0]
+        : {
+            hid: 'og:locale',
+            name: 'og:locale',
+            content: this.$i18n.locale
+          }
     return {
       htmlAttrs,
       link: [
@@ -122,11 +130,7 @@ export default Vue.extend({
           property: 'og:url',
           content: `https://stopcovid19.metro.tokyo.lg.jp${this.$route.path}`
         },
-        {
-          hid: 'og:locale',
-          property: 'og:locale',
-          content: this.$i18n.locale
-        },
+        ogLocale,
         {
           hid: 'og:title',
           property: 'og:title',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2002

## 📝 関連する issue / Related Issues
- #1497

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- og:localeをnuxtI18nSeoで生成したものに置き換えることで、og:localeの値がll_CCになる

グラフAPIエクスプローラで実行したところエラーは解消しました。
<img width="1262" alt="スクリーンショット 2020-03-29 19 07 32" src="https://user-images.githubusercontent.com/1819135/77846384-a99dc400-71f0-11ea-8a2e-5704f264835f.png">

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->