### PR TITLE
Hotfix/2955 align graph layout

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -84,6 +84,7 @@
   padding: 8px;
   font-size: 12px;
   color: $gray-3;
+  height: 80px;
 }
 </style>
 

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -24,6 +24,7 @@
   margin-bottom: 0;
   font-size: 12px;
   color: $gray-3;
+  height: 80px;
 }
 </style>
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
## 👏 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues
- #2955 
- #2790 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- (EN) Having the upmost two (2) graphs in line for better look and feel
- (JP) 「検査陽性者の状況」「検査実施状況」の隣合せのグラフの上端を揃えることで、優れたルック＆フィールを実現する

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
[Before this Change 変更前]
![78637964-6b865b80-78e6-11ea-9463-fda3ded27a38](https://user-images.githubusercontent.com/10361533/78780471-9e5d4c00-79d9-11ea-84a8-86862df9bdbe.jpg)

[When the Change is Applied 変更後]
![78766698-921ac400-79c4-11ea-9a44-773dc1cf73a8](https://user-images.githubusercontent.com/10361533/78780659-ed0ae600-79d9-11ea-8cde-354e929eef2f.png)
