### PR TITLE
「陽性患者の属性」テーブルにて、「10歳未満」を「10代」よりも小さい値としてソートする

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -120,6 +120,19 @@ export default Vue.extend({
     url: {
       type: String,
       default: ''
+    },
+    customSort: {
+      type: Function,
+      default(items: Object[], index: string[], isDesc: boolean[]) {
+        items.sort((a: any, b: any) => {
+          if (!isDesc[0]) {
+            return a[index[0]] < b[index[0]] ? -1 : 1
+          } else {
+            return b[index[0]] < a[index[0]] ? -1 : 1
+          }
+        })
+        return items
+      }
     }
   },
   mounted() {
@@ -130,34 +143,6 @@ export default Vue.extend({
     tables.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
-  },
-  methods: {
-    // '10歳未満' < '10代' となるようにソートする
-    customSort(items: Object[], index: string[], isDesc: boolean[]) {
-      const lt10 = this.$t('10歳未満').toString()
-      items.sort((a: any, b: any) => {
-        if (
-          index[0] === '年代' &&
-          (a[index[0]] === lt10 || b[index[0]] === lt10)
-        ) {
-          if (a[index[0]] === lt10) {
-            // 公表日を常に降順にする
-            if (b[index[0]] === lt10) {
-              return a['公表日'] > b['公表日'] ? -1 : 1
-            } else {
-              return !isDesc[0] ? -1 : 1
-            }
-          } else {
-            return !isDesc[0] ? 1 : -1
-          }
-        } else if (!isDesc[0]) {
-          return a[index[0]] < b[index[0]] ? -1 : 1
-        } else {
-          return b[index[0]] < a[index[0]] ? -1 : 1
-        }
-      })
-      return items
-    }
   }
 })
 </script>

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -125,11 +125,18 @@ export default Vue.extend({
       type: Function,
       default(items: Object[], index: string[], isDesc: boolean[]) {
         items.sort((a: any, b: any) => {
-          if (!isDesc[0]) {
-            return a[index[0]] < b[index[0]] ? -1 : 1
-          } else {
-            return b[index[0]] < a[index[0]] ? -1 : 1
+          let comparison = 0
+          if (a[index[0]] < b[index[0]]) {
+            comparison = -1
+          } else if (b[index[0]] < a[index[0]]) {
+            comparison = 1
           }
+          // a と b が等しい場合は上記のif文を両方とも通過するので 0 のままとなる
+
+          // 降順指定の場合は符号を反転
+          comparison = isDesc[0] ? comparison * -1 : comparison
+
+          return comparison
         })
         return items
       }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -126,9 +126,9 @@ export default Vue.extend({
       default(items: Object[], index: string[], isDesc: boolean[]) {
         items.sort((a: any, b: any) => {
           let comparison = 0
-          if (a[index[0]] < b[index[0]]) {
+          if (String(a[index[0]]) < String(b[index[0]])) {
             comparison = -1
-          } else if (b[index[0]] < a[index[0]]) {
+          } else if (String(b[index[0]]) < String(a[index[0]])) {
             comparison = 1
           }
           // a と b が等しい場合は上記のif文を両方とも通過するので 0 のままとなる

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -133,15 +133,16 @@ export default Vue.extend({
   },
   methods: {
     // '10歳未満' < '10代' となるようにソートする
-    customSort: (items: Object[], index: string[], isDesc: boolean[]) => {
+    customSort(items: Object[], index: string[], isDesc: boolean[]) {
+      const lt10 = this.$t('10歳未満').toString()
       items.sort((a: any, b: any) => {
         if (
           index[0] === '年代' &&
-          (a[index[0]] === '10歳未満' || b[index[0]] === '10歳未満')
+          (a[index[0]] === lt10 || b[index[0]] === lt10)
         ) {
-          if (a[index[0]] === '10歳未満') {
+          if (a[index[0]] === lt10) {
             // 公表日を常に降順にする
-            if (b[index[0]] === '10歳未満') {
+            if (b[index[0]] === lt10) {
               return a['公表日'] > b['公表日'] ? -1 : 1
             } else {
               return !isDesc[0] ? -1 : 1

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -134,8 +134,9 @@ export default Vue.extend({
           // a と b が等しい場合は上記のif文を両方とも通過するので 0 のままとなる
 
           // 降順指定の場合は符号を反転
-          comparison = isDesc[0] ? comparison * -1 : comparison
-
+          if (comparison !== 0) {
+            comparison = isDesc[0] ? comparison * -1 : comparison
+          }
           return comparison
         })
         return items

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -12,6 +12,7 @@
       :height="240"
       :fixed-header="true"
       :mobile-breakpoint="0"
+      :custom-sort="customSort"
       class="cardTable"
     />
     <div class="note">
@@ -129,6 +130,33 @@ export default Vue.extend({
     tables.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
+  },
+  methods: {
+    // '10歳未満' < '10代' となるようにソートする
+    customSort: (items: Object[], index: string[], isDesc: boolean[]) => {
+      items.sort((a: any, b: any) => {
+        if (
+          index[0] === '年代' &&
+          (a[index[0]] === '10歳未満' || b[index[0]] === '10歳未満')
+        ) {
+          if (a[index[0]] === '10歳未満') {
+            // 公表日を常に降順にする
+            if (b[index[0]] === '10歳未満') {
+              return a['公表日'] > b['公表日'] ? -1 : 1
+            } else {
+              return !isDesc[0] ? -1 : 1
+            }
+          } else {
+            return !isDesc[0] ? 1 : -1
+          }
+        } else if (!isDesc[0]) {
+          return a[index[0]] < b[index[0]] ? -1 : 1
+        } else {
+          return b[index[0]] < a[index[0]] ? -1 : 1
+        }
+      })
+      return items
+    }
   }
 })
 </script>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -84,25 +84,31 @@ export default {
     customSort(items, index, isDesc) {
       const lt10 = this.$t('10歳未満').toString()
       items.sort((a, b) => {
+        let comparison = 0
         if (
           index[0] === '年代' &&
           (a[index[0]] === lt10 || b[index[0]] === lt10)
         ) {
-          if (a[index[0]] === lt10) {
-            // 公表日を常に降順にする
-            if (b[index[0]] === lt10) {
-              return a['公表日'] > b['公表日'] ? -1 : 1
-            } else {
-              return !isDesc[0] ? -1 : 1
-            }
+          // '10歳未満'のときには先頭へ
+          if (a[index[0]] === lt10 && b[index[0]] === lt10) {
+            comparison = 0
+          } else if (a[index[0]] === lt10) {
+            comparison = 1
           } else {
-            return !isDesc[0] ? 1 : -1
+            comparison = -1
           }
-        } else if (!isDesc[0]) {
-          return a[index[0]] < b[index[0]] ? -1 : 1
-        } else {
-          return b[index[0]] < a[index[0]] ? -1 : 1
+        } else if (a[index[0]] < b[index[0]]) {
+          comparison = 1
+        } else if (b[index[0]] < a[index[0]]) {
+          comparison = -1
         }
+
+        // 降順指定の場合は符号を反転
+        if (comparison !== 0) {
+          comparison = isDesc[0] ? comparison * -1 : comparison
+        }
+
+        return comparison
       })
       return items
     }

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -84,25 +84,23 @@ export default {
     customSort(items, index, isDesc) {
       const lt10 = this.$t('10歳未満').toString()
       items.sort((a, b) => {
+        // 両者が等しい場合は 0 を返す
+        if (a[index[0]] === b[index[0]]) {
+          return 0
+        }
+
+        // 「10歳未満」同士を比較する場合、そうでない場合に場合分け
+        let comparison = 0
         if (
           index[0] === '年代' &&
           (a[index[0]] === lt10 || b[index[0]] === lt10)
         ) {
-          if (a[index[0]] === lt10) {
-            // 公表日を常に降順にする
-            if (b[index[0]] === lt10) {
-              return a['公表日'] > b['公表日'] ? -1 : 1
-            } else {
-              return !isDesc[0] ? -1 : 1
-            }
-          } else {
-            return !isDesc[0] ? 1 : -1
-          }
-        } else if (!isDesc[0]) {
-          return String(a[index[0]]) < String(b[index[0]]) ? -1 : 1
+          comparison = a[index[0]] === lt10 ? -1 : 1
         } else {
-          return String(b[index[0]]) < String(a[index[0]]) ? -1 : 1
+          comparison = String(a[index[0]]) < String(b[index[0]]) ? -1 : 1
         }
+
+        return isDesc[0] ? comparison * -1 : comparison
       })
       return items
     }

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -9,6 +9,7 @@
       :info="sumInfoOfPatients"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
       :source="$t('オープンデータを入手')"
+      :custom-sort="customSort"
     />
   </v-col>
 </template>
@@ -78,6 +79,32 @@ export default {
       }
 
       return this.$t(value)
+    },
+    // '10歳未満' < '10代' となるようにソートする
+    customSort(items, index, isDesc) {
+      const lt10 = this.$t('10歳未満').toString()
+      items.sort((a, b) => {
+        if (
+          index[0] === '年代' &&
+          (a[index[0]] === lt10 || b[index[0]] === lt10)
+        ) {
+          if (a[index[0]] === lt10) {
+            // 公表日を常に降順にする
+            if (b[index[0]] === lt10) {
+              return a['公表日'] > b['公表日'] ? -1 : 1
+            } else {
+              return !isDesc[0] ? -1 : 1
+            }
+          } else {
+            return !isDesc[0] ? 1 : -1
+          }
+        } else if (!isDesc[0]) {
+          return a[index[0]] < b[index[0]] ? -1 : 1
+        } else {
+          return b[index[0]] < a[index[0]] ? -1 : 1
+        }
+      })
+      return items
     }
   }
 }

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -99,9 +99,9 @@ export default {
             return !isDesc[0] ? 1 : -1
           }
         } else if (!isDesc[0]) {
-          return a[index[0]] < b[index[0]] ? -1 : 1
+          return String(a[index[0]]) < String(b[index[0]]) ? -1 : 1
         } else {
-          return b[index[0]] < a[index[0]] ? -1 : 1
+          return String(b[index[0]]) < String(a[index[0]]) ? -1 : 1
         }
       })
       return items

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -84,31 +84,25 @@ export default {
     customSort(items, index, isDesc) {
       const lt10 = this.$t('10歳未満').toString()
       items.sort((a, b) => {
-        let comparison = 0
         if (
           index[0] === '年代' &&
           (a[index[0]] === lt10 || b[index[0]] === lt10)
         ) {
-          // '10歳未満'のときには先頭へ
-          if (a[index[0]] === lt10 && b[index[0]] === lt10) {
-            comparison = 0
-          } else if (a[index[0]] === lt10) {
-            comparison = 1
+          if (a[index[0]] === lt10) {
+            // 公表日を常に降順にする
+            if (b[index[0]] === lt10) {
+              return a['公表日'] > b['公表日'] ? -1 : 1
+            } else {
+              return !isDesc[0] ? -1 : 1
+            }
           } else {
-            comparison = -1
+            return !isDesc[0] ? 1 : -1
           }
-        } else if (a[index[0]] < b[index[0]]) {
-          comparison = 1
-        } else if (b[index[0]] < a[index[0]]) {
-          comparison = -1
+        } else if (!isDesc[0]) {
+          return a[index[0]] < b[index[0]] ? -1 : 1
+        } else {
+          return b[index[0]] < a[index[0]] ? -1 : 1
         }
-
-        // 降順指定の場合は符号を反転
-        if (comparison !== 0) {
-          comparison = isDesc[0] ? comparison * -1 : comparison
-        }
-
-        return comparison
       })
       return items
     }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2949 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `v-data-table`の`custom-sort` Propを用いて、以下の要件を満たすソート関数を使用してソートする
  - `10歳未満`は`10代`より小さい値とする
  - 同一年代のデータは、ソートの向きに関わらず公表日の降順に並べる

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### 年代で昇順にした場合の表の最上部
![image](https://user-images.githubusercontent.com/42484226/78710457-5ba36180-7950-11ea-80a3-0938c557c5eb.png)
### 年代で降順にした場合の表の最下部
![image](https://user-images.githubusercontent.com/42484226/78710501-665df680-7950-11ea-978d-242682f76646.png)