### PR TITLE
[ruby] 新型コロナウイルス感染症が心配なときに（PC） のルビタグ対応

### DIFF
--- a/components/flow/FlowPc.vue
+++ b/components/flow/FlowPc.vue
@@ -1,7 +1,11 @@
 <template>
   <div :class="$style.FlowCard">
     <div :class="$style.FirstSectionWrapper">
-      <h3>{{ $t('新型コロナウイルス感染症にかかる相談窓口について') }}</h3>
+      <h3>
+        <t-i18n>{{
+          $t('新型コロナウイルス感染症にかかる相談窓口について')
+        }}</t-i18n>
+      </h3>
       <div :class="[$style.Outer, $style.OuterUpper]">
         <div :class="[$style.CardBlock, $style.Past]">
           <div :class="[$style.CardBlockInner]">
@@ -54,17 +58,19 @@
     </div>
     <div :class="$style.SecondSectionWrapper">
       <h3>
-        <i18n
-          :class="$style.TitleSmall"
-          tag="span"
-          path="{advisory}による相談結果"
-        >
-          <template v-slot:advisory>
-            <span :class="$style.TitleLarge">
-              {{ $t('新型コロナ受診相談窓口') }}
-            </span>
-          </template>
-        </i18n>
+        <t-i18n>
+          <i18n
+            :class="$style.TitleSmall"
+            tag="span"
+            path="{advisory}による相談結果"
+          >
+            <template v-slot:advisory>
+              <span :class="$style.TitleLarge">
+                {{ $t('新型コロナ受診相談窓口') }}
+              </span>
+            </template>
+          </i18n>
+        </t-i18n>
       </h3>
       <div :class="[$style.Outer, $style.OuterLower]">
         <div
@@ -111,11 +117,11 @@
         </div>
       </div>
       <p :class="$style.Note">
-        {{
+        <t-i18n>{{
           $t(
             '※保険適用となる検査は、当面の間、院内感染防止等の観点から、「帰国者・接触者外来」等の医療機関で実施'
           )
-        }}
+        }}</t-i18n>
       </p>
     </div>
   </div>
@@ -131,6 +137,7 @@ import FlowPcRequired from './FlowPcRequired.vue'
 import FlowPcPcr from './FlowPcPcr.vue'
 import FlowPcNotRequired from './FlowPcNotRequired.vue'
 import FlowPcHospitalized from './FlowPcHospitalized.vue'
