### PR TITLE
ハンバーガーメニューから他のページに遷移した際、ヘッダーの下部に点線が出る問題を修正しました。

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -204,7 +204,7 @@ export default Vue.extend({
   mounted() {
     // Webページ表示後に、サイドバーのロゴまたは「都内の最新感染動向」リンクをクリックした場合に
     // handleChangeRoute()が発火しないため、初回のみclickイベントを登録しておく。
-    this.eraseLinkUnderLine();
+    this.eraseLinkUnderLine()
   },
   methods: {
     eraseLinkUnderLine() {

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -201,6 +201,11 @@ export default Vue.extend({
   watch: {
     $route: 'handleChageRoute'
   },
+  mounted() {
+    // Webページ表示後に、サイドバーのロゴまたは「都内の最新感染動向」リンクをクリックした場合に
+    // handleChangeRoute()が発火しないため、初回のみclickイベントを登録しておく。
+    this.eraseLinkUnderLine();
+  },
   methods: {
     eraseLinkUnderLine() {
       const $Side = this.$refs.Side as HTMLEmbedElement | undefined
@@ -217,11 +222,6 @@ export default Vue.extend({
         this.eraseLinkUnderLine()
       })
     }
-  },
-  mounted() {
-    // Webページ表示後に、サイドバーのロゴまたは「都内の最新感染動向」リンクをクリックした場合に
-    // handleChangeRoute()が発火しないため、初回のみclickイベントを登録しておく。
-    this.eraseLinkUnderLine();
   }
 })
 </script>

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -214,7 +214,7 @@ export default Vue.extend({
     handleChageRoute() {
       // nuxt-link で遷移するとフォーカスが残り続けるので $route を監視して SideNavigation にフォーカスする
       return this.$nextTick().then(() => {
-        this.eraseLinkUnderLine();
+        this.eraseLinkUnderLine()
       })
     }
   },

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -204,7 +204,7 @@ export default Vue.extend({
   mounted() {
     // Webページ表示後に、サイドバーのロゴまたは「都内の最新感染動向」リンクをクリックした場合に
     // handleChangeRoute()が発火しないため、初回のみclickイベントを登録しておく。
-    this.eraseLinkUnderLine()
+    this.eraseLinkUnderLineWithRegistHandler()
   },
   methods: {
     eraseLinkUnderLine() {
@@ -212,14 +212,21 @@ export default Vue.extend({
       if ($Side) {
         $Side.focus()
         $Side.blur()
+      }
+    },
+    eraseLinkUnderLineWithRegistHandler() {
+      const $Side = this.$refs.Side as HTMLEmbedElement | undefined
+      if ($Side) {
+        // 現在表示されているリンクの下線を消す。
+        this.eraseLinkUnderLine()
         // 同じリンクをクリックした場合にリンクの下線を消す処理が走るよう、clickイベントを登録しておく。
-        $Side.addEventListener('click', this.eraseLinkUnderLine)
+        $Side.addEventListener('click', this.eraseLinkUnderLine, false)
       }
     },
     handleChageRoute() {
       // nuxt-link で遷移するとフォーカスが残り続けるので $route を監視して SideNavigation にフォーカスする
       return this.$nextTick().then(() => {
-        this.eraseLinkUnderLine()
+        this.eraseLinkUnderLineWithRegistHandler()
       })
     }
   }

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -202,15 +202,26 @@ export default Vue.extend({
     $route: 'handleChageRoute'
   },
   methods: {
+    eraseLinkUnderLine() {
+      const $Side = this.$refs.Side as HTMLEmbedElement | undefined
+      if ($Side) {
+        $Side.focus()
+        $Side.blur()
+        // 同じリンクをクリックした場合にリンクの下線を消す処理が走るよう、clickイベントを登録しておく。
+        $Side.addEventListener('click', this.eraseLinkUnderLine)
+      }
+    },
     handleChageRoute() {
       // nuxt-link で遷移するとフォーカスが残り続けるので $route を監視して SideNavigation にフォーカスする
       return this.$nextTick().then(() => {
-        const $Side = this.$refs.Side as HTMLEmbedElement | undefined
-        if ($Side) {
-          $Side.focus()
-        }
+        this.eraseLinkUnderLine();
       })
     }
+  },
+  mounted() {
+    // Webページ表示後に、サイドバーのロゴまたは「都内の最新感染動向」リンクをクリックした場合に
+    // handleChangeRoute()が発火しないため、初回のみclickイベントを登録しておく。
+    this.eraseLinkUnderLine();
   }
 })
 </script>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- [ハンバーガーメニューから他のページに遷移した際、ヘッダーの下部に点線が出る問題 #2493](https://github.com/tokyo-metropolitan-gov/covid19/issues/2493)

## 📝 関連する issue / Related Issues
- (なし)

## ⛏ 変更内容 / Details of Changes
- リンククリック時にフォーカスを外すよう修正しました。
- また、同じリンクをクリックした場合に `handleChangeRoute()` が発火しない問題があったため、リンククリック時にclickイベントを紐づけ、イベントハンドラの中からフォーカスを外すようにしています。
- 加えて、PC向けのサイト表示においてWebページが表示された後、クリックするリンクによっては handleChangeRoute() が発火しない場合があり、こちらも合わせて修正しています。
   - (具体的にはサイドバーのロゴと「都内の最新感染動向」リンクで発生する不具合です)

## 📸 スクリーンショット / Screenshots
 - ハンバーガーメニューで下線が残る問題の修正例。
![a](https://user-images.githubusercontent.com/772589/78470784-ec1e4e00-7766-11ea-9d67-918924e1665e.gif)

 - PC向けのサイト表示で下線が残る問題の修正例。
![b](https://user-images.githubusercontent.com/772589/78470788-f3455c00-7766-11ea-812b-6d28c5ad2cb2.gif)


