### PR TITLE
Allow previewing translations on development 

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -1,3 +1,71 @@
+const locales = [
+  {
+    code: 'ja',
+    name: '日本語',
+    iso: 'ja-JP',
+    file: 'ja.json',
+    description: 'Japanese'
+  },
+  {
+    code: 'en',
+    name: 'English',
+    iso: 'en-US',
+    file: 'en.json',
+    description: 'English'
+  },
+  {
+    code: 'zh-cn',
+    name: '简体中文',
+    iso: 'zh-CN',
+    file: 'zh_CN.json',
+    description: 'Simplified Chinese'
+  },
+  {
+    code: 'zh-tw',
+    name: '繁體中文',
+    iso: 'zh-TW',
+    file: 'zh_TW.json',
+    description: 'Traditional Chinese'
+  },
+  {
+    code: 'ko',
+    name: '한국어',
+    iso: 'ko-KR',
+    file: 'ko.json',
+    description: 'Korean'
+  },
+  // #1126, #872 (comment)
+  // ポルトガル語は訳が揃っていないため非表示
+  // {
+  //   code: 'pt-BR',
+  //   name: 'Portuguese',
+  //   iso: 'pt-BR',
+  //   file: 'pt_BR.json',
+  //   description: 'Portuguese'
+  // },
+  {
+    code: 'ja-basic',
+    name: 'やさしい にほんご',
+    iso: 'ja-JP',
+    file: 'ja-Hira.json',
+    description: 'Easy Japanese'
+  }
+]
+
+// Allow previewing translations on development #2603, #1985
+require('dotenv').config({
+  path: `.env.${process.env.NODE_ENV || 'development'}`
+})
+if (process.env.GENERATE_ENV === 'development') {
+  locales.push({
+    code: 'vi',
+    name: 'Tiếng Việt',
+    iso: 'vi-VN',
+    file: 'vi.json',
+    description: 'Vietnamese'
+  })
+}
+
 export default {
   strategy: 'prefix_except_default',
   detectBrowserLanguage: {
@@ -12,57 +80,5 @@ export default {
   // vueI18nLoader: true,
   lazy: true,
   langDir: 'assets/locales/',
-  locales: [
-    {
-      code: 'ja',
-      name: '日本語',
-      iso: 'ja-JP',
-      file: 'ja.json',
-      description: 'Japanese'
-    },
-    {
-      code: 'en',
-      name: 'English',
-      iso: 'en-US',
-      file: 'en.json',
-      description: 'English'
-    },
-    {
-      code: 'zh-cn',
-      name: '简体中文',
-      iso: 'zh-CN',
-      file: 'zh_CN.json',
-      description: 'Simplified Chinese'
-    },
-    {
-      code: 'zh-tw',
-      name: '繁體中文',
-      iso: 'zh-TW',
-      file: 'zh_TW.json',
-      description: 'Traditional Chinese'
-    },
-    {
-      code: 'ko',
-      name: '한국어',
-      iso: 'ko-KR',
-      file: 'ko.json',
-      description: 'Korean'
-    },
-    // #1126, #872 (comment)
-    // ポルトガル語は訳が揃っていないため非表示
-    // {
-    //   code: 'pt-BR',
-    //   name: 'Portuguese',
-    //   iso: 'pt-BR',
-    //   file: 'pt_BR.json',
-    //   description: 'Portuguese'
-    // },
-    {
-      code: 'ja-basic',
-      name: 'やさしい にほんご',
-      iso: 'ja-JP',
-      file: 'ja-Hira.json',
-      description: 'Easy Japanese'
-    }
-  ]
+  locales
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- https://github.com/tokyo-metropolitan-gov/covid19/issues/2603#issuecomment-606335146
 ベトナム語翻訳を本番 production 環境以外（ development, staging）でプレビューできるようにした

## 📝 関連する issue / Related Issues
- #2603 
- #1985

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- nuxt-i18n.config.ts で `.env.NODE_ENV` を読み込む
- `process.env.GENERATE_ENV === 'development'` なら、ベトナム語を有効にする

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

![image](https://user-images.githubusercontent.com/123111/77984851-bd127180-734d-11ea-965c-9acb389294ea.png)

