### PR TITLE
[ruby] 新型コロナウイルス感染症が心配なときに（SP）のルビタグ対応

### DIFF
--- a/components/flow/FlowSp.vue
+++ b/components/flow/FlowSp.vue
@@ -1,7 +1,9 @@
 <template>
   <div :class="$style.FlowCard">
     <h3 :class="['mb-4', $style.FlowCardHeading]">
-      {{ $t('新型コロナウイルス感染症にかかる相談窓口について') }}
+      <t-i18n>{{
+        $t('新型コロナウイルス感染症にかかる相談窓口について')
+      }}</t-i18n>
     </h3>
     <div :class="$style.FlowCard">
       <flow-sp-past />
@@ -37,6 +39,7 @@ import FlowSpSuspect from './FlowSpSuspect.vue'
 import FlowSpAdvisory from './FlowSpAdvisory.vue'
 import FlowSpAccording from './FlowSpAccording.vue'
 import FlowSpHospitalized from './FlowSpHospitalized.vue'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
   components: {
@@ -46,7 +49,8 @@ export default {
     FlowSpSuspect,
     FlowSpAdvisory,
     FlowSpAccording,
-    FlowSpHospitalized
+    FlowSpHospitalized,
+    TI18n
   },
   mounted() {
     // ハッシュつきのURLにアクセスされたらすぐに遷移する

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -1,36 +1,40 @@
 <template>
   <div :class="[$style.container, $style.according]">
-    <i18n tag="div" :class="$style.heading" path="{advisory}による相談結果">
-      <template v-slot:advisory>
-        <span :class="[$style.fzLarge, $style.break]">
-          {{ $t('新型コロナ受診相談窓口') }}
-        </span>
-      </template>
-    </i18n>
-    <i18n
-      tag="p"
-      :class="$style.diag"
-      path="新型コロナ外来 {advice} と判断された場合"
-    >
-      <template v-slot:advice>
-        <span :class="[$style.fzXLLarge, $style.break]">
-          {{ $t('受診が必要') }}
-        </span>
-      </template>
-    </i18n>
+    <t-i18n>
+      <i18n tag="div" :class="$style.heading" path="{advisory}による相談結果">
+        <template v-slot:advisory>
+          <span :class="[$style.fzLarge, $style.break]">
+            {{ $t('新型コロナ受診相談窓口') }}
+          </span>
+        </template>
+      </i18n>
+    </t-i18n>
+    <t-i18n>
+      <i18n
+        tag="p"
+        :class="$style.diag"
+        path="新型コロナ外来 {advice} と判断された場合"
+      >
+        <template v-slot:advice>
+          <span :class="[$style.fzXLLarge, $style.break]">
+            {{ $t('受診が必要') }}
+          </span>
+        </template>
+      </i18n>
+    </t-i18n>
     <p :class="$style.decision">
       <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
-        <span :class="$style.fzSmall">
+        <t-i18n :class="$style.fzSmall">
           {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
-        </span>
-        <span :class="[$style.fzLarge, $style.break]">{{
+        </t-i18n>
+        <t-i18n :class="[$style.fzLarge, $style.break]">{{
           $t('医師による判断')
-        }}</span>
+        }}</t-i18n>
       </template>
       <template v-else>
-        <span :class="[$style.fzLarge, $style.break]">
+        <t-i18n :class="[$style.fzLarge, $style.break]">
           {{ $t('Diagnosis by a doctor at a COVID-19 outpatient facility') }}
-        </span>
+        </t-i18n>
       </template>
     </p>
     <div :class="[$style.rectContainer, $style.double]">
@@ -40,13 +44,15 @@
         href="#not_required"
       >
         <p>
-          <i18n path="検査の必要{ifRequired}">
-            <template v-slot:ifRequired>
-              <span :class="[$style.fzXLarge, $style.break]">
-                {{ $t('なし') }}
-              </span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="検査の必要{ifRequired}">
+              <template v-slot:ifRequired>
+                <span :class="[$style.fzXLarge, $style.break]">
+                  {{ $t('なし') }}
+                </span>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
           <GreenArrow />
@@ -58,13 +64,15 @@
         href="#pcr"
       >
         <p>
-          <i18n path="検査の必要{ifRequired}">
-            <template v-slot:ifRequired>
-              <span :class="[$style.fzXLarge, $style.break]">
-                {{ $t('あり') }}
-              </span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="検査の必要{ifRequired}">
+              <template v-slot:ifRequired>
+                <span :class="[$style.fzXLarge, $style.break]">
+                  {{ $t('あり') }}
+                </span>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
           <Arrow />
@@ -75,18 +83,18 @@
       <span :class="$style.break">
         <!-- 改行によって空白が入らないように-->
         <!-- eslint-disable -->
-        <span :class="$style.fzXLLarge">{{ $t('PCR検査') }}</span>{{ $t('※') }}
+        <t-i18n :class="$style.fzXLLarge">{{ $t('PCR検査') }}</t-i18n>{{ $t('※') }}
         <!-- eslint-enable -->
       </span>
-      <span :class="$style.break">
+      <t-i18n :class="$style.break">
         {{ $t('東京都健康安全研究センター等') }}
-      </span>
+      </t-i18n>
       <small :class="[$style.note, $style.fzSmall, $style.break]">
-        {{
+        <t-i18n>{{
           $t(
             '※保険適用となる検査は、当面の間、院内感染防止等の観点から、「帰国者・接触者外来」等の医療機関で実施'
           )
-        }}
+        }}</t-i18n>
       </small>
     </p>
     <div :class="[$style.rectContainer, $style.double]">
@@ -96,7 +104,7 @@
         href="#not_required"
       >
         <p>
-          <span :class="$style.fzXLarge">{{ $t('陰性') }}</span>
+          <t-i18n :class="$style.fzXLarge">{{ $t('陰性') }}</t-i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
           <GreenArrow />
@@ -108,52 +116,60 @@
         href="#hospitalized"
       >
         <p>
-          <span :class="$style.fzXLarge">{{ $t('陽性') }}</span>
+          <t-i18n :class="$style.fzXLarge">{{ $t('陽性') }}</t-i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
           <Arrow />
         </div>
       </a>
     </div>
-    <i18n
-      id="not_required"
-      tag="p"
-      :class="[$style.diag, $style.hr]"
-      path="新型コロナ外来 {advice} と判断された場合"
-    >
-      <template v-slot:advice>
-        <span :class="[$style.break, $style.fzXLLarge]">
-          {{ $t('受診が不要') }}
-        </span>
-      </template>
-    </i18n>
+    <t-i18n>
+      <i18n
+        id="not_required"
+        tag="p"
+        :class="[$style.diag, $style.hr]"
+        path="新型コロナ外来 {advice} と判断された場合"
+      >
+        <template v-slot:advice>
+          <span :class="[$style.break, $style.fzXLLarge]">
+            {{ $t('受診が不要') }}
+          </span>
+        </template>
+      </i18n>
+    </t-i18n>
     <div :class="[$style.rectContainer, $style.double]">
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
           <House />
         </div>
-        <p>{{ $t('自宅で安静に過ごす') }}</p>
+        <p>
+          <t-i18n>{{ $t('自宅で安静に過ごす') }}</t-i18n>
+        </p>
       </div>
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
           <Apartment />
         </div>
-        <p>{{ $t('一般の医療機関を受診') }}</p>
+        <p>
+          <t-i18n>{{ $t('一般の医療機関を受診') }}</t-i18n>
+        </p>
       </div>
       <div :class="[$style.rect, $style.consult]">
         <p>
-          <i18n path="{getWorse}{advisory}に相談">
-            <template v-slot:getWorse>
-              <i18n path="症状が良くならない場合は">
-                <span>{{ $t('症状が良くならない場合は') }}</span>
-              </i18n>
-            </template>
-            <template v-slot:advisory>
-              <strong :class="$style.advisory">
-                {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
-              </strong>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="{getWorse}{advisory}に相談">
+              <template v-slot:getWorse>
+                <i18n path="症状が良くならない場合は">
+                  <span>{{ $t('症状が良くならない場合は') }}</span>
+                </i18n>
+              </template>
+              <template v-slot:advisory>
+                <strong :class="$style.advisory">
+                  {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
+                </strong>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
       </div>
     </div>
@@ -165,13 +181,15 @@ import Apartment from '@/static/flow/responsive/apartment.svg'
 import House from '@/static/flow/responsive/house.svg'
 import Arrow from '@/static/flow/responsive/arrow_downward.svg'
 import GreenArrow from '@/static/flow/responsive/arrow_green.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
   components: {
     Apartment,
     House,
     Arrow,
-    GreenArrow
+    GreenArrow,
+    TI18n
   },
   computed: {
     langsWithoutOutpatient() {

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -1,18 +1,18 @@
 <template>
   <div :class="$style.container">
     <h4 id="consult" :class="[$style.heading, $style.fzXLarge]">
-      {{ $t('新型コロナ受診相談窓口（日本語のみ）') }}
-      <small :class="[$style.break, $style.fzRegular, $style.mt5]">{{
-        $t('帰国者・接触者 電話相談センター')
-      }}</small>
+      <t-i18n>{{ $t('新型コロナ受診相談窓口（日本語のみ）') }}</t-i18n>
+      <small :class="[$style.break, $style.fzRegular, $style.mt5]"
+        ><t-i18n>{{ $t('帰国者・接触者 電話相談センター') }}</t-i18n></small
+      >
     </h4>
     <p :class="[$style.open, $style.fzMedium]">
-      <span>{{ $t('24時間対応') }}</span>
+      <t-i18n :class="$style.baseline">{{ $t('24時間対応') }}</t-i18n>
     </p>
     <dl>
       <div :class="$style.daytime">
         <dt :class="[$style.title, $style.fzMedium]">
-          {{ $t('平日（日中）') }}
+          <t-i18n>{{ $t('平日（日中）') }}</t-i18n>
         </dt>
         <dd :class="$style.link">
           <a
@@ -20,7 +20,7 @@
             target="_blank"
             rel="noopener noreferrer"
           >
-            {{ $t('各保健所の電話番号は福祉保健局HPへ') }}
+            <t-i18n>{{ $t('各保健所の電話番号は福祉保健局HPへ') }}</t-i18n>
             <v-icon size="16">
               mdi-open-in-new
             </v-icon>
@@ -31,15 +31,14 @@
         <dt>
           <ul :class="[$style.night]">
             <li>
-              <span :class="[$style.fzMedium, $style.break, $style.mb10]">
-                {{ $t('平日（夜間）') }}
-              </span>
-              {{ $t('午後5時から翌朝午前9時') }}
+              <t-i18n :class="[$style.fzMedium, $style.break, $style.mb10]">
+                {{ $t('平日（夜間）') }} </t-i18n
+              ><t-i18n> {{ $t('午後5時から翌朝午前9時') }}</t-i18n>
             </li>
             <li>
-              <span :class="$style.fzMedium">
+              <t-i18n :class="$style.fzMedium">
                 {{ $t('土日祝 終日') }}
-              </span>
+              </t-i18n>
             </li>
           </ul>
         </dt>
@@ -54,9 +53,9 @@
             v-if="!['ja', 'ja-basic'].includes($i18n.locale)"
             :class="[$style.phone, $style.fzNumeric]"
           >
-            <span :class="[$style.fzMedium, $style.break, $style.mb10]">
+            <t-i18n :class="[$style.fzMedium, $style.break, $style.mb10]">
               {{ $t('ひまわり') }}
-            </span>
+            </t-i18n>
           </div>
         </dd>
       </div>
@@ -66,9 +65,10 @@
 
 <script lang="ts">
 import PhoneIcon from '@/static/flow/responsive/phone.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
-  components: { PhoneIcon }
+  components: { PhoneIcon, TI18n }
 }
 </script>
 
@@ -131,6 +131,10 @@ export default {
       margin-top: px2vw(20);
     }
   }
+}
+
+.baseline {
+  align-items: baseline !important;
 }
 
 @include largerThan($small) {

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -5,70 +5,78 @@
         <span :class="$style.icon">
           <DirectionsWalkIcon aria-hidden="true" />
         </span>
-        {{ $t('ご高齢な方') }}
+        <t-i18n>
+          {{ $t('ご高齢な方') }}
+        </t-i18n>
       </span>
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
           <AccessibleIcon aria-hidden="true" />
         </span>
-        {{ $t('基礎疾患のある方') }}
+        <t-i18n> {{ $t('基礎疾患のある方') }}</t-i18n>
       </span>
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
           <PregnantWomanIcon aria-hidden="true" />
         </span>
-        {{ $t('妊娠中の方') }}
+        <t-i18n> {{ $t('妊娠中の方') }}</t-i18n>
       </span>
     </div>
     <ul :class="[$style.rectContainer, $style.double]">
       <li :class="$style.symptom">
         <span>
-          <i18n path="{cold}のような症状">
-            <template v-slot:cold>
-              <span :class="$style.ConditionsItemLarger">
-                {{ $t('風邪') }}
-              </span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="{cold}のような症状">
+              <template v-slot:cold>
+                <span :class="$style.ConditionsItemLarger">
+                  {{ $t('風邪') }}
+                </span>
+              </template>
+            </i18n>
+          </t-i18n>
         </span>
       </li>
       <li :class="$style.symptom">
-        <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <template v-slot:temperature>
-            <i18n
-              tag="span"
-              path="{tempNum}以上"
-              :class="[$style.break, $style.fzRegular]"
-            >
-              <template v-slot:tempNum>
-                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
-              </template>
-            </i18n>
-          </template>
-        </i18n>
+        <t-i18n>
+          <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
+            <template v-slot:temperature>
+              <i18n
+                tag="span"
+                path="{tempNum}以上"
+                :class="[$style.break, $style.fzRegular]"
+              >
+                <template v-slot:tempNum>
+                  <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+                </template>
+              </i18n>
+            </template>
+          </i18n>
+        </t-i18n>
       </li>
       <li :class="$style.symptom">
-        {{ $t('強いだるさ') }}
+        <t-i18n>{{ $t('強いだるさ') }}</t-i18n>
       </li>
       <li :class="$style.symptom">
-        {{ $t('息苦しさ') }}
+        <t-i18n>{{ $t('息苦しさ') }}</t-i18n>
       </li>
     </ul>
 
     <p :class="$style.duration">
-      <i18n path="{duration}続いている">
-        <template v-slot:duration>
-          <i18n
-            :class="[$style.underline, $style.fzLarge]"
-            tag="span"
-            path="{day}日程度"
-          >
-            <template v-slot:day>
-              <strong :class="$style.fzNumeric">2</strong>
-            </template>
-          </i18n>
-        </template>
-      </i18n>
+      <t-i18n>
+        <i18n path="{duration}続いている">
+          <template v-slot:duration>
+            <i18n
+              :class="[$style.underline, $style.fzLarge]"
+              tag="span"
+              path="{day}日程度"
+            >
+              <template v-slot:day>
+                <strong :class="$style.fzNumeric">2</strong>
+              </template>
+            </i18n>
+          </template>
+        </i18n>
+      </t-i18n>
     </p>
 
     <a
@@ -79,7 +87,7 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <t-i18n :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</t-i18n>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>
@@ -91,13 +99,15 @@ import AccessibleIcon from '@/static/flow/responsive/accessible.svg'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 import DirectionsWalkIcon from '@/static/flow/responsive/directions_walk.svg'
 import PregnantWomanIcon from '@/static/flow/responsive/pregnant_woman.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
   components: {
     AccessibleIcon,
     ArrowForwardIcon,
     DirectionsWalkIcon,
-    PregnantWomanIcon
+    PregnantWomanIcon,
+    TI18n
   },
   methods: { onDoneScroll }
 }

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -4,54 +4,62 @@
       <span :class="[$style.icon, $style.top]" aria-hidden="true">
         <HumanIcon />
       </span>
-      <span :class="$style.fzMedium">{{ $t('一般の方') }}</span>
+      <t-i18n :class="$style.fzMedium">{{ $t('一般の方') }}</t-i18n>
     </p>
     <ul :class="[$style.rectContainer, $style.double]">
       <li :class="$style.symptom">
         <span>
-          <i18n path="{cold}のような症状">
-            <template v-slot:cold>
-              <span :class="$style.ConditionsItemLarger">{{ $t('風邪') }}</span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="{cold}のような症状">
+              <template v-slot:cold>
+                <span :class="$style.ConditionsItemLarger">{{
+                  $t('風邪')
+                }}</span>
+              </template>
+            </i18n>
+          </t-i18n>
         </span>
       </li>
       <li :class="$style.symptom">
-        <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <template v-slot:temperature>
+        <t-i18n>
+          <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
+            <template v-slot:temperature>
+              <i18n
+                tag="span"
+                path="{tempNum}以上"
+                :class="[$style.break, $style.fzRegular]"
+              >
+                <template v-slot:tempNum>
+                  <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+                </template>
+              </i18n>
+            </template>
+          </i18n>
+        </t-i18n>
+      </li>
+      <li :class="$style.symptom">
+        <t-i18n>{{ $t('強いだるさ') }}</t-i18n>
+      </li>
+      <li :class="$style.symptom">
+        <t-i18n>{{ $t('息苦しさ') }}</t-i18n>
+      </li>
+    </ul>
+    <p :class="$style.duration">
+      <t-i18n>
+        <i18n path="{duration}続いている">
+          <template v-slot:duration>
             <i18n
+              :class="[$style.underline, $style.fzLarge]"
               tag="span"
-              path="{tempNum}以上"
-              :class="[$style.break, $style.fzRegular]"
+              path="{day}日以上"
             >
-              <template v-slot:tempNum>
-                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+              <template v-slot:day>
+                <strong :class="$style.fzNumeric">4</strong>
               </template>
             </i18n>
           </template>
         </i18n>
-      </li>
-      <li :class="$style.symptom">
-        {{ $t('強いだるさ') }}
-      </li>
-      <li :class="$style.symptom">
-        {{ $t('息苦しさ') }}
-      </li>
-    </ul>
-    <p :class="$style.duration">
-      <i18n path="{duration}続いている">
-        <template v-slot:duration>
-          <i18n
-            :class="[$style.underline, $style.fzLarge]"
-            tag="span"
-            path="{day}日以上"
-          >
-            <template v-slot:day>
-              <strong :class="$style.fzNumeric">4</strong>
-            </template>
-          </i18n>
-        </template>
-      </i18n>
+      </t-i18n>
     </p>
     <a
       v-scroll-to="{
@@ -61,7 +69,7 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <t-i18n :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</t-i18n>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>
@@ -71,8 +79,10 @@
 import { onDoneScroll } from '@/utils/vueScrollTo'
 import HumanIcon from '@/static/flow/responsive/accessibility.svg'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
+import TI18n from '@/components/TI18n.vue'
+
 export default {
-  components: { HumanIcon, ArrowForwardIcon },
+  components: { HumanIcon, ArrowForwardIcon, TI18n },
   methods: { onDoneScroll }
 }
 </script>

--- a/components/flow/FlowSpHospitalized.vue
+++ b/components/flow/FlowSpHospitalized.vue
@@ -4,19 +4,20 @@
       <span :class="[$style.icon, $style.top]">
         <HotelIcon aria-hidden="true" />
       </span>
-      <span :class="$style.fzMedium">{{ $t('入院となります') }}</span>
+      <t-i18n :class="$style.fzMedium">{{ $t('入院となります') }}</t-i18n>
     </p>
     <p :class="[$style.facility, $style.fzXLarge]">
-      {{ $t('感染症指定医療機関等') }}
+      <t-i18n>{{ $t('感染症指定医療機関等') }}</t-i18n>
     </p>
   </div>
 </template>
 
 <script lang="ts">
 import HotelIcon from '@/static/flow/responsive/hotel.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
-  components: { HotelIcon }
+  components: { HotelIcon, TI18n }
 }
 </script>
 

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -1,119 +1,133 @@
 <template>
   <div :class="$style.container">
     <p :class="$style.heading">
-      <i18n path="{past}の出来ごとと症状" tag="span">
-        <template v-slot:past>
-          <i18n :class="$style.fzLarge" tag="span" path="発症前{two}週間以内">
-            <template v-slot:two>
-              <span :class="$style.fzNumeric">2</span>
-            </template>
-          </i18n>
-        </template>
-      </i18n>
-    </p>
-    <p :class="$style.type">
-      <template v-if="!langsNeedReversedOrder.includes($i18n.locale)">
-        <strong :class="$style.source">{{
-          $t('「新型コロナウイルス感染者」と')
-        }}</strong>
-        <i18n
-          tag="span"
-          path="{closeContact}をした方"
-          :class="[$style.behavior, $style.fzXLarge]"
-        >
-          <template v-slot:closeContact>
-            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
-          </template>
-        </i18n>
-      </template>
-      <template v-else>
-        <i18n
-          tag="span"
-          path="{closeContact}をした方"
-          :class="[$style.behavior, $style.fzXLarge]"
-        >
-          <template v-slot:closeContact>
-            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
-          </template>
-        </i18n>
-        <span :class="$style.source">{{
-          $t('「新型コロナウイルス感染者」と')
-        }}</span>
-      </template>
-    </p>
-    <div :class="[$style.rectContainer, $style.req]">
-      <p :class="$style.symptom">
-        {{ $t('発熱') }}
-      </p>
-      <p :class="$style.op">
-        {{ $t('または') }}
-      </p>
-      <p :class="$style.symptom">
-        {{ $t('呼吸器症状') }}
-      </p>
-    </div>
-    <p :class="[$style.type, $style.hr]">
-      <template v-if="!langsWithoutFlowTitle.includes($i18n.locale)">
-        <strong :class="$style.source">{{
-          $t('流行地域への渡航・居住歴がある方')
-        }}</strong>
-        <i18n
-          tag="span"
-          :class="[$style.behavior, $style.fzXLarge]"
-          path="{you} か {closeContact}をした方"
-        >
-          <template v-slot:you>
-            <em :class="$style.underline">{{ $t('ご本人') }}</em>
-          </template>
-          <template v-slot:closeContact>
-            <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
-          </template>
-        </i18n>
-      </template>
-      <template v-else>
-        <i18n
-          tag="span"
-          :class="[$style.behavior, $style.fzRegular]"
-          path="travel history from {area}"
-        >
-          <template v-slot:area>
-            <em :class="$style.underline">{{
-              $t('COVID-19 prevalent area')
-            }}</em>
-          </template>
-        </i18n>
-        <i18n
-          tag="span"
-          :class="[$style.behavior, $style.fzXLarge]"
-          path="been {inCloseContact} with returnees"
-        >
-          <template v-slot:inCloseContact>
-            <em :class="$style.underline">{{ $t('in close contact') }}</em>
-          </template>
-        </i18n>
-      </template>
-    </p>
-    <div :class="[$style.rectContainer, $style.req]">
-      <p :class="$style.symptom">
-        {{ $t('呼吸器症状') }}
-      </p>
-      <p :class="$style.op">
-        {{ $t('かつ') }}
-      </p>
-      <p :class="$style.symptom">
-        <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
-          <template v-slot:temperature>
-            <i18n
-              tag="span"
-              path="{tempNum}以上"
-              :class="[$style.break, $style.fzRegular]"
-            >
-              <template v-slot:tempNum>
-                <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+      <t-i18n>
+        <i18n path="{past}の出来ごとと症状" tag="span">
+          <template v-slot:past>
+            <i18n :class="$style.fzLarge" tag="span" path="発症前{two}週間以内">
+              <template v-slot:two>
+                <span :class="$style.fzNumeric">2</span>
               </template>
             </i18n>
           </template>
         </i18n>
+      </t-i18n>
+    </p>
+    <p :class="$style.type">
+      <template v-if="!langsNeedReversedOrder.includes($i18n.locale)">
+        <strong :class="$style.source"
+          ><t-i18n>{{ $t('「新型コロナウイルス感染者」と') }}</t-i18n></strong
+        >
+        <t-i18n>
+          <i18n
+            tag="span"
+            path="{closeContact}をした方"
+            :class="[$style.behavior, $style.fzXLarge]"
+          >
+            <template v-slot:closeContact>
+              <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+            </template>
+          </i18n>
+        </t-i18n>
+      </template>
+      <template v-else>
+        <t-i18n>
+          <i18n
+            tag="span"
+            path="{closeContact}をした方"
+            :class="[$style.behavior, $style.fzXLarge]"
+          >
+            <template v-slot:closeContact>
+              <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+            </template>
+          </i18n>
+        </t-i18n>
+        <t-i18n :class="$style.source">{{
+          $t('「新型コロナウイルス感染者」と')
+        }}</t-i18n>
+      </template>
+    </p>
+    <div :class="[$style.rectContainer, $style.req]">
+      <p :class="$style.symptom">
+        <t-i18n>{{ $t('発熱') }}</t-i18n>
+      </p>
+      <p :class="$style.op">
+        <t-i18n>{{ $t('または') }}</t-i18n>
+      </p>
+      <p :class="$style.symptom">
+        <t-i18n>{{ $t('呼吸器症状') }}</t-i18n>
+      </p>
+    </div>
+    <p :class="[$style.type, $style.hr]">
+      <template v-if="!langsWithoutFlowTitle.includes($i18n.locale)">
+        <strong :class="$style.source"
+          ><t-i18n>{{ $t('流行地域への渡航・居住歴がある方') }}</t-i18n></strong
+        >
+        <t-i18n>
+          <i18n
+            tag="span"
+            :class="[$style.behavior, $style.fzXLarge]"
+            path="{you} か {closeContact}をした方"
+          >
+            <template v-slot:you>
+              <em :class="$style.underline">{{ $t('ご本人') }}</em>
+            </template>
+            <template v-slot:closeContact>
+              <em :class="$style.underline">{{ $t('濃厚接触') }}</em>
+            </template>
+          </i18n>
+        </t-i18n>
+      </template>
+      <template v-else>
+        <t-i18n>
+          <i18n
+            tag="span"
+            :class="[$style.behavior, $style.fzRegular]"
+            path="travel history from {area}"
+          >
+            <template v-slot:area>
+              <em :class="$style.underline">{{
+                $t('COVID-19 prevalent area')
+              }}</em>
+            </template>
+          </i18n>
+        </t-i18n>
+        <t-i18n>
+          <i18n
+            tag="span"
+            :class="[$style.behavior, $style.fzXLarge]"
+            path="been {inCloseContact} with returnees"
+          >
+            <template v-slot:inCloseContact>
+              <em :class="$style.underline">{{ $t('in close contact') }}</em>
+            </template>
+          </i18n>
+        </t-i18n>
+      </template>
+    </p>
+    <div :class="[$style.rectContainer, $style.req]">
+      <p :class="$style.symptom">
+        <t-i18n>{{ $t('呼吸器症状') }}</t-i18n>
+      </p>
+      <p :class="$style.op">
+        <t-i18n>{{ $t('かつ') }}</t-i18n>
+      </p>
+      <p :class="$style.symptom">
+        <t-i18n>
+          <i18n tag="span" path="発熱{temperature}" :class="$style.fzSmall">
+            <template v-slot:temperature>
+              <i18n
+                tag="span"
+                path="{tempNum}以上"
+                :class="[$style.break, $style.fzRegular]"
+              >
+                <template v-slot:tempNum>
+                  <span :class="$style.temp">{{ $t('37.5℃') }}</span>
+                </template>
+              </i18n>
+            </template>
+          </i18n>
+        </t-i18n>
       </p>
     </div>
     <a
@@ -124,7 +138,7 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
+      <t-i18n :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</t-i18n>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>
@@ -133,9 +147,10 @@
 <script lang="ts">
 import { onDoneScroll } from '@/utils/vueScrollTo'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
-  components: { ArrowForwardIcon },
+  components: { ArrowForwardIcon, TI18n },
   computed: {
     langsNeedReversedOrder() {
       return ['en']

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -4,27 +4,27 @@
       <span :class="[$style.icon, $style.top]">
         <SentimentIcon aria-hidden="true" />
       </span>
-      <span :class="$style.fzMedium">{{ $t('不安に思う方') }}</span>
+      <t-i18n :class="$style.fzMedium">{{ $t('不安に思う方') }}</t-i18n>
     </p>
 
     <ul :class="[$style.rectContainer, $style.triple]">
       <li :class="$style.symptom">
-        {{ $t('微熱') }}
+        <t-i18n>{{ $t('微熱') }}</t-i18n>
       </li>
       <li :class="$style.symptom">
-        {{ $t('軽い咳') }}
+        <t-i18n>{{ $t('軽い咳') }}</t-i18n>
       </li>
       <li :class="$style.symptom">
-        {{ $t('感染の不安') }}
+        <t-i18n>{{ $t('感染の不安') }}</t-i18n>
       </li>
     </ul>
 
     <div :class="$style.callcenter">
       <p :class="$style.fzLarge">
-        {{ $t('新型コロナコールセンター') }}
+        <t-i18n>{{ $t('新型コロナコールセンター') }}</t-i18n>
       </p>
       <p :class="$style.open">
-        {{ $t('午前9時から午後9時（土日祝含む）') }}
+        <t-i18n>{{ $t('午前9時から午後9時（土日祝含む）') }}</t-i18n>
       </p>
       <p :class="[$style.phone, $style.fzNumeric]">
         <span :class="$style.icon">
@@ -42,7 +42,7 @@
       href="#consult"
       :class="[$style.button, $style.clickable]"
     >
-      <span :class="$style.text">{{ $t('専門的な助言が必要な場合') }}</span>
+      <t-i18n :class="$style.text">{{ $t('専門的な助言が必要な場合') }}</t-i18n>
       <ArrowForwardIcon :class="$style.icon" />
     </a>
   </div>
@@ -53,9 +53,10 @@ import { onDoneScroll } from '@/utils/vueScrollTo'
 import ArrowForwardIcon from '@/static/flow/responsive/arrow_forward.svg'
 import PhoneIcon from '@/static/flow/responsive/phone.svg'
 import SentimentIcon from '@/static/flow/responsive/sentiment_very_dissatisfied.svg'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
-  components: { ArrowForwardIcon, PhoneIcon, SentimentIcon },
+  components: { ArrowForwardIcon, PhoneIcon, SentimentIcon, TI18n },
   methods: { onDoneScroll }
 }
 </script>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3128

## 📝 関連する issue / Related Issues
- #3116 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 新型コロナウイルス感染症が心配なときに（SP）のルビタグ対応
  - `components/flow/FlowSp*.vue` が対象
- `FlowSpAdvisory.vue`の「24時間対応」にあたる部分のみ、以下のように表示されてしまうため、`align-items: baseline` を付与し、下揃えになるように変更
![image](https://user-images.githubusercontent.com/42484226/79036145-45bbc800-7c00-11ea-81ee-3b7228fb99f4.png)

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![localhost_3000_ja-basic_flow (1)](https://user-images.githubusercontent.com/42484226/79036124-fc6b7880-7bff-11ea-859e-a1de78164fa3.png)

