### PR TITLE
Improvement: 2911 Omitting unused fontawesome CSS

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -73,7 +73,7 @@
                 :aria-label="$t('クリップボードにコピー')"
                 @click="copyEmbedCode"
               >
-                far fa-clipboard
+                mdi-clipboard-outline
               </v-icon>
               {{ graphEmbedValue }}
             </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,10 +54,11 @@ const config: Configuration = {
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { rel: 'apple-touch-icon', href: '/apple-touch-icon-precomposed.png' },
-      {
-        rel: 'stylesheet',
-        href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css'
-      }
+      // For the Issue #2911, omitting unused CSS to avoid unknown security threats
+      // {
+      //   rel: 'stylesheet',
+      //   href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css'
+      // }
     ]
   },
   /*

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,10 +55,10 @@ const config: Configuration = {
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { rel: 'apple-touch-icon', href: '/apple-touch-icon-precomposed.png' },
       // For the Issue #2911, omitting unused CSS to avoid unknown security threats
-      // {
-      //   rel: 'stylesheet',
-      //   href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css'
-      // }
+      {
+        rel: 'stylesheet',
+        href: 'material-design-icons-iconfont/dist/material-design-icons.css'
+      }
     ]
   },
   /*

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -54,11 +54,6 @@ const config: Configuration = {
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { rel: 'apple-touch-icon', href: '/apple-touch-icon-precomposed.png' },
-      // For the Issue #2911, omitting unused CSS to avoid unknown security threats
-      // {
-      //   rel: 'stylesheet',
-      //   href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css'
-      // }
     ]
   },
   /*

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,10 +55,10 @@ const config: Configuration = {
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { rel: 'apple-touch-icon', href: '/apple-touch-icon-precomposed.png' },
       // For the Issue #2911, omitting unused CSS to avoid unknown security threats
-      {
-        rel: 'stylesheet',
-        href: 'material-design-icons-iconfont/dist/material-design-icons.css'
-      }
+      // {
+      //   rel: 'stylesheet',
+      //   href: 'https://use.fontawesome.com/releases/v5.6.1/css/all.css'
+      // }
     ]
   },
   /*


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2911 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- (EN) In terms of IT security, an unused CSS in `nuxt.config.ts` needs to be disabled so that we can expect that unknown threats that may come through the CSS will be avoided as needed
- (JA) IT セキュリティの観点から、現在使用されていない CSS を `nuxt.config.ts` 上で無効化する。それによって CSS を標的とした未知の脅威を防ぐことが期待される

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- (EN) Using mdi icon instead of fontawesome (see the clipboard icon)
- (JA) Fontawesome を、mdi アイコンで置き換えた場合のイメージ（クリップボードのアイコン）
![2020-04-07 083113](https://user-images.githubusercontent.com/10361533/78614758-791df000-78aa-11ea-9e6b-f09c31403d6d.png)
