### PR TITLE
「検査陽性者の状況」「検査実施状況」の数値を3桁区切りで表示する

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -8,7 +8,7 @@
             <br />({{ $t('累計') }})
           </span>
           <span>
-            <strong>{{ 陽性者数 }}</strong>
+            <strong>{{ 陽性者数.toLocaleString() }}</strong>
             <span :class="$style.unit">{{ $t('人') }}</span>
           </span>
         </div>
@@ -19,7 +19,7 @@
             <div :class="$style.content">
               <span>{{ $t('入院中') }}</span>
               <span>
-                <strong>{{ 入院中 }}</strong>
+                <strong>{{ 入院中.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('人') }}</span>
               </span>
             </div>
@@ -32,7 +32,7 @@
                   <span v-html="$t('軽症・<br />中等症')" />
                   <!-- eslint-enable vue/no-v-html-->
                   <span>
-                    <strong>{{ 軽症中等症 }}</strong>
+                    <strong>{{ 軽症中等症.toLocaleString() }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>
                 </div>
@@ -43,7 +43,7 @@
                 <div :class="$style.content">
                   <span>{{ $t('重症') }}</span>
                   <span>
-                    <strong>{{ 重症 }}</strong>
+                    <strong>{{ 重症.toLocaleString() }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
                   </span>
                 </div>
@@ -56,7 +56,7 @@
             <div :class="$style.content">
               <span>{{ $t('死亡') }}</span>
               <span>
-                <strong>{{ 死亡 }}</strong>
+                <strong>{{ 死亡.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('人') }}</span>
               </span>
             </div>
@@ -67,7 +67,7 @@
             <div :class="$style.content">
               <span>{{ $t('退院') }}</span>
               <span>
-                <strong>{{ 退院 }}</strong>
+                <strong>{{ 退院.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('人') }}</span>
               </span>
             </div>

--- a/components/TestedCasesDetailsTable.vue
+++ b/components/TestedCasesDetailsTable.vue
@@ -10,7 +10,7 @@
           </span>
           <!-- eslint-enable vue/no-v-html-->
           <span>
-            <strong>{{ 累計人数 }}</strong>
+            <strong>{{ 累計人数.toLocaleString() }}</strong>
             <span :class="$style.unit">{{ $t('人') }}</span>
           </span>
         </div>
@@ -25,7 +25,7 @@
         <div :class="$style.content">
           <span>{{ $t('合計') }}</span>
           <span>
-            <strong>{{ 合計件数 }}</strong>
+            <strong>{{ 合計件数.toLocaleString() }}</strong>
             <span :class="$style.unit">{{ $t('件.tested') }}</span>
           </span>
         </div>
@@ -36,7 +36,7 @@
             <div :class="$style.content">
               <span>{{ $t('都内発生') }}</span>
               <span>
-                <strong>{{ 都内発生件数 }}</strong>
+                <strong>{{ 都内発生件数.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('件.tested') }}</span>
               </span>
             </div>
@@ -50,7 +50,7 @@
                 $t('（チャーター機・クルーズ船等）')
               }}</span>
               <span>
-                <strong>{{ その他件数 }}</strong>
+                <strong>{{ その他件数.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('件.tested') }}</span>
               </span>
             </div>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2870 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「検査陽性者の状況」「検査実施状況」にて、数値を3桁区切りで表示する

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
以下の数値はダミーデータです。
### 数値が4桁以上の場合（区切りが必要な場合）
![image](https://user-images.githubusercontent.com/42484226/78461680-20155700-7706-11ea-9823-c7996138798f.png)

### 数値が3桁以下の場合（区切りが不要な場合）
![image](https://user-images.githubusercontent.com/42484226/78461690-30c5cd00-7706-11ea-82b3-80e3a2383989.png)
