### PR TITLE
グラフの色をアップデートする

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -50,7 +50,7 @@ import { ChartOptions } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
-import { triple as colors } from '@/utils/colors'
+import { getGraphSeriesStyle } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends MouseEvent {
   currentTarget: T
@@ -70,7 +70,7 @@ type Computed = {
       data: number[]
       backgroundColor: string
       borderColor: string
-      borderWidth: object
+      borderWidth: number
     }[]
   }
   displayOption: ChartOptions
@@ -140,21 +140,16 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   computed: {
     displayData() {
-      const borderColor = '#ffffff'
-      const borderWidth = [
-        { left: 0, top: 1, right: 0, bottom: 0 },
-        { left: 0, top: 1, right: 0, bottom: 0 },
-        { left: 0, top: 0, right: 0, bottom: 0 }
-      ]
+      const graphSeries = getGraphSeriesStyle(this.chartData.datasets.length)
       return {
         labels: this.chartData.labels as string[],
         datasets: this.chartData.datasets.map((item, index) => {
           return {
             label: this.agencies[index] as string,
             data: item.data,
-            backgroundColor: colors[index] as string,
-            borderColor,
-            borderWidth: borderWidth[index]
+            backgroundColor: graphSeries[index].fillColor,
+            borderColor: graphSeries[index].strokeColor,
+            borderWidth: 1
           }
         })
       }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -49,7 +49,7 @@ import { TranslateResult } from 'vue-i18n'
 import { ChartOptions, ChartData } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
-import { triple as colors } from '@/utils/colors'
+import { getGraphSeriesStyle } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -66,6 +66,7 @@ type Computed = {
       label: string
       data: number[]
       backgroundColor: string
+      borderColor: string
       borderWidth: number
     }[]
   }
@@ -161,12 +162,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   }),
   computed: {
     displayData() {
+      const graphSeries = getGraphSeriesStyle(this.chartData.labels!.length)
       const datasets = this.chartData.labels!.map((label, i) => {
         return {
           label: label as string,
           data: this.chartData.datasets!.map(d => d.data![i]) as number[],
-          backgroundColor: colors[i],
-          borderWidth: 0
+          backgroundColor: graphSeries[i].fillColor,
+          borderColor: graphSeries[i].strokeColor,
+          borderWidth: 1
         }
       })
       return {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -57,7 +57,7 @@ import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 
-import { single as color } from '@/utils/colors'
+import { getGraphSeriesStyle } from '@/utils/colors'
 
 type Data = {
   dataKind: 'transition' | 'cumulative'
@@ -80,6 +80,7 @@ type Computed = {
       label: 'transition' | 'cumulative'
       data: number[]
       backgroundColor: string
+      borderColor: string
       borderWidth: number
     }[]
   }
@@ -202,6 +203,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayData() {
+      const style = getGraphSeriesStyle(1)[0]
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
@@ -213,8 +215,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               data: this.chartData.map(d => {
                 return d.transition
               }),
-              backgroundColor: color,
-              borderWidth: 0
+              backgroundColor: style.fillColor,
+              borderColor: style.strokeColor,
+              borderWidth: 1
             }
           ]
         }
@@ -227,8 +230,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             data: this.chartData.map(d => {
               return d.cumulative
             }),
-            backgroundColor: color,
-            borderWidth: 0
+            backgroundColor: style.fillColor,
+            borderColor: style.strokeColor,
+            borderWidth: 1
           }
         ]
       }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -66,7 +66,7 @@ import { TranslateResult } from 'vue-i18n'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
