### PR TITLE
埋め込み時に「日別/累計」のデフォルト値を変更できるようにする

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -126,6 +126,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 > = {
   created() {
     this.canvas = process.browser
+    this.dataKind =
+      this.$route.query.embed && this.$route.query.dataKind === 'cumulative'
+        ? 'cumulative'
+        : 'transition'
   },
   components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
   props: {


### PR DESCRIPTION

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2574

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- クエリ文字列として`dataKind`というパラメタを追加し、`dataKind=cumulative`であれば累計を、`dataKind=transition`であれば日別で表示するように変更します。
    - 実際には`cumulative` 以外は `transition`にしています。
    - 指定がない場合も `transition`にしています。
- 埋め込み時以外(embedパラメタがない場合)は無視されます。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

使用したHTMLコード:

```html
<iframe width="560" height="500"
  src="http://localhost:3000/cards/number-of-confirmed-cases?embed=true&dataKind=cumulative"
  frameborder="0">
</iframe>
<iframe width="560" height="500"
  src="http://localhost:3000/cards/number-of-confirmed-cases?embed=true&dataKind=transition"
  frameborder="0">
</iframe>
```

結果画像:

![スクリーンショット](https://user-images.githubusercontent.com/10401/77855913-9a3d6b80-722e-11ea-966d-2b13043aba28.png)
