### PR TITLE
[ruby] 「やさしいにほんご」を直接開くとローディングが終わらない問題を修正

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -15,13 +15,20 @@
       class="cardTable"
     >
       <template v-slot:item.居住地="{ item }">
-        <t-i18n>{{ item.居住地 }}</t-i18n>
+        <!-- FIXME SSRとCSRでDOMが一致しないのでSSRを無効にする -->
+        <no-ssr>
+          <t-i18n>{{ item.居住地 }}</t-i18n>
+        </no-ssr>
       </template>
       <template v-slot:item.年代="{ item }">
-        <t-i18n>{{ item.年代 }}</t-i18n>
+        <no-ssr>
+          <t-i18n>{{ item.年代 }}</t-i18n>
+        </no-ssr>
       </template>
       <template v-slot:item.性別="{ item }">
-        <t-i18n>{{ item.性別 }}</t-i18n>
+        <no-ssr>
+          <t-i18n>{{ item.性別 }}</t-i18n>
+        </no-ssr>
       </template>
     </v-data-table>
     <div class="note">

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -15,20 +15,13 @@
       class="cardTable"
     >
       <template v-slot:item.居住地="{ item }">
-        <!-- FIXME SSRとCSRでDOMが一致しないのでSSRを無効にする -->
-        <no-ssr>
-          <t-i18n>{{ item.居住地 }}</t-i18n>
-        </no-ssr>
+        <t-i18n>{{ item.居住地 }}</t-i18n>
       </template>
       <template v-slot:item.年代="{ item }">
-        <no-ssr>
-          <t-i18n>{{ item.年代 }}</t-i18n>
-        </no-ssr>
+        <t-i18n>{{ item.年代 }}</t-i18n>
       </template>
       <template v-slot:item.性別="{ item }">
-        <no-ssr>
-          <t-i18n>{{ item.性別 }}</t-i18n>
-        </no-ssr>
+        <t-i18n>{{ item.性別 }}</t-i18n>
       </template>
     </v-data-table>
     <div class="note">

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -69,8 +69,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return createElement(slot.tag, slot.data, slot.children)
     }
 
-    const createRubyNodes = (texts: RubyText[]): (VNode | string)[] => {
-      return texts.map(t => {
+    const createRubyNode = (texts: RubyText[]): VNode => {
+      const rubyTexts = texts.map(t => {
         if (!t.kana) return t.ja
         return createElement('ruby', [
           t.ja,
@@ -79,22 +79,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           createElement('rp', '）')
         ])
       })
+      return createElement('span', rubyTexts)
     }
 
-    const createVNode = (
-      node: VNode,
-      parentTag: string = ''
-    ): VNode | (VNode | string)[] => {
+    const createVNode = (node: VNode): VNode => {
       if (node.text) {
         const texts = this.createRubyTexts(node.text)
-        const nodes = createRubyNodes(texts)
-        return parentTag ? nodes : createElement('span', nodes)
+        return createRubyNode(texts)
       }
-      const vnode = node.children!.map(node => createVNode(node, parentTag))
-      return createElement(node.tag, node.data, vnode)
+      const vnodes = node.children!.map(node => createVNode(node))
+      return createElement(node.tag, node.data, vnodes)
     }
 
-    return createVNode(slot, slot.tag) as VNode
+    return createVNode(slot)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@nuxtjs/dotenv": "^1.4.0",
     "@nuxtjs/pwa": "^3.0.0-0",
     "@types/d3": "^5.7.2",
+    "@types/lodash": "^4.14.149",
     "@types/mapbox-gl": "^1.8.0",
     "chart.js": "^2.9.3",
     "cross-env": "^5.2.0",

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import { sortBy } from 'lodash'
 
 const headers = [
   { text: '公表日', value: '公表日' },
@@ -40,18 +41,17 @@ export default (data: DataType[]) => {
     headers,
     datasets: []
   }
-  data.forEach(d => {
-    const TableRow: TableDataType = {
-      公表日: dayjs(d['リリース日']).format('MM/DD') ?? '不明',
-      居住地: d['居住地'] ?? '調査中',
-      年代: d['年代'] ?? '不明',
-      性別: d['性別'] ?? '不明',
-      退院: d['退院']
+  const datasets = data.map(
+    (d): TableDataType => {
+      return {
+        公表日: dayjs(d['リリース日']).format('MM/DD') ?? '不明',
+        居住地: d['居住地'] ?? '調査中',
+        年代: d['年代'] ?? '不明',
+        性別: d['性別'] ?? '不明',
+        退院: d['退院']
+      }
     }
-    tableDate.datasets.push(TableRow)
-  })
-  tableDate.datasets.sort((a, b) =>
-    a.公表日 === b.公表日 ? 0 : a.公表日 < b.公表日 ? 1 : -1
   )
+  tableDate.datasets = sortBy(datasets, [o => -dayjs(o.公表日)])
   return tableDate
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,6 +1872,11 @@
   resolved "https://registry.yarnpkg.com/@types/less/-/less-3.0.1.tgz#625694093c72f8356c4042754e222407e50d6b08"
   integrity sha512-dBp05MtWN/w1fGVjj5LVrDw6VrdYllpWczbUkCsrzBj08IHsSyRLOFvUrCFqZFVR+nsqkrRLNg6oOlvqMLPaSA==
 
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/mapbox-gl@^1.8.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@types/mapbox-gl/-/mapbox-gl-1.8.1.tgz#dbc12da1324d5bdb3dbf71b90b77cac17994a1a3"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2764

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
- `/ja-basic/` を開いた際にローディング画面で止まってしまう問題を修正しました https://github.com/tokyo-metropolitan-gov/covid19/issues/2764#issuecomment-610382548
- ~~Vuetify の `DataTable` コンポーネント内の多言語対応で SSR と CSR で DOM が一致しないのが原因ですが、`TI18n`コンポーネント内で対応が難しそうだったので一旦 SSR を無効にしました~~
  - これがベストな方法ではないので、他に良い対応方法があればアドバイスいただけると嬉しいです
- `DataTable`にわたすデータのソート順が保証されていないのが原因だったので、`lodash` で順番を保証した sort に差し替えました

## 📸 スクリーンショット / Screenshots
ここのテーブルのレンダリングでエラーが発生していました。

![スクリーンショット 2020-04-08 23 21 30](https://user-images.githubusercontent.com/5207601/78795215-b6d86100-79ef-11ea-813c-cd54880a1b41.png)

やさしい日本語を表示した状態でリロードして、エラーが発生しないことを確認しました。

[![Image from Gyazo](https://i.gyazo.com/803e649cf9b706b6c0d442ec7f21ac32.gif)](https://gyazo.com/803e649cf9b706b6c0d442ec7f21ac32)