-import { double as colors } from '@/utils/colors'
+import { getGraphSeriesStyle } from '@/utils/colors'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -96,7 +96,7 @@ type Computed = {
       data: number[]
       backgroundColor: string
       borderColor: string
-      borderWidth: object
+      borderWidth: number
     }[]
   }
   tableHeaders: {
@@ -213,11 +213,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayData() {
-      const borderColor = '#ffffff'
-      const borderWidth = [
-        { left: 0, top: 1, right: 0, bottom: 0 },
-        { left: 0, top: 0, right: 0, bottom: 0 }
-      ]
+      const graphSeries = getGraphSeriesStyle(this.chartData.length)
       if (this.dataKind === 'transition') {
         return {
           labels: this.labels,
@@ -225,9 +221,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return {
               label: this.items[index],
               data: item,
-              backgroundColor: colors[index],
-              borderColor,
-              borderWidth: borderWidth[index]
+              backgroundColor: graphSeries[index].fillColor,
+              borderColor: graphSeries[index].strokeColor,
+              borderWidth: 1
             }
           })
         }
@@ -238,9 +234,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           return {
             label: this.items[index],
             data: this.cumulative(item),
-            backgroundColor: colors[index],
-            borderColor,
-            borderWidth: borderWidth[index]
+            backgroundColor: graphSeries[index].fillColor,
+            borderColor: graphSeries[index].strokeColor,
+            borderWidth: 1
           }
         })
       }

--- a/components/VisitorsBarChart.vue
+++ b/components/VisitorsBarChart.vue
@@ -67,7 +67,7 @@ import weekOfYear from 'dayjs/plugin/weekOfYear'
 import updateLocale from 'dayjs/plugin/updateLocale'
 import minMax from 'dayjs/plugin/minMax'
 import DataView from '@/components/DataView.vue'
-import { single as color } from '@/utils/colors'
+import { getGraphSeriesStyle } from '@/utils/colors'
 import SourceLink from '@/components/SourceLink.vue'
 
 dayjs.extend(updateLocale)
@@ -111,6 +111,8 @@ type Computed = {
     datasets: {
       data: number[]
       backgroundColor: string
+      borderColor: string
+      borderWidth: number
     }[]
   }
   displayOptions: {
@@ -272,12 +274,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const percentages = this.targetValues.map(
         (val: number) => ((val - this.standardValue) / this.standardValue) * 100
       )
+      const style = getGraphSeriesStyle(1)[0]
       return {
         labels: this.labels,
         datasets: [
           {
             data: percentages,
-            backgroundColor: color
+            backgroundColor: style.fillColor,
+            borderColor: style.strokeColor,
+            borderWidth: 1
           }
         ]
       }

--- a/utils/colors.ts
+++ b/utils/colors.ts
@@ -1,4 +1,30 @@
-export const single: string = '#006400'
-export const double: string[] = ['#006400', '#1B75BC']
-export const triple: string[] = ['#00441B', '#006400', '#1B75BC']
-export const quadruple: string[] = ['#00441B', '#006400', '#1B75BC', '#505B00']
+export type SurfaceStyle = {
+  strokeColor: string
+  fillColor: string
+}
+
+const surfaceStyleA: SurfaceStyle = {
+  strokeColor: '#5a8055',
+  fillColor: '#1b4d30'
+}
+
+const surfaceStyleB: SurfaceStyle = {
+  strokeColor: '#5a8055',
+  fillColor: '#00a040'
+}
+
+const surfaceStyleC: SurfaceStyle = {
+  strokeColor: '#5a8055',
+  fillColor: '#c5e2c6'
+}
+
+export function getGraphSeriesStyle(seriesLength: number) {
+  switch (seriesLength) {
+    case 1:
+      return [surfaceStyleB]
+    case 2:
+      return [surfaceStyleA, surfaceStyleB]
+    default:
+      return [surfaceStyleA, surfaceStyleB, surfaceStyleC]
+  }
+}


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2364

## ⛏ 変更内容 / Details of Changes
- 棒グラフの色（塗りおよび罫線）を #2364 で検討された結果にアップデートした
- 系列数におうじてスタイルを取得できるように `getGraphSeriesStyle` 関数を用意した

## 📸 スクリーンショット / Screenshots
![localhost_3000_ (2)](https://user-images.githubusercontent.com/490085/78088062-0a4e1c00-73fe-11ea-8fd1-fa2fc37f672a.png)