### PR TITLE
[Issue 2587] Add lastUpdate to meta description

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <v-app class="app">
     <v-overlay v-if="loading" color="#F8F9FA" opacity="1" z-index="9999">
       <div class="loader">
@@ -34,10 +34,12 @@
 <script lang="ts">
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
+import Data from '@/data/data.json'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 import SideNavigation from '@/components/SideNavigation.vue'
 import NoScript from '@/components/NoScript.vue'
 import DevelopmentModeMark from '@/components/DevelopmentModeMark.vue'
+import { convertDateToISO8601Format } from '@/utils/formatDate'
 
 type LocalData = {
   hasNavigation: boolean
@@ -111,9 +113,13 @@ export default Vue.extend({
         {
           hid: 'description',
           name: 'description',
-          content: this.$tc(
-            '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
-          )
+          content:
+            this.$t('最終更新日：') +
+            convertDateToISO8601Format(Data.lastUpdate) +
+            ' ' +
+            this.$tc(
+              '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
+            )
         },
         {
           hid: 'og:site_name',
@@ -144,9 +150,13 @@ export default Vue.extend({
         {
           hid: 'og:description',
           property: 'og:description',
-          content: this.$tc(
-            '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
-          )
+          content:
+            this.$t('最終更新日：') +
+            convertDateToISO8601Format(Data.lastUpdate) +
+            ' ' +
+            this.$tc(
+              '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
+            )
         },
         {
           hid: 'og:image',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,7 +39,7 @@ import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 import SideNavigation from '@/components/SideNavigation.vue'
 import NoScript from '@/components/NoScript.vue'
 import DevelopmentModeMark from '@/components/DevelopmentModeMark.vue'
-import { convertDateToISO8601Format } from '@/utils/formatDate'
+import { convertDateToSimpleFormat } from '@/utils/formatDate'
 
 type LocalData = {
   hasNavigation: boolean
@@ -114,9 +114,8 @@ export default Vue.extend({
           hid: 'description',
           name: 'description',
           content:
-            this.$t('最終更新日：') +
-            convertDateToISO8601Format(Data.lastUpdate) +
-            ' ' +
+            convertDateToSimpleFormat(Data.lastUpdate) +
+            ' 更新：　' +
             this.$tc(
               '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
             )
@@ -151,9 +150,8 @@ export default Vue.extend({
           hid: 'og:description',
           property: 'og:description',
           content:
-            this.$t('最終更新日：') +
-            convertDateToISO8601Format(Data.lastUpdate) +
-            ' ' +
+            convertDateToSimpleFormat(Data.lastUpdate) +
+            ' 更新：　' +
             this.$tc(
               '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
             )

--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -17,3 +17,12 @@ export const convertDatetimeToISO8601Format = (dateString: string): string => {
 export const convertDateToISO8601Format = (dateString: string): string => {
   return dayjs(dateString).format('YYYY-MM-DD')
 }
+
+/**
+ * Get date string formatted Simple(YYYY/MM/DD)
+ *
+ * @param dateString- Parsable string by dayjs
+ */
+export const convertDateToSimpleFormat = (dateString: string): string => {
+  return dayjs(dateString).format('YYYY/MM/DD')
+}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2587 

## 📝 関連する issue / Related Issues
- #2587 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- meta 情報に最終更新日が付記されるよう、layouts/default.vue に `data.lastUpdate` を追加 
- 日付の書式で YYYY/MM/DD が利用できるよう、utils/formatDate.ts にフォーマットを追加


## 📸 スクリーンショット / Screenshots
[Issue2587_solve](https://user-images.githubusercontent.com/62841352/78272182-28c02e80-7548-11ea-867c-d51bd465263f.jpg)