### PR TITLE
「都営地下鉄の利用者数の推移」グラフのリンクテキストを修正

### DIFF
--- a/assets/locales/ja.json
+++ b/assets/locales/ja.json
@@ -339,5 +339,5 @@
   "https://creativecommons.org/licenses/by/4.0/deed.ja": "https://creativecommons.org/licenses/by/4.0/deed.ja",
   "Google Chrome 最新版（Windows 10以上, Android 8.0以上）": "Google Chrome 最新版（Windows 10以上, Android 8.0以上）",
   "Safari 最新版（macOS, iOS）": "Safari 最新版（macOS, iOS）",
-  "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）": "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）"
+  "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）[PDF]": "鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）[PDF]"
 }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -31,8 +31,8 @@
     />
     <template v-slot:footer>
       <external-link
-        :url="'https://smooth-biz.metro.tokyo.lg.jp/archive/date.pdf'"
-        :label="$t('鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）')"
+        :url="'https://smooth-biz.metro.tokyo.lg.jp/pdf/202004date3.pdf'"
+        :label="$t('鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）[PDF]')"
       />
     </template>
   </data-view>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2947 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
-  PDFへのリンクのテキストを`鉄道利用者数の推移（新宿、東京、渋谷、各駅エリア）[PDF]` に変更
- リンク先を`https://smooth-biz.metro.tokyo.lg.jp/pdf/202004date3.pdf`に変更
- テキストの変更に伴って翻訳キーを更新

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42484226/78624200-06217300-78c4-11ea-97dd-2dcd12c30315.png)

