### PR TITLE
pre-commitにx権限を追加。bashであることを明示

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "sh pre-commit.sh && lint-staged"
+      "pre-commit": "./pre-commit.sh && lint-staged"
     }
   },
   "dependencies": {

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # ref: https://qiita.com/ryounagaoka/items/3e7a1b44d43ad0547d4f
 
 unchangeable_files=(

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # ref: https://qiita.com/ryounagaoka/items/3e7a1b44d43ad0547d4f
 
 unchangeable_files=(


### PR DESCRIPTION
##👏 解決する issue / Resolved Issues
- close #3106 

## ⛏ 変更内容 / Details of Changes
- `chmod +x ./pre-commit.sh`を実行して、commitしました。
- `pre-commit.sh`内でbashであることを明示
- `husky`内で`sh`で実行していた部分を削除

## 📸 スクリーンショット / Screenshots
なし
