### PR TITLE
スマートフォン表示時のSelectorのフォントサイズ変更

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
     margin-left: 4px;
     color: $gray-1;
     font-size: 12px;
-    @media screen and (max-width: 600px) {
+    @include lessThan($small) {
       font-size: 16px;
     }
   }
@@ -108,7 +108,7 @@ export default Vue.extend({
     border: 1px dotted $gray-3;
     outline: none;
   }
-  @media screen and (max-width: 600px) {
+  @include lessThan($small) {
     padding-left: 70px;
     font-size: 16px;
   }

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -74,6 +74,9 @@ export default Vue.extend({
     margin-left: 4px;
     color: $gray-1;
     font-size: 12px;
+    @media screen and (max-width: 600px) {
+      font-size: 16px;
+    }
   }
 }
 
@@ -104,6 +107,10 @@ export default Vue.extend({
   &:focus {
     border: 1px dotted $gray-3;
     outline: none;
+  }
+  @media screen and (max-width: 600px) {
+    padding-left: 70px;
+    font-size: 16px;
   }
 }
 </style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2591 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイドバーが表示されるのと同じブレイクポイント(600px)で下記を変更
    - Selectorのフォントサイズを変更
    - Selector内部のラベル「Lang:」部分も同様にフォントサイズを変更
    - 👆に伴うSelector内部のpadding-leftの変更

## 📸 スクリーンショット / Screenshots

- iOS(Safari)と、Windows(Edge-Chromium)のスクショです。
  - Issueで「やさしいにほんご」の表示に懸念が上がっていたのでそちらも添付しています。
- iPhone 7 Plus / iOS 13.3.1 / Safari 
 - ![20200403_054457000_iOS](https://user-images.githubusercontent.com/22936439/78328337-e46d7680-75b9-11ea-9ec2-b39ca95aaf28.png)
  - ![20200403_035857000_iOS](https://user-images.githubusercontent.com/22936439/78327578-2f868a00-75b8-11ea-8854-b004b6f0a455.png)
  - ![20200403_035840000_iOS](https://user-images.githubusercontent.com/22936439/78327458-e0405980-75b7-11ea-81e1-86b4d9022328.png)

- Windows10(表示スケール150%) / Edge(Chromium)
  - <img width="443" alt="yasa" src="https://user-images.githubusercontent.com/22936439/78327862-c6ebdd00-75b8-11ea-87ef-4a4d1568123d.png">
- Windows10(表示スケール100%) / Edge(Chromium)
  - ![100](https://user-images.githubusercontent.com/22936439/78328069-32ce4580-75b9-11ea-8d23-066505e19a39.png)

