### PR TITLE
ExternalLink の設計を変更

### DIFF
--- a/components/ExternalLink.vue
+++ b/components/ExternalLink.vue
@@ -1,6 +1,6 @@
 <template>
   <a class="ExternalLink" :href="url" target="_blank" rel="noopener noreferrer">
-    {{ $t(label) }}
+    {{ label }}
     <v-icon
       class="ExternalLinkIcon"
       size="15"

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -13,7 +13,7 @@
         </v-icon>
         <external-link
           url="https://www.bousai.metro.tokyo.lg.jp/1007617/index.html"
-          label="東京都緊急事態措置について"
+          :label="$t('東京都緊急事態措置について')"
         />
       </span>
     </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3046

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/3013#discussion_r405486265 

## ⛏ 変更内容 / Details of Changes
- `ExternalLink` の設計を変更する
    - `ExternalLink` は以下のような実装になっており，template の内部で，component の外部から渡された引数（文字列）をキーとして `$t` による翻訳を行っている．
        - component の外部から翻訳済みの文字列を渡した方が見通しがよい上，`MetroBarChart.vue` では翻訳済みの文字列を渡してしまっており，2重に `$t` を実行してしまっている現状があったため，リファクタリングによってこの状態を解消した．
