### PR TITLE
お問い合わせ一覧をSPモードで直接開いた際にセマンティックマークアップを付加する

### DIFF
--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -145,7 +145,7 @@ export default Vue.extend({
       return this.pc ? {} : { role: 'heading', 'aria-level': '3' }
     }
   },
-  created() {
+  mounted() {
     if (process.browser) {
       window.addEventListener('resize', this.handleResize)
       this.handleResize()


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue,PR / Related Issues,PRs
- #2411 
- #2572 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- #2572 で発生していた、SPモードで「お問い合わせ一覧」を直接開いた際にセマンティックマークアップが付加されない問題を修正 https://github.com/tokyo-metropolitan-gov/covid19/pull/2572#issuecomment-605834566

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![output](https://user-images.githubusercontent.com/42484226/77895991-86d3e400-72b2-11ea-9a03-18290329109d.gif)
