### PR TITLE
Canvasの代替の隠しテーブルのデータの誤りを修正

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -235,7 +235,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           { text: this.displayData.labels[i] as string },
           ...this.displayData.datasets!.map((_, j) => {
             return {
-              [j]: this.displayData.datasets[0].data[i]
+              [j]: this.displayData.datasets[j].data[i]
             }
           })
         )

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -196,9 +196,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.displayData.datasets[0].data.map((_, i) => {
         return Object.assign(
           { text: this.chartData.datasets![i].label as string },
-          ...this.chartData.datasets!.map((_, j) => {
+          ...this.chartData.labels!.map((_, j) => {
             return {
-              [j]: this.displayData.datasets[0].data[i]
+              [j]: this.displayData.datasets[j].data[i]
             }
           })
         )


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3014 

## ⛏ 変更内容 / Details of Changes
* 「都営地下鉄の利用者数の推移」「都庁来庁者数の推移」の隠しテーブルの値の誤りを修正

## 📸 スクリーンショット / Screenshots

*修正前後を分かりやすくするためデベロッパーツールからグラフとテーブル双方が表示されるようにした状態でのスクリーンショットです*

![修正前](https://user-images.githubusercontent.com/4785040/78859697-16c01d80-7a6b-11ea-9404-85b0ea55403c.png)
![修正後](https://user-images.githubusercontent.com/4785040/78859706-1d4e9500-7a6b-11ea-8ded-90121047fe58.png)
