### PR TITLE
refs #2570 Match label of MetroCard graph to other graph

### DIFF
--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -41,10 +41,14 @@ export default {
   data() {
     // 都営地下鉄の利用者数の推移
     const metroGraph = MetroData
+    for (const dataset of metroGraph.datasets) {
+      dataset.label = this.getWeekLabel(dataset.label)
+    }
+
     // metroGraph ツールチップ title文字列
     // this.$t を使うため metroGraphOption の外側へ
     const metroGraphTooltipTitle = (tooltipItems, _) => {
-      const label = tooltipItems[0].label
+      const label = this.getWeekLabel(tooltipItems[0].label)
       return this.$t('期間: {duration}', {
         // duration = label = '2月10日~14日' | '2月17日~21日' | '2月25日~28日'
         duration: this.$t(label)
@@ -70,6 +74,24 @@ export default {
       metroGraphTooltipLabel
     }
     return data
+  },
+  methods: {
+    /**
+     * 表の横軸に表示する、「MM/DD~MM/DD」形式のラベルを取得する
+     */
+    getWeekLabel(label) {
+      const slashCount = label.split('/').length - 1
+      if (slashCount === 1) {
+        // MM/DD~DD形式だったので、「~」の後に「MM/」を追加する
+        const month = label.substr(0, label.indexOf('/'))
+        label = label.replace('~', `~${month}/`)
+      }
+
+      // 日は、0埋めしない
+      label = label.replace('/0', '/')
+
+      return label
+    }
   }
 }
 </script>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- closes #2570

## 📝 関連する issue / Related Issues
- #1627 

## ⛏ 変更内容 / Details of Changes
`都営地下鉄の利用者数の推移`で横軸に表示しているラベルの形式を他のグラフと同じ形式になるように変更した

## 📸 スクリーンショット / Screenshots
<img width="525" alt="スクリーンショット 2020-03-29 23 37 06" src="https://user-images.githubusercontent.com/6235307/77852455-c7cbea00-7219-11ea-9ee4-c41d31a5c42d.png">