+import TI18n from '@/components/TI18n.vue'
 
 export default {
   components: {
@@ -142,7 +149,8 @@ export default {
     FlowPcRequired,
     FlowPcPcr,
     FlowPcNotRequired,
-    FlowPcHospitalized
+    FlowPcHospitalized,
+    TI18n
   }
 }
 </script>

--- a/components/flow/FlowPcAdvisory.vue
+++ b/components/flow/FlowPcAdvisory.vue
@@ -3,18 +3,18 @@
     <div :class="$style.AdvisoryContainer">
       <div :class="$style.AdvisoryContents">
         <div>
-          <span :class="$style.AdvisoryContentsTitle">{{
+          <t-i18n :class="$style.AdvisoryContentsTitle">{{
             $t('新型コロナ受診相談窓口（日本語のみ）')
-          }}</span>
+          }}</t-i18n>
         </div>
         <div :class="[$style.AdvisoryContentsColsSentense, 'mt-4']">
-          {{ $t('帰国者・接触者 電話相談センター') }}
+          <t-i18n>{{ $t('帰国者・接触者 電話相談センター') }}</t-i18n>
         </div>
         <div>
           <div :class="[$style.AdvisoryBoxContainer, $style.AdvisoryWhiteBox]">
-            <span :class="$style.AdvisoryWhiteBoxSentense">
+            <t-i18n :class="$style.AdvisoryWhiteBoxSentense">
               {{ $t('24時間対応') }}
-            </span>
+            </t-i18n>
           </div>
         </div>
       </div>
@@ -22,7 +22,7 @@
       <div :class="$style.AdvisoryContents">
         <div class="py-8">
           <div :class="$style.AdvisoryContentsTitle2">
-            {{ $t('平日（日中）') }}
+            <t-i18n>{{ $t('平日（日中）') }}</t-i18n>
           </div>
           <div
             :class="[
@@ -36,7 +36,7 @@
               target="_blank"
               rel="noopener noreferrer"
             >
-              <span>{{ $t('各保健所の電話番号は福祉保健局HPへ') }}</span>
+              <t-i18n>{{ $t('各保健所の電話番号は福祉保健局HPへ') }}</t-i18n>
               <v-icon size="18">
                 mdi-open-in-new
               </v-icon>
@@ -48,14 +48,14 @@
       <div :class="$style.AdvisoryContents">
         <div class="pt-8">
           <div :class="$style.AdvisoryContentsTitle2">
-            {{ $t('平日（夜間）') }}
+            <t-i18n>{{ $t('平日（夜間）') }}</t-i18n>
           </div>
-          <span>{{ $t('午後5時から翌朝午前9時') }}</span>
+          <t-i18n>{{ $t('午後5時から翌朝午前9時') }}</t-i18n>
         </div>
         <div class="mt-1">
-          <span :class="$style.AdvisoryContentsSubTitle">
+          <t-i18n :class="$style.AdvisoryContentsSubTitle">
             {{ $t('土日祝 終日') }}
-          </span>
+          </t-i18n>
         </div>
         <div
           :class="[
@@ -75,13 +75,20 @@
           </a>
         </div>
         <div v-if="!['ja', 'ja-basic'].includes($i18n.locale)" class="pt-8">
-          <span>{{ $t('ひまわり') }}</span>
+          <t-i18n>{{ $t('ひまわり') }}</t-i18n>
         </div>
       </div>
     </div>
   </div>
 </template>
-
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 <style module lang="scss">
 .Advisory {
   display: flex;

--- a/components/flow/FlowPcAdvisory2.vue
+++ b/components/flow/FlowPcAdvisory2.vue
@@ -1,13 +1,20 @@
 <template>
   <div :class="$style.Container">
     <div :class="['pa-4', $style.AdvisoryBoxContainer]">
-      <span :class="$style.AdvisoryBlackBoxSentense">{{
+      <t-i18n :class="$style.AdvisoryBlackBoxSentense">{{
         $t('専門的な助言が必要な場合')
-      }}</span>
+      }}</t-i18n>
     </div>
   </div>
 </template>
-
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 <style module lang="scss">
 .Container {
   align-items: center;

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -242,7 +242,7 @@
         font-weight: bold;
 
         @include largerThan($large) {
-          font-size: 20px;
+          font-size: 18px;
         }
       }
 

--- a/components/flow/FlowPcDays.vue
+++ b/components/flow/FlowPcDays.vue
@@ -9,41 +9,45 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('一般の方') }}
+          <t-i18n>{{ $t('一般の方') }}</t-i18n>
         </p>
       </div>
       <div>
         <p>
-          <i18n path="{duration}続いている">
-            <template v-slot:duration>
-              <i18n
-                tag="span"
-                path="{day}日以上"
-                :class="$style.FlowRowEmphasis"
-              >
-                <template v-slot:day>
-                  <span :class="$style.FlowRowEmphasisDay">4</span>
-                </template>
-              </i18n>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="{duration}続いている">
+              <template v-slot:duration>
+                <i18n
+                  tag="span"
+                  path="{day}日以上"
+                  :class="$style.FlowRowEmphasis"
+                >
+                  <template v-slot:day>
+                    <span :class="$style.FlowRowEmphasisDay">4</span>
+                  </template>
+                </i18n>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
       </div>
     </div>
     <div :class="[$style.FlowRow, $style.FlowRowRowCheck]">
       <div :class="$style.FlowRowCondition">
         <p>
-          <i18n
-            tag="span"
-            path="{cold}のような症状"
-            :class="$style.FlowRowConditionSmall"
-          >
-            <template v-slot:cold>
-              <span :class="$style.FlowRowConditionLarge">
-                {{ $t('風邪') }}
-              </span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n
+              tag="span"
+              path="{cold}のような症状"
+              :class="$style.FlowRowConditionSmall"
+            >
+              <template v-slot:cold>
+                <span :class="$style.FlowRowConditionLarge">
+                  {{ $t('風邪') }}
+                </span>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
         <img
           :class="$style.FlowRowConditionIcon"
@@ -54,21 +58,23 @@
       </div>
       <div :class="$style.FlowRowCondition">
         <p>
