### PR TITLE
「陽性患者の属性」テーブルにて、患者の年代が調査中の場合は「調査中」と表示する

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -50,13 +50,11 @@ export default {
       row['性別'] = this.getTranslatedWording(row['性別'])
       row['退院'] = this.getTranslatedWording(row['退院'])
 
-      if (row['年代'] === '10歳未満') {
-        row['年代'] = this.$t('10歳未満')
-      } else if (row['年代'] === '不明') {
-        row['年代'] = this.$t('不明')
-      } else {
+      if (row['年代'].substr(-1, 1) === '代') {
         const age = row['年代'].substring(0, 2)
         row['年代'] = this.$t('{age}代', { age })
+      } else {
+        row['年代'] = this.$t(row['年代'])
       }
     }
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2962

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 年代の翻訳を以下のアルゴリズムで行うように変更した
  - データ中の年代の文字列が「代」で終わっている場合
    - 先頭2文字を使用して `{age}代` として表示する
  - そうでない場合
    - データ中の年代の文字列を直に表示する
      - 年代として想定外の文字列が来た際も、とりあえず「〜〜代」とは表示されない
 
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/42484226/78642819-4b5a9a80-78ee-11ea-8c40-3ef010cfad4b.png)
