### PR TITLE
Firefoxでデフォルトのソート順が公表日の降順にならない

### DIFF
--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -50,6 +50,6 @@ export default (data: DataType[]) => {
     }
     tableDate.datasets.push(TableRow)
   })
-  tableDate.datasets.sort((a, b) => (a === b ? 0 : a < b ? 1 : -1))
+  tableDate.datasets.sort((a, b) => (a.公表日 === b.公表日 ? 0 : a.公表日 < b.公表日 ? 1 : -1))
   return tableDate
 }

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -50,6 +50,8 @@ export default (data: DataType[]) => {
     }
     tableDate.datasets.push(TableRow)
   })
-  tableDate.datasets.sort((a, b) => (a.公表日 === b.公表日 ? 0 : a.公表日 < b.公表日 ? 1 : -1))
+  tableDate.datasets.sort((a, b) =>
+    a.公表日 === b.公表日 ? 0 : a.公表日 < b.公表日 ? 1 : -1
+  )
   return tableDate
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2525

## 📝 関連する issue / Related Issues
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ソートの際に明示的に公表日を比較するように修正。
- FirefoxとChromeではオブジェクトまるごと比較すると、逆にソートしてしまう。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
