### PR TITLE
「都営地下鉄の利用者数の推移」グラフにテキストを追加 #2877

### DIFF
--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -338,5 +338,6 @@
   "感染症の影響を受け、売上が減少した都内中小企業の展示会出展費用の一部を助成します（限度額：150万円 / 助成率：5分の4 / 助成対象期間：交付決定日から1年1カ月 / 受付期間：5月11日～20日〈予定〉）。": "感染症の影響を受け、売上が減少した都内中小企業の展示会出展費用の一部を助成します（限度額：150万円 / 助成率：5分の4 / 助成対象期間：交付決定日から1年1カ月 / 受付期間：5月11日～20日〈予定〉）。",
   "https://creativecommons.org/licenses/by/4.0/deed.ja": "https://creativecommons.org/licenses/by/4.0/deed.ja",
   "Google Chrome 最新版（Windows 10以上, Android 8.0以上）": "Google Chrome 最新版（Windows 10以上, Android 8.0以上）",
-  "Safari 最新版（macOS, iOS）": "Safari 最新版（macOS, iOS）"
+  "Safari 最新版（macOS, iOS）": "Safari 最新版（macOS, iOS）",
+  "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）": "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）"
 }

--- a/components/ExternalLink.vue
+++ b/components/ExternalLink.vue
@@ -1,0 +1,39 @@
+<template>
+  <a class="ExternalLink" :href="url" target="_blank" rel="noopener noreferrer">
+    {{ $t(label) }}
+    <v-icon
+      class="ExternalLinkIcon"
+      size="15"
+      :aria-label="this.$t('別タブで開く')"
+      role="img"
+      :aria-hidden="false"
+    >
+      mdi-open-in-new
+    </v-icon>
+  </a>
+</template>
+
+<style lang="scss">
+.ExternalLink {
+  text-decoration: none;
+  .ExternalLinkIcon {
+    vertical-align: text-bottom;
+  }
+}
+</style>
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    url: {
+      type: String,
+      default: ''
+    },
+    label: {
+      type: String,
+      default: ''
+    }
+  }
+})
+</script>

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -29,9 +29,12 @@
       class="cardTable"
       item-key="name"
     />
-    <p :class="$style.DataViewDesc">
-      <slot name="additionalNotes" />
-    </p>
+    <template v-slot:footer>
+      <external-link
+        :url="'https://smooth-biz.metro.tokyo.lg.jp/archive/date.pdf'"
+        :label="$t('鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）')"
+      />
+    </template>
   </data-view>
 </template>
 
@@ -53,6 +56,7 @@ import { ChartOptions, ChartData } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
+import ExternalLink from '@/components/ExternalLink.vue'
 
 interface HTMLElementEvent<T extends HTMLElement> extends Event {
   currentTarget: T
@@ -125,7 +129,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView },
+  components: { DataView, ExternalLink },
   props: {
     title: {
       type: String,

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -29,6 +29,9 @@
       class="cardTable"
       item-key="name"
     />
+    <p :class="$style.DataViewDesc">
+      <slot name="additionalNotes" />
+    </p>
   </data-view>
 </template>
 

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -25,6 +25,12 @@
           )
         }}
       </template>
+      <template v-slot:additionalNotes>
+        <external-link
+          :url="'https://smooth-biz.metro.tokyo.lg.jp/archive/date.pdf'"
+          :label="$t('鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）')"
+        />
+      </template>
     </metro-bar-chart>
   </v-col>
 </template>
@@ -33,10 +39,12 @@
 import Data from '@/data/data.json'
 import MetroData from '@/data/metro.json'
 import MetroBarChart from '@/components/MetroBarChart.vue'
+import ExternalLink from '@/components/ExternalLink.vue'
 
 export default {
   components: {
-    MetroBarChart
+    MetroBarChart,
+    ExternalLink
   },
   data() {
     // 都営地下鉄の利用者数の推移

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -25,12 +25,6 @@
           )
         }}
       </template>
-      <template v-slot:additionalNotes>
-        <external-link
-          :url="'https://smooth-biz.metro.tokyo.lg.jp/archive/date.pdf'"
-          :label="$t('鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）')"
-        />
-      </template>
     </metro-bar-chart>
   </v-col>
 </template>
@@ -39,12 +33,10 @@
 import Data from '@/data/data.json'
 import MetroData from '@/data/metro.json'
 import MetroBarChart from '@/components/MetroBarChart.vue'
-import ExternalLink from '@/components/ExternalLink.vue'
 
 export default {
   components: {
-    MetroBarChart,
-    ExternalLink
+    MetroBarChart
   },
   data() {
     // 都営地下鉄の利用者数の推移


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2877 

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
- 「都営地下鉄の利用者数の推移」の下部に利用者数推移へのリンクを追加
    -  外部リンク用にコンポーネントとして `ExternalLink.vue` を追加

## 📸 スクリーンショット / Screenshots

<img width="543" alt="スクリーンショット 2020-04-05 18 22 02" src="https://user-images.githubusercontent.com/1461773/78471189-6a302400-776a-11ea-8af9-33dcbc1669eb.png">