-          <i18n
-            tag="span"
-            :class="$style.FlowRowConditionSmall"
-            path="発熱{temperature}"
-          >
-            <template v-slot:temperature>
-              <i18n tag="span" path="{tempNum}以上">
-                <template v-slot:tempNum>
-                  <span :class="$style.FlowRowConditionLarge">
-                    {{ $t('37.5℃') }}
-                  </span>
-                </template>
-              </i18n>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n
+              tag="span"
+              :class="$style.FlowRowConditionSmall"
+              path="発熱{temperature}"
+            >
+              <template v-slot:temperature>
+                <i18n tag="span" path="{tempNum}以上">
+                  <template v-slot:tempNum>
+                    <span :class="$style.FlowRowConditionLarge">
+                      {{ $t('37.5℃') }}
+                    </span>
+                  </template>
+                </i18n>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
         <img
           :class="$style.FlowRowConditionIcon"
@@ -78,7 +84,9 @@
         />
       </div>
       <div :class="$style.FlowRowCondition">
-        <p>{{ $t('強いだるさ') }}</p>
+        <p>
+          <t-i18n>{{ $t('強いだるさ') }}</t-i18n>
+        </p>
         <img
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
@@ -87,7 +95,9 @@
         />
       </div>
       <div :class="$style.FlowRowCondition">
-        <p>{{ $t('息苦しさ') }}</p>
+        <p>
+          <t-i18n>{{ $t('息苦しさ') }}</t-i18n>
+        </p>
         <img
           :class="$style.FlowRowConditionIcon"
           src="/flow/check_circle-24px.svg"
@@ -106,7 +116,7 @@
               aria-hidden="true"
               alt=" "
             />
-            {{ $t('ご高齢な方') }}
+            <t-i18n>{{ $t('ご高齢な方') }}</t-i18n>
           </li>
           <li :class="$style.FlowRowRowThreeCareTargetListItem">
             <img
@@ -115,7 +125,7 @@
               aria-hidden="true"
               alt=" "
             />
-            {{ $t('基礎疾患のある方') }}
+            <t-i18n>{{ $t('基礎疾患のある方') }}</t-i18n>
           </li>
           <li :class="$style.FlowRowRowThreeCareTargetListItem">
             <img
@@ -124,25 +134,27 @@
               aria-hidden="true"
               alt=" "
             />
-            {{ $t('妊娠中の方') }}
+            <t-i18n>{{ $t('妊娠中の方') }}</t-i18n>
           </li>
         </ul>
       </div>
       <div>
         <p>
-          <i18n path="{duration}続いている">
-            <template v-slot:duration>
-              <i18n
-                tag="span"
-                path="{day}日程度"
-                :class="$style.FlowRowEmphasis"
-              >
-                <template v-slot:day>
-                  <span :class="$style.FlowRowEmphasisDay">2</span>
-                </template>
-              </i18n>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="{duration}続いている">
+              <template v-slot:duration>
+                <i18n
+                  tag="span"
+                  path="{day}日程度"
+                  :class="$style.FlowRowEmphasis"
+                >
+                  <template v-slot:day>
+                    <span :class="$style.FlowRowEmphasisDay">2</span>
+                  </template>
+                </i18n>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
       </div>
     </div>
@@ -277,3 +289,11 @@
   }
 }
 </style>
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>

--- a/components/flow/FlowPcHospitalized.vue
+++ b/components/flow/FlowPcHospitalized.vue
@@ -7,14 +7,21 @@
         aria-hidden="true"
         alt=" "
       />
-      {{ $t('入院となります') }}
+      <t-i18n>{{ $t('入院となります') }}</t-i18n>
     </p>
     <p :class="$style.FlowPcHospitalizedsubHeading">
-      {{ $t('感染症指定医療機関等') }}
+      <t-i18n>{{ $t('感染症指定医療機関等') }}</t-i18n>
     </p>
   </div>
 </template>
-
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 <style module lang="scss">
 .FlowPcHospitalized {
   display: flex;

--- a/components/flow/FlowPcNotRequired.vue
+++ b/components/flow/FlowPcNotRequired.vue
@@ -1,13 +1,15 @@
 <template>
   <div :class="$style.flowContainer">
     <h3 :class="$style.sectionTitle">
-      <i18n path="新型コロナ外来 {advice} と判断された場合" tag="p">
-        <template v-slot:advice>
-          <strong>
-            {{ $t('受診が不要') }}
-          </strong>
-        </template>
-      </i18n>
+      <t-i18n>
+        <i18n path="新型コロナ外来 {advice} と判断された場合" tag="p">
+          <template v-slot:advice>
+            <strong>
+              {{ $t('受診が不要') }}
+            </strong>
+          </template>
+        </i18n>
+      </t-i18n>
     </h3>
     <div :class="$style.actionContainer">
       <ul :class="$style.actions">
@@ -18,7 +20,7 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('自宅で安静に過ごす') }}
+          <t-i18n>{{ $t('自宅で安静に過ごす') }}</t-i18n>
         </li>
         <li :class="$style.actionsList">
           <img
