### PR TITLE
デバッグモード表示時にIE11でエラーになるのを修正

### DIFF
--- a/.env.dev-no-axe
+++ b/.env.dev-no-axe
@@ -1,2 +1,1 @@
-GENERATE_ENV=development
 VUE_AXE=false

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,1 @@
-GENERATE_ENV=development
 VUE_AXE=true

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-GENERATE_ENV=production
+

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "node": ">=10.19.0"
   },
   "scripts": {
-    "dev": "cross-env NODE_ENV=development nuxt-ts",
-    "dev-no-axe": "cross-env NODE_ENV=dev-no-axe nuxt-ts",
+    "dev": "cross-env NODE_ENV=development GENERATE_ENV=development nuxt-ts",
+    "dev-no-axe": "cross-env NODE_ENV=dev-no-axe GENERATE_ENV=development nuxt-ts",
     "build": "nuxt-ts build",
     "start": "cross-env NODE_ENV=production nuxt-ts start",
-    "generate:deploy": "cross-env NODE_ENV=production nuxt-ts generate",
-    "generate:dev": "cross-env NODE_ENV=development nuxt-ts generate",
+    "generate:deploy": "cross-env GENERATE_ENV=production nuxt-ts generate",
+    "generate:dev": "cross-env GENERATE_ENV=development nuxt-ts generate",
     "generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "lint-and-generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "test": "echo 'skip tests (there is no test)'",


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2758

## ⛏ 変更内容 / Details of Changes
- IE11のエラーの原因となってるNODE_ENV=developmentでのgenerateをやめるために、generateコマンドからNODE_ENVの指定を削除
- このままではdevサイト・stgサイトの開発中バーを表示されないので、開発中バーの表示非表示を判定するGENERATE_ENVの指定を.envファイルから削除して、べたにnpm-scriptsで指定（本番環境はgenerate:deployのみなのでここだけGENERATE_ENV=production、それ以外のビルドはGENERATE_ENV=development）

## 備考
とりあえず現状のエラーを回避するためにこのような修正しましたが、もっとスマートな環境変数の構成はあるかと思います