### PR TITLE
「東京都緊急事態措置について」のリンクボタンをサイトトップに設置

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -11,6 +11,7 @@ $gray-4: #d9d9d9;
 $gray-5: #f8f9fa;
 $white: #fff;
 $link: #006ca8;
+$emergency: #FFE200;
 
 // ==================
 // shadow

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -90,14 +90,13 @@ export default Vue.extend({
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
+    margin-bottom: 12px;
 
     .WhatsNew-title {
       display: flex;
       align-items: center;
 
       @include card-h2();
-
-      margin-bottom: 12px;
       color: $gray-2;
 
       &-icon {

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -95,10 +95,8 @@ export default Vue.extend({
     .WhatsNew-title {
       display: flex;
       align-items: center;
-
-      @include card-h2();
       color: $gray-2;
-
+      @include card-h2();
       &-icon {
         margin: 3px;
       }

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -70,61 +70,61 @@ export default Vue.extend({
 
   padding: 10px;
   margin-bottom: 20px;
-}
 
-.WhatsNew-heading {
-  display: flex;
-  align-items: center;
+  &-heading {
+    display: flex;
+    align-items: center;
 
-  @include card-h2();
+    @include card-h2();
 
-  margin-bottom: 12px;
-  color: $gray-2;
-  margin-left: 12px;
+    margin-bottom: 12px;
+    color: $gray-2;
+    margin-left: 12px;
 
-  &-icon {
-    margin: 3px;
+    &-icon {
+      margin: 3px;
+    }
   }
-}
 
-.WhatsNew .WhatsNew-list {
-  padding-left: 0;
-  list-style-type: none;
+  .WhatsNew-list {
+    padding-left: 0;
+    list-style-type: none;
 
-  &-item {
-    &-anchor {
-      text-decoration: none;
-      margin: 5px;
-      font-size: 14px;
-
-      @include lessThan($medium) {
-        display: flex;
-        flex-wrap: wrap;
-      }
-
-      &-time {
-        flex: 0 0 90px;
+    &-item {
+      &-anchor {
+        text-decoration: none;
+        margin: 5px;
+        font-size: 14px;
 
         @include lessThan($medium) {
-          flex: 0 0 100%;
+          display: flex;
+          flex-wrap: wrap;
         }
 
-        color: $gray-1;
-      }
+        &-time {
+          flex: 0 0 90px;
 
-      &-link {
-        flex: 0 1 auto;
+          @include lessThan($medium) {
+            flex: 0 0 100%;
+          }
 
-        @include text-link();
-
-        @include lessThan($medium) {
-          padding-left: 8px;
+          color: $gray-1;
         }
-      }
 
-      &-ExternalLinkIcon {
-        margin-left: 2px;
-        color: $gray-3 !important;
+        &-link {
+          flex: 0 1 auto;
+
+          @include text-link();
+
+          @include lessThan($medium) {
+            padding-left: 8px;
+          }
+        }
+
+        &-ExternalLinkIcon {
+          margin-left: 2px;
+          color: $gray-3 !important;
+        }
       }
     }
   }

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -117,10 +117,6 @@ export default Vue.extend({
         border-radius: 4px;
       }
 
-      &-icon {
-        margin: 3px;
-      }
-
       .ExternalLink {
         color: $gray-2 !important;
         text-decoration: none;

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -1,11 +1,13 @@
 <template>
   <div class="WhatsNew">
-    <h3 class="WhatsNew-heading">
-      <v-icon size="24" class="WhatsNew-heading-icon">
-        mdi-information
-      </v-icon>
-      {{ $t('最新のお知らせ') }}
-    </h3>
+    <div class="WhatsNew-heading">
+      <h3 class="WhatsNew-title">
+        <v-icon size="24" class="WhatsNew-title-icon">
+          mdi-information
+        </v-icon>
+        {{ $t('最新のお知らせ') }}
+      </h3>
+    </div>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
         <a
@@ -71,18 +73,20 @@ export default Vue.extend({
   padding: 10px;
   margin-bottom: 20px;
 
-  &-heading {
-    display: flex;
-    align-items: center;
+  .WhatsNew-heading {
+    .WhatsNew-title {
+      display: flex;
+      align-items: center;
 
-    @include card-h2();
+      @include card-h2();
 
-    margin-bottom: 12px;
-    color: $gray-2;
-    margin-left: 12px;
+      margin-bottom: 12px;
+      color: $gray-2;
+      margin-left: 12px;
 
-    &-icon {
-      margin: 3px;
+      &-icon {
+        margin: 3px;
+      }
     }
   }
 

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -111,6 +111,7 @@ export default Vue.extend({
       border: 2px solid $emergency;
       color: $gray-2;
       border-radius: 4px;
+      font-size: 1rem;
 
       &:hover {
         background-color: $white;

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -91,8 +91,6 @@ export default Vue.extend({
     align-items: center;
     flex-wrap: wrap;
 
-    @include text-link();
-
     .WhatsNew-title {
       display: flex;
       align-items: center;
@@ -109,8 +107,6 @@ export default Vue.extend({
     }
 
     .WhatsNew-link-to-emergency-page {
-      @include text-link();
-
       background-color: $emergency;
       border: 2px solid $emergency;
       color: $gray-2;

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -7,6 +7,15 @@
         </v-icon>
         {{ $t('最新のお知らせ') }}
       </h3>
+      <span class="WhatsNew-link-to-emergency-page">
+        <v-icon size="16" class="emergency-icon">
+          mdi-bullhorn
+        </v-icon>
+        <external-link
+          url="https://www.bousai.metro.tokyo.lg.jp/1007617/index.html"
+          label="東京都緊急事態措置について"
+        />
+      </span>
     </div>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
@@ -96,6 +105,33 @@ export default Vue.extend({
 
       &-icon {
         margin: 3px;
+      }
+    }
+
+    .WhatsNew-link-to-emergency-page {
+      @include text-link();
+
+      background-color: $emergency;
+      border: 2px solid $emergency;
+      color: $gray-2;
+      border-radius: 4px;
+
+      &:hover {
+        background-color: $white;
+        border-radius: 4px;
+      }
+
+      .ExternalLink {
+        color: $gray-2 !important;
+        text-decoration: none;
+      }
+
+      > span {
+        @include button-text('sm');
+      }
+
+      @include lessThan($small) {
+        margin-top: 4px;
       }
     }
   }

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -74,6 +74,13 @@ export default Vue.extend({
   margin-bottom: 20px;
 
   .WhatsNew-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+
+    @include text-link();
+
     .WhatsNew-title {
       display: flex;
       align-items: center;

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -40,12 +40,15 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import ExternalLink from '@/components/ExternalLink.vue'
+
 import {
   convertDateByCountryPreferTimeFormat,
   convertDateToISO8601Format
 } from '@/utils/formatDate'
 
 export default Vue.extend({
+  components: { ExternalLink },
   props: {
     items: {
       type: Array,

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -8,7 +8,7 @@
         {{ $t('最新のお知らせ') }}
       </h3>
       <span class="WhatsNew-link-to-emergency-page">
-        <v-icon size="16" class="emergency-icon">
+        <v-icon size="20" class="WhatsNew-link-to-emergency-page-icon">
           mdi-bullhorn
         </v-icon>
         <external-link
@@ -99,7 +99,6 @@ export default Vue.extend({
 
       margin-bottom: 12px;
       color: $gray-2;
-      margin-left: 12px;
 
       &-icon {
         margin: 3px;
@@ -112,10 +111,15 @@ export default Vue.extend({
       color: $gray-2;
       border-radius: 4px;
       font-size: 1rem;
+      padding: 4px 8px;
 
       &:hover {
         background-color: $white;
         border-radius: 4px;
+      }
+
+      &-icon {
+        margin: 3px;
       }
 
       .ExternalLink {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2966 

## ⛏ 変更内容 / Details of Changes
- 「東京都緊急事態措置について」のボタン（https://www.bousai.metro.tokyo.lg.jp/1007617/index.html にリンク）をサイトトップに設置する

## 📸 スクリーンショット / Screenshots
### PC (Large)
![スクリーンショット 2020-04-07 23 47 33](https://user-images.githubusercontent.com/23148331/78683456-47e50480-792a-11ea-8ec2-c5a5c6d905d3.png)

### PC (Small)
![スクリーンショット 2020-04-07 23 47 55](https://user-images.githubusercontent.com/23148331/78683465-4b788b80-792a-11ea-8c3a-32392f00899b.png)
### SP
![スクリーンショット 2020-04-07 23 48 12](https://user-images.githubusercontent.com/23148331/78683466-4c112200-792a-11ea-9dba-8f2de1a39573.png)