@@ -27,22 +29,33 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('一般の医療機関を受診') }}
+          <t-i18n>{{ $t('一般の医療機関を受診') }}</t-i18n>
         </li>
       </ul>
       <div :class="$style.nextAction">
-        <i18n path="{getWorse}{advisory}に相談" :class="$style.content">
-          <template v-slot:getWorse>
-            <span>{{ $t('症状が良くならない場合は') }}</span>
-          </template>
-          <template v-slot:advisory>
-            <strong>{{ $t('新型コロナ受診相談窓口（日本語のみ）') }}</strong>
-          </template>
-        </i18n>
+        <t-i18n>
+          <i18n path="{getWorse}{advisory}に相談" :class="$style.content">
+            <template v-slot:getWorse>
+              <span>{{ $t('症状が良くならない場合は') }}</span>
+            </template>
+            <template v-slot:advisory>
+              <strong>{{ $t('新型コロナ受診相談窓口（日本語のみ）') }}</strong>
+            </template>
+          </i18n>
+        </t-i18n>
       </div>
     </div>
   </div>
 </template>
+
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 
 <style module lang="scss">
 .flowContainer {

--- a/components/flow/FlowPcPcr.vue
+++ b/components/flow/FlowPcPcr.vue
@@ -3,25 +3,32 @@
     <div :class="$style.actionArea">
       <div>
         <p :class="$style.h1">
-          {{ $t('PCR検査') }}
-          <span :class="$style.small">{{ $t('※') }}</span>
+          <t-i18n>{{ $t('PCR検査') }}</t-i18n>
+          <t-i18n :class="$style.small">{{ $t('※') }}</t-i18n>
         </p>
         <p :class="$style.content">
-          {{ $t('東京都健康安全研究センター等') }}
+          <t-i18n>{{ $t('東京都健康安全研究センター等') }}</t-i18n>
         </p>
       </div>
     </div>
     <div :class="$style.resultArea">
       <div :class="[$style.label, $style.ResultLabel]">
-        {{ $t('陰性') }}
+        <t-i18n>{{ $t('陰性') }}</t-i18n>
       </div>
       <div :class="[$style.label, $style.ResultLabel, $style.positive]">
-        {{ $t('陽性') }}
+        <t-i18n>{{ $t('陽性') }}</t-i18n>
       </div>
     </div>
   </div>
 </template>
-
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 <style module lang="scss">
 .FlowPcPcr {
   @include card-container();

--- a/components/flow/FlowPcRequired.vue
+++ b/components/flow/FlowPcRequired.vue
@@ -1,31 +1,35 @@
 <template>
   <div :class="$style.Container">
     <div :class="$style.Row">
-      <i18n
-        :class="$style.Catch"
-        tag="p"
-        path="新型コロナ外来 {advice} と判断された場合"
-      >
-        <template v-slot:advice>
-          <span :class="$style.Emphasis">
-            {{ $t('受診が必要') }}
-          </span>
-        </template>
-      </i18n>
+      <t-i18n>
+        <i18n
+          :class="$style.Catch"
+          tag="p"
+          path="新型コロナ外来 {advice} と判断された場合"
+        >
+          <template v-slot:advice>
+            <span :class="$style.Emphasis">
+              {{ $t('受診が必要') }}
+            </span>
+          </template>
+        </i18n>
+      </t-i18n>
     </div>
     <div :class="$style.Row">
       <div :class="[$style.Card, $style.CardLarge, $style.CardGray]">
         <template v-if="!langsWithoutOutpatient.includes($i18n.locale)">
           <p :class="$style.Outpatient">
-            {{ $t('新型コロナ外来（帰国者・接触者外来）') }}
+            <t-i18n>{{ $t('新型コロナ外来（帰国者・接触者外来）') }}</t-i18n>
           </p>
           <p :class="$style.Judge">
-            {{ $t('医師による判断') }}
+            <t-i18n>{{ $t('医師による判断') }}</t-i18n>
           </p>
         </template>
         <template v-else>
           <p :class="$style.Judge">
-            {{ $t('Diagnosis by a doctor at a COVID-19 outpatient facility') }}
+            <t-i18n>{{
+              $t('Diagnosis by a doctor at a COVID-19 outpatient facility')
+            }}</t-i18n>
           </p>
         </template>
       </div>
@@ -33,20 +37,24 @@
     <div :class="$style.TwoRow">
       <div :class="[$style.Card, $style.CardGreen]">
         <p :class="$style.CardGreenText">
-          <i18n path="検査の必要{ifRequired}">
-            <template v-slot:ifRequired>
-              <span>{{ $t('あり') }}</span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="検査の必要{ifRequired}">
+              <template v-slot:ifRequired>
+                <span>{{ $t('あり') }}</span>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
       </div>
       <div :class="[$style.Card, $style.CardWhite]">
         <p :class="$style.CardWhiteText">
-          <i18n path="検査の必要{ifRequired}">
-            <template v-slot:ifRequired>
-              <span>{{ $t('なし') }}</span>
-            </template>
-          </i18n>
+          <t-i18n>
+            <i18n path="検査の必要{ifRequired}">
+              <template v-slot:ifRequired>
+                <span>{{ $t('なし') }}</span>
+              </template>
+            </i18n>
+          </t-i18n>
         </p>
       </div>
     </div>
@@ -54,7 +62,11 @@
 </template>
 
 <script>
+import TI18n from '@/components/TI18n.vue'
 export default {
+  components: {
+    TI18n
+  },
   computed: {
     langsWithoutOutpatient() {
       return ['en']

--- a/components/flow/FlowPcSuspect.vue
+++ b/components/flow/FlowPcSuspect.vue
@@ -15,7 +15,7 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('不安に思う方') }}
+          <t-i18n>{{ $t('不安に思う方') }}</t-i18n>
         </div>
       </div>
       <div :class="$style.RowItems">
@@ -26,7 +26,7 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('微熱') }}
+          <t-i18n>{{ $t('微熱') }}</t-i18n>
         </div>
         <div :class="$style.CheckBox">
           <img
@@ -35,7 +35,7 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('軽い咳') }}
+          <t-i18n>{{ $t('軽い咳') }}</t-i18n>
         </div>
         <div :class="$style.CheckBox">
           <img
