### PR TITLE
お問い合わせ一覧のセマンティックマークアップ改善

### DIFF
--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -4,7 +4,7 @@
       {{ $t('お問い合わせ先一覧') }}
     </page-header>
     <div class="Contacts-Card">
-      <table class="Contacts-Card-Table" role="presentation">
+      <table class="Contacts-Card-Table" v-bind="tableAttrs">
         <thead>
           <tr>
             <th class="text-center" scope="col">
@@ -138,6 +138,9 @@ export default Vue.extend({
     }
   },
   computed: {
+    tableAttrs(): any {
+      return this.pc ? {} : { role: 'presentation' }
+    },
     headingAttrs(): any {
       return this.pc ? {} : { role: 'heading', 'aria-level': '3' }
     }

--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -16,14 +16,14 @@
         </thead>
         <tbody>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('サイト全般に関すること') }}
             </td>
             <td class="bureau">{{ $t('政策企画局') }}</td>
             <td class="tel"><a href="tel:03-5388-2171">03-5388-2171</a></td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('サイトの技術面に関すること') }}<br />{{
                 $t('オープンデータ、オープンソースに関すること')
               }}
@@ -32,7 +32,7 @@
             <td class="tel"><a href="tel:03-5320-7930">03-5320-7930</a></td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('新型コロナウイルス感染症対策本部会議に関すること')
               }}<br />{{ $t('都庁来庁者データに関すること') }}
             </td>
@@ -49,7 +49,7 @@
             </td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('都公式ホームページに関すること') }}<br />{{
                 $t('都公式SNSアカウントに関すること')
               }}
@@ -67,7 +67,7 @@
             </td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('中小企業支援、テレワークに関すること') }}
             </td>
             <td class="bureau">{{ $t('産業労働局') }}</td>
@@ -84,7 +84,7 @@
             </td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('新型コロナウイルス感染症の予防・検査・医療に関すること') }}
             </td>
             <td class="bureau">{{ $t('福祉保健局') }}</td>
@@ -94,21 +94,21 @@
             </td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('都立学校に関すること') }}
             </td>
             <td class="bureau">{{ $t('教育庁') }}</td>
             <td class="tel"><a href="tel:03-5320-6705">03-5320-6705</a></td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('スムーズビズに関すること') }}
             </td>
             <td class="bureau">{{ $t('都市整備局') }}</td>
             <td class="tel"><a href="tel:03-5388-3317">03-5388-3317</a></td>
           </tr>
           <tr>
-            <td class="content" role="heading" aria-level="3">
+            <td class="content" v-bind="headingAttrs">
               {{ $t('都営交通に関すること') }}
             </td>
             <td class="bureau">{{ $t('交通局') }}</td>
@@ -131,6 +131,32 @@ import PageHeader from '@/components/PageHeader.vue'
 export default Vue.extend({
   components: {
     PageHeader
+  },
+  data() {
+    return {
+      pc: true
+    }
+  },
+  computed: {
+    headingAttrs(): any {
+      return this.pc ? {} : { role: 'heading', 'aria-level': '3' }
+    }
+  },
+  created() {
+    if (process.browser) {
+      window.addEventListener('resize', this.handleResize)
+      this.handleResize()
+    }
+  },
+  destroyed() {
+    if (process.browser) {
+      window.removeEventListener('resize', this.handleResize)
+    }
+  },
+  methods: {
+    handleResize() {
+      this.pc = window.innerWidth > 768
+    }
   },
   head(): MetaInfo {
     return {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2411

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- お問い合わせ一覧にて、以下のセマンティックマークアップをPC版では付加しないようにする
  - `table`に対する`role="presentation"`
  -「お問い合わせ内容」にあたるテキストに対する`role="heading" aria-level="3"`
- PC版では表形式で表示されているため、視覚的な表示に合ったセマンティクスにする https://github.com/tokyo-metropolitan-gov/covid19/issues/2411#issuecomment-605393410

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### PC版
![image](https://user-images.githubusercontent.com/42484226/77852510-08c3fe80-721a-11ea-9883-5d6306d9eab0.png)
### SP版
![image](https://user-images.githubusercontent.com/42484226/77852539-2f823500-721a-11ea-9fce-e837f5e2c202.png)
