### PR TITLE
v-data-tableのtbodyの日付セルをthに変更

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -32,10 +32,10 @@
       <template v-slot:body="{ items }">
         <tbody>
           <tr v-for="item in items" :key="item.text">
-            <th>{{ item.text }}</th>
-            <td>{{ item[0] }}</td>
-            <td>{{ item[1] }}</td>
-            <td>{{ item[2] }}</td>
+            <th class="text-start">{{ item.text }}</th>
+            <td class="text-start">{{ item[0] }}</td>
+            <td class="text-start">{{ item[1] }}</td>
+            <td class="text-start">{{ item[2] }}</td>
           </tr>
         </tbody>
       </template>

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -28,7 +28,18 @@
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
-    />
+    >
+      <template v-slot:body="{ items }">
+        <tbody>
+          <tr v-for="item in items" :key="item.text">
+            <th>{{ item.text }}</th>
+            <td>{{ item[0] }}</td>
+            <td>{{ item[1] }}</td>
+            <td>{{ item[2] }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-data-table>
   </data-view>
 </template>
 

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -64,6 +64,10 @@
       tr {
         color: $gray-1;
 
+        th {
+          font-weight: normal;
+        }
+
         td {
           padding: 8px 10px;
           height: auto;

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -18,11 +18,11 @@
       <template v-slot:body="{ items }">
         <tbody>
           <tr v-for="item in items" :key="item.text">
-            <th>{{ item['公表日'] }}</th>
-            <td>{{ item['居住地'] }}</td>
-            <td>{{ item['年代'] }}</td>
-            <td>{{ item['性別'] }}</td>
-            <td>{{ item['退院'] }}</td>
+            <th class="text-start">{{ item['公表日'] }}</th>
+            <td class="text-start">{{ item['居住地'] }}</td>
+            <td class="text-start">{{ item['年代'] }}</td>
+            <td class="text-start">{{ item['性別'] }}</td>
+            <td class="text-center">{{ item['退院'] }}</td>
           </tr>
         </tbody>
       </template>

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -14,7 +14,19 @@
       :mobile-breakpoint="0"
       :custom-sort="customSort"
       class="cardTable"
-    />
+    >
+      <template v-slot:body="{ items }">
+        <tbody>
+          <tr v-for="item in items" :key="item.text">
+            <th>{{ item['公表日'] }}</th>
+            <td>{{ item['居住地'] }}</td>
+            <td>{{ item['年代'] }}</td>
+            <td>{{ item['性別'] }}</td>
+            <td>{{ item['退院'] }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-data-table>
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
     </div>
@@ -63,6 +75,7 @@
         }
 
         &:nth-child(odd) {
+          th,
           td {
             background: rgba($gray-4, 0.3);
           }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -32,10 +32,10 @@
       <template v-slot:body="{ items }">
         <tbody>
           <tr v-for="item in items" :key="item.text">
-            <th>{{ item.text }}</th>
-            <td>{{ item[0] }}</td>
-            <td>{{ item[1] }}</td>
-            <td>{{ item[2] }}</td>
+            <th class="text-start">{{ item.text }}</th>
+            <td class="text-start">{{ item[0] }}</td>
+            <td class="text-start">{{ item[1] }}</td>
+            <td class="text-start">{{ item[2] }}</td>
           </tr>
         </tbody>
       </template>

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -28,7 +28,18 @@
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
-    />
+    >
+      <template v-slot:body="{ items }">
+        <tbody>
+          <tr v-for="item in items" :key="item.text">
+            <th>{{ item.text }}</th>
+            <td>{{ item[0] }}</td>
+            <td>{{ item[1] }}</td>
+            <td>{{ item[2] }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-data-table>
     <template v-slot:footer>
       <external-link
         :url="'https://smooth-biz.metro.tokyo.lg.jp/pdf/202004date3.pdf'"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -50,8 +50,8 @@
       <template v-slot:body="{ items }">
         <tbody>
           <tr v-for="item in items" :key="item.text">
-            <th>{{ item.text }}</th>
-            <td>{{ item['0'] }}</td>
+            <th class="text-start">{{ item.text }}</th>
+            <td class="text-start">{{ item['0'] }}</td>
           </tr>
         </tbody>
       </template>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -46,7 +46,16 @@
       :mobile-breakpoint="0"
       class="cardTable"
       item-key="name"
-    />
+    >
+      <template v-slot:body="{ items }">
+        <tbody>
+          <tr v-for="item in items" :key="item.text">
+            <th>{{ item.text }}</th>
+            <td>{{ item['0'] }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-data-table>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -79,8 +79,19 @@
       :fixed-header="true"
       :disable-sort="true"
       :mobile-breakpoint="0"
+      class="cardTable"
       item-key="name"
-    />
+    >
+      <template v-slot:body="{ items }">
+        <tbody>
+          <tr v-for="item in items" :key="item.text">
+            <th>{{ item.text }}</th>
+            <td>{{ item['0'] }}</td>
+            <td>{{ item['1'] }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-data-table>
     <p :class="$style.DataViewDesc">
       <slot name="additionalNotes" />
     </p>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -85,9 +85,9 @@
       <template v-slot:body="{ items }">
         <tbody>
           <tr v-for="item in items" :key="item.text">
-            <th>{{ item.text }}</th>
-            <td>{{ item['0'] }}</td>
-            <td>{{ item['1'] }}</td>
+            <th class="text-start">{{ item.text }}</th>
+            <td class="text-start">{{ item['0'] }}</td>
+            <td class="text-start">{{ item['1'] }}</td>
           </tr>
         </tbody>
       </template>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3110

## ⛏ 変更内容 / Details of Changes
- `v-data-table`の`slot:body`を使用して、`tbody`の日付セルを`th`タグに変更

## 📸 スクリーンショット / Screenshots
thタグに変更した箇所が複数あったため、下記のようなスクリーンショットを用意しました。
- 非表示になっていた`table`タグを開発ツールで表示
- `th`タグに黄色の背景を設定

### thタグの背景色変更
<img width="605" alt="スクリーンショット 2020-04-11 10 51 53" src="https://user-images.githubusercontent.com/548508/79032720-a7216e00-7be3-11ea-8c4f-ea38529f95a4.png">

![localhost_3000_](https://user-images.githubusercontent.com/548508/79032752-efd92700-7be3-11ea-9639-2f58ecc1b965.png)

### 通常表示
![localhost_3000_ (2)](https://user-images.githubusercontent.com/548508/79032815-4e060a00-7be4-11ea-8f75-8755f5b385bd.png)