@@ -44,17 +44,17 @@
             aria-hidden="true"
             alt=" "
           />
-          {{ $t('感染の不安') }}
+          <t-i18n>{{ $t('感染の不安') }}</t-i18n>
         </div>
       </div>
     </div>
 
     <div :class="[$style.SubtleBox, $style.Box2, $style.Center]">
       <div :class="$style.LargerText">
-        {{ $t('新型コロナコールセンター') }}
+        <t-i18n>{{ $t('新型コロナコールセンター') }}</t-i18n>
       </div>
       <div :class="$style.SmallerText">
-        {{ $t('午前9時から午後9時（土日祝含む）') }}
+        <t-i18n>{{ $t('午前9時から午後9時（土日祝含む）') }}</t-i18n>
       </div>
 
       <div :class="$style.Tel">
@@ -71,7 +71,14 @@
     </div>
   </div>
 </template>
-
+<script lang="ts">
+import TI18n from '@/components/TI18n.vue'
+export default {
+  components: {
+    TI18n
+  }
+}
+</script>
 <style module lang="scss">
 .FlowComponent {
   color: $gray-2;


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issue
- close #3127


## 📝 関連する issue / Related Issues
- #3127
- #3116

## ⛏ 変更内容 / Details of Changes
- 「新型コロナウイルス感染症が心配なときに」のPC版ページにTI18nコンポーネントを適用し、ルビ置き換えを実施。
## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-04-11 17 03 15](https://user-images.githubusercontent.com/36391432/79038703-6131cd80-7c16-11ea-9c80-415002170581.png)
![スクリーンショット 2020-04-11 17 02 48](https://user-images.githubusercontent.com/36391432/79038710-6abb3580-7c16-11ea-8de6-78e188f2c746.png)
![スクリーンショット 2020-04-11 17 02 28](https://user-images.githubusercontent.com/36391432/79038712-6ee75300-7c16-11ea-98ba-80eac3cc1ee0.png)
