### PR TITLE
トップページへの遷移時のグラフ横幅初期化不具合の修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -279,7 +279,7 @@ export default Vue.extend({
     margin: 16px 0;
     position: relative;
     overflow: hidden;
-    > div:first-child {
+    .scrollable {
       overflow-x: scroll;
       &::-webkit-scrollbar {
         height: 4px;
@@ -289,7 +289,7 @@ export default Vue.extend({
         background-color: rgba(0, 0, 0, 0.07);
       }
     }
-    > div:nth-child(2) {
+    .sticky-legend {
       position: absolute;
       top: 0;
       pointer-events: none;

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -14,17 +14,21 @@
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
     <div class="LegendStickyChart">
+      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
+        <div :style="{ width: `${chartWidth}px` }">
+          <bar
+            :ref="'barChart'"
+            :chart-id="chartId"
+            :chart-data="displayData"
+            :options="displayOption"
+            :plugins="scrollPlugin"
+            :height="240"
+            :width="chartWidth"
+          />
+        </div>
+      </div>
       <bar
-        :ref="'barChart'"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="chartId"
-        :chart-data="displayData"
-        :options="displayOption"
-        :plugins="scrollPlugin"
-        :height="240"
-        :width="chartWidth"
-      />
-      <bar
+        class="sticky-legend"
         :style="{ display: canvas ? 'block' : 'none' }"
         :chart-id="`${chartId}-header`"
         :chart-data="displayDataHeader"
@@ -481,7 +485,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     }
   },
-  beforeMount() {
+  mounted() {
     if (this.$el) {
       this.chartWidth =
         ((this.$el!.clientWidth - 22 * 2 - 38) / 60) *
@@ -492,8 +496,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         this.chartWidth
       )
     }
-  },
-  mounted() {
     const barChart = this.$refs.barChart as Vue
     const barElement = barChart.$el
     const canvas = barElement.querySelector('canvas')

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -47,18 +47,22 @@
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
     <div class="LegendStickyChart">
+      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
+        <div :style="{ width: `${chartWidth}px` }">
+          <bar
+            :ref="'barChart'"
+            :chart-id="chartId"
+            :chart-data="displayData"
+            :options="displayOption"
+            :plugins="scrollPlugin"
+            :display-legends="displayLegends"
+            :height="240"
+            :width="chartWidth"
+          />
+        </div>
+      </div>
       <bar
-        :ref="'barChart'"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="chartId"
-        :chart-data="displayData"
-        :options="displayOption"
-        :plugins="scrollPlugin"
-        :display-legends="displayLegends"
-        :height="240"
-        :width="chartWidth"
-      />
-      <bar
+        class="sticky-legend"
         :style="{ display: canvas ? 'block' : 'none' }"
         :chart-id="`${chartId}-header`"
         :chart-data="displayDataHeader"
@@ -568,7 +572,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return sumArray
     }
   },
-  beforeMount() {
+  mounted() {
     if (this.$el) {
       this.chartWidth =
         ((this.$el!.clientWidth - 22 * 2 - 38) / 60) * this.labels.length + 38
@@ -577,8 +581,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         this.chartWidth
       )
     }
-  },
-  mounted() {
     const barChart = this.$refs.barChart as Vue
     const barElement = barChart.$el
     const canvas = barElement.querySelector('canvas')

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -76,7 +76,9 @@ const createCustomChart = () => {
         displayLegends: watchDisplayLegends
       },
       mounted(): void {
-        this.renderChart(this.chartData, this.options)
+        setTimeout(() => {
+          this.renderChart(this.chartData, this.options)
+        })
       }
     }
   )
@@ -145,13 +147,9 @@ export const scrollPlugin: Chart.PluginServiceRegistrationOptions[] = [
   {
     beforeInit(chartInstance) {
       const fn = () => {
-        if (
-          chartInstance &&
-          chartInstance.canvas &&
-          chartInstance.canvas.parentElement
-        ) {
-          chartInstance.canvas.parentElement.scrollLeft! = chartInstance.width!
-        }
+        try {
+          chartInstance.canvas!.parentElement!.parentElement!.parentElement!.scrollLeft! = chartInstance.width!
+        } catch (e) {}
       }
       window.addEventListener('resize', fn)
       fn()


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3067 

## ⛏ 変更内容 / Details of Changes
- 上述「任意のページからトップページに遷移した際にグラフの横幅が不適切になる」を修正
- beforeMountフックの時点では親コンポーネントのDOMが存在しないケースがあるためグラフ横幅の確定はmountedフックへ移動
- chart.jsの初期化を確実に横幅確定後にするためvue-chart#renderChartはをsetTimeoutで非同期化
- 横幅の指定はcanvas自体でなくcanvasの親要素で行うべきというchart.jsドキュメントの指定に倣いDOM構造を変更
- 上の変更に伴い、スクロール位置調製の際のDOMのトラバーサルを調整
