### PR TITLE
スマホ 言語変更したらサイドナビを閉じる

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -47,8 +47,9 @@ export default Vue.extend({
     }
   },
   methods: {
-    handleChangeLanguage() {
+    handleChangeLanguage(event: Event) {
       this.$root.$i18n.setLocale(this.currentLocaleCode)
+      this.$emit('change', event)
     }
   }
 })

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -42,7 +42,7 @@
             <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
               {{ $t('多言語対応選択メニュー') }}
             </label>
-            <LanguageSelector />
+            <LanguageSelector @change="$emit('closeNavi', $event)" />
           </div>
         </div>
         <MenuList :items="items" @click="$emit('closeNavi', $event)" />


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2841 

## ⛏ 変更内容 / Details of Changes
- `<MenuList>`をクリックするとcloseNaviが発火するように、`<LanguageSelector>`が変更されるとcloseNaviが発火するようにして、閉じるようにしました。
