### PR TITLE
実績値の前に最新情報の日付を追加

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -177,9 +177,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       if (this.dataKind === 'transition') {
         return {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
-          sText: `${this.$t('実績値')}（${this.$t('前日比')}: ${
-            this.displayTransitionRatio
-          } ${this.unit}）`,
+          sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+            '実績値'
+          )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
           unit: this.unit
         }
       }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2652 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性患者数」「検査実施人数」「新型コロナコールセンター相談件数」「新型コロナ受診相談窓口相談件数」における「実績値」文字列の前に、取得した最新情報の日付が表示されるようにした。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/29789286/78017243-ebf90980-7386-11ea-9102-559bd731da43.png)