### PR TITLE
PC表示時にスクロールできなくなる問題の修正

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,10 +71,10 @@ export default Vue.extend({
   },
   mounted() {
     this.loading = false
-    window.addEventListener('resize', this.hideNavigation)
+    window.addEventListener('resize', this.resizeHandler)
   },
   beforeDestroy() {
-    window.removeEventListener('resize', this.hideNavigation)
+    window.removeEventListener('resize', this.resizeHandler)
   },
   methods: {
     openNavigation(): void {
@@ -82,6 +82,11 @@ export default Vue.extend({
     },
     hideNavigation(): void {
       this.isOpenNavigation = false
+    },
+    resizeHandler(): void {
+      if (window.matchMedia('(min-width: 600px)').matches) {
+        this.hideNavigation()
+      }
     }
   },
   head(): MetaInfo {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -73,6 +73,9 @@ export default Vue.extend({
     this.loading = false
     window.addEventListener('resize', this.hideNavigation)
   },
+  beforeDestroy() {
+    window.removeEventListener('resize', this.hideNavigation)
+  },
   methods: {
     openNavigation(): void {
       this.isOpenNavigation = true

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,10 +71,10 @@ export default Vue.extend({
   },
   mounted() {
     this.loading = false
-    window.addEventListener('resize', this.resizeHandler)
+    this.getMatchMedia().addListener(this.hideNavigation)
   },
   beforeDestroy() {
-    window.removeEventListener('resize', this.resizeHandler)
+    this.getMatchMedia().removeListener(this.hideNavigation)
   },
   methods: {
     openNavigation(): void {
@@ -83,10 +83,8 @@ export default Vue.extend({
     hideNavigation(): void {
       this.isOpenNavigation = false
     },
-    resizeHandler(): void {
-      if (window.matchMedia('(min-width: 600px)').matches) {
-        this.hideNavigation()
-      }
+    getMatchMedia(): MediaQueryList {
+      return window.matchMedia('(min-width: 601px)')
     }
   },
   head(): MetaInfo {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -71,6 +71,7 @@ export default Vue.extend({
   },
   mounted() {
     this.loading = false
+    window.addEventListener('resize', this.hideNavigation)
   },
   methods: {
     openNavigation(): void {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2843 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- サイドナビを開いた状態でPC表示に切り替えると、メインウィンドウのスクロールが無効になってしまうので、ウィンドウのリサイズイベントが起こった際にサイドナビゲーションを閉じるようにしました。