### PR TITLE
[ruby] ルビタグ生成処理のクロスブラウザ対応

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -14,14 +14,14 @@
       :mobile-breakpoint="0"
       class="cardTable"
     >
-      <template v-slot:item.居住地="{ item }">
-        <t-i18n>{{ item.居住地 }}</t-i18n>
+      <template v-slot:item.居住地="slotProps">
+        <t-i18n>{{ slotProps.item.居住地 }}</t-i18n>
       </template>
-      <template v-slot:item.年代="{ item }">
-        <t-i18n>{{ item.年代 }}</t-i18n>
+      <template v-slot:item.年代="slotProps">
+        <t-i18n>{{ slotProps.item.年代 }}</t-i18n>
       </template>
-      <template v-slot:item.性別="{ item }">
-        <t-i18n>{{ item.性別 }}</t-i18n>
+      <template v-slot:item.性別="slotProps">
+        <t-i18n>{{ slotProps.item.性別 }}</t-i18n>
       </template>
     </v-data-table>
     <div class="note">

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
+import XRegExp from 'xregexp/'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 type RubyText = {
@@ -31,22 +32,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     createRubyTexts(text) {
       let match: RegExpExecArray | null
       let lastText: string
-      let prevIndex = 0
+      let pos = 0
       const texts: RubyText[] = []
-      const regp = new RegExp(
-        /([\p{sc=Han}|\s|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/,
-        'gu'
-      )
+      const regp = /([\p{sc=Han}|\s|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/gu
 
       // ふりがなを含んだ文字列をパースしてオブジェクトを生成
-      while ((match = regp.exec(text)) !== null) {
+      while ((match = XRegExp.exec(text, regp, pos))) {
         if (match.index > 0) {
-          texts.push({ ja: match.input.slice(prevIndex, match.index) })
+          texts.push({ ja: match.input.slice(pos, match.index) })
         }
         texts.push({ ja: match[1], kana: match[2] })
-        prevIndex = match.index + match[0].length
+        pos = match.index + match[0].length
       }
-      if ((lastText = text.slice(prevIndex))) texts.push({ ja: lastText })
+      if ((lastText = text.slice(pos))) texts.push({ ja: lastText })
       return texts
     }
   },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/d3": "^5.7.2",
     "@types/lodash": "^4.14.149",
     "@types/mapbox-gl": "^1.8.0",
+    "@types/xregexp": "^4.3.0",
     "chart.js": "^2.9.3",
     "cross-env": "^5.2.0",
     "dayjs": "^1.8.21",
@@ -51,7 +52,8 @@
     "nuxt-i18n": "^6.6.0",
     "vue-chartjs": "^3.5.0",
     "vue-scrollto": "^2.17.1",
-    "vue-spinner": "^1.0.3"
+    "vue-spinner": "^1.0.3",
+    "xregexp": "^4.3.0"
   },
   "devDependencies": {
     "@fullhuman/postcss-purgecss": "^2.1.0",

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -52,6 +52,6 @@ export default (data: DataType[]) => {
       }
     }
   )
-  tableDate.datasets = sortBy(datasets, [o => -dayjs(o.公表日)])
+  tableDate.datasets = sortBy(datasets, [o => dayjs(o['公表日'])]).reverse()
   return tableDate
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,6 +766,14 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
+"@babel/runtime-corejs3@^7.8.3":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz#26fe4aa77e9f1ecef9b776559bbb8e84d34284b7"
+  integrity sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.6.3":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -2059,6 +2067,11 @@
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
+
+"@types/xregexp@^4.3.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@types/xregexp/-/xregexp-4.3.0.tgz#e981c9b7281579019cc5740e08d206f3403e029f"
+  integrity sha512-3gJTS9gt27pS7U9q5IVqo4YvKSlkf2ck8ish6etuDj6LIRxkL/2Y8RMUtK/QzvE1Yv2zwWV5yemI2BS0GGGFnA==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -3812,6 +3825,11 @@ core-js-compat@^3.6.2:
   dependencies:
     browserslist "^4.8.3"
     semver "7.0.0"
+
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
 core-js@^2.6.5:
   version "2.6.11"
@@ -12570,6 +12588,13 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xregexp@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
+  integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.8.3"
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #2764

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- Chrome 以外でも Unicode 文字プロパティの正規表現を使えるようにしました
  - https://github.com/tokyo-metropolitan-gov/covid19/issues/1295#issuecomment-605595988
  -  [xregexp](https://github.com/slevithan/xregexp) というライブラリを利用しました
  - [サポートブラウザ](http://xregexp.com/): Internet Explorer 5.5+, Firefox 1.5+, Chrome, Safari 3+, and Opera 11+

## 進捗まとめ
こちらの方法で多言語対応しているものについては、ルビタグがつけられるようになりました

- Vue コンポーネント内の `$t` メソッドのルビタグ
- Flow ページなどで使われている `i18n` タグのルビタグ

今回の PR でクロスブラウザ対応ができれば、以下のページはルビタグ対応の実装をすすめられると思います。
見落としている点などありましたら、お知らせいただければ対応いたします。

### テンプレート内のタグを `<t-i18n>`タグで置き換えるページ
- 新型コロナウイルス感染症が心配なときに（PC）
- 新型コロナウイルス感染症が心配なときに（SP）
- お子様をお持ちの皆様へ
- 企業の皆様・はたらく皆様へ
- 当サイトについて
- お問い合わせ先一覧

### 別途対応が必要なページ
都内の最新感染動向の一部のグラフについては、`canvas` 内で多言語化した文字列を出力しているので別途対応が必要です。

![スクリーンショット 2020-04-09 21 43 05](https://user-images.githubusercontent.com/5207601/78896234-1e9fb200-7aab-11ea-90ee-34c207344d69.png)


対応方針は決まっているので、僕の方で調査・実装しようと思います。
https://github.com/tokyo-metropolitan-gov/covid19/issues/2764#issuecomment-609911262

## 📸 スクリーンショット / Screenshots
Chrome, Safari, Firefox, Edge, IE 11 で「やさしい日本語」のページを表示・リロードできることを確認しました。

### Safari
![スクリーンショット 2020-04-09 19 53 27](https://user-images.githubusercontent.com/5207601/78888002-d62cc800-7a9b-11ea-8c47-b609222ceb14.png)

### Firefox
![スクリーンショット 2020-04-09 19 19 45](https://user-images.githubusercontent.com/5207601/78885189-22293e00-7a97-11ea-9fb8-1266259145ac.png)

