### PR TITLE
[ruby] やさしい日本語ページをリロードするとローディングで止まるバグを修正

### DIFF
--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -25,7 +25,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 > = {
   data() {
     return {
-      locale: this.$i18n.locale
+      locale: ''
     }
   },
   methods: {
@@ -47,6 +47,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       if ((lastText = text.slice(pos))) texts.push({ ja: lastText })
       return texts
     }
+  },
+  mounted() {
+    this.locale = this.$i18n.locale
   },
   watch: {
     '$root.$i18n.locale'(newLocale) {

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -51,6 +51,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   mounted() {
     this.locale = this.$i18n.locale
   },
+  watch: {
+    '$root.$i18n.locale'(newLocale) {
+      this.locale = newLocale
+    }
+  },
   render(createElement): VNode {
     const slot = this.$slots.default ? this.$slots.default![0] : ''
 

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -51,11 +51,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   mounted() {
     this.locale = this.$i18n.locale
   },
-  watch: {
-    '$root.$i18n.locale'(newLocale) {
-      this.locale = newLocale
-    }
-  },
   render(createElement): VNode {
     const slot = this.$slots.default ? this.$slots.default![0] : ''
 


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #3141 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- トップページでやさしい日本語を直接表示したり、リロードした際にローディングで止まるバグを修正しました
- `data` で直接 locale の初期値を設定すると Node がずれるので、`mounted` で設定するようにしました
  - おそらく `nuxt-i18n` の言語設定のタイミングと `v-i18n` のレンダリングタイミングがあっていないのが原因だと思います（nuxt-i18n の実装の詳細に詳しくないので確証はないですが..）

## 📸 スクリーンショット / Screenshots

[![Image from Gyazo](https://i.gyazo.com/907e0aae414499af324caa572078be90.gif)](https://gyazo.com/907e0aae414499af324caa572078be90)