### PR TITLE
コンポーネントのタグ記法をケバブケースに統一

### DIFF
--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="LauguageSelector">
     <div class="LauguageSelector-Background">
-      <EarthIcon class="EarthIcon" aria-hidden="true" />
-      <SelectMenuIcon class="SelectMenuIcon" aria-hidden="true" />
+      <earth-icon class="EarthIcon" aria-hidden="true" />
+      <select-menu-icon class="SelectMenuIcon" aria-hidden="true" />
     </div>
     <select
       id="LanguageSelector"

--- a/components/PrinterButton.vue
+++ b/components/PrinterButton.vue
@@ -9,8 +9,8 @@
       @mouseleave="mouseleave"
     >
       <div class="PrinterButton-PrinterIcon">
-        <PrinterWhiteIcon v-if="hover" aria-hidden="true" />
-        <PrinterIcon v-else aria-hidden="true" />
+        <printer-white-icon v-if="hover" aria-hidden="true" />
+        <printer-icon v-else aria-hidden="true" />
       </div>
       <span class="PrinterButton-Text">
         {{ $t('print') }}

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -42,10 +42,10 @@
             <label class="SideNavigation-LanguageLabel" for="LanguageSelector">
               {{ $t('多言語対応選択メニュー') }}
             </label>
-            <LanguageSelector />
+            <language-selector />
           </div>
         </div>
-        <MenuList :items="items" @click="$emit('closeNavi', $event)" />
+        <menu-list :items="items" @click="$emit('closeNavi', $event)" />
       </nav>
 
       <footer class="SideNavigation-Footer">

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -49,7 +49,7 @@
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <green-arrow />
+          <green-arrow-icon />
         </div>
       </a>
       <a
@@ -99,7 +99,7 @@
           <span :class="$style.fzXLarge">{{ $t('陰性') }}</span>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <green-arrow />
+          <green-arrow-icon />
         </div>
       </a>
       <a
@@ -164,14 +164,14 @@
 import ApartmentIcon from '@/static/flow/responsive/apartment.svg'
 import HouseIcon from '@/static/flow/responsive/house.svg'
 import ArrowDownwardIcon from '@/static/flow/responsive/arrow_downward.svg'
-import GreenArrow from '@/static/flow/responsive/arrow_green.svg'
+import GreenArrowIcon from '@/static/flow/responsive/arrow_green.svg'
 
 export default {
   components: {
     ApartmentIcon,
     HouseIcon,
     ArrowDownwardIcon,
-    GreenArrow
+    GreenArrowIcon
   },
   computed: {
     langsWithoutOutpatient() {

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -49,7 +49,7 @@
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <GreenArrow />
+          <green-arrow />
         </div>
       </a>
       <a
@@ -67,7 +67,7 @@
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <Arrow />
+          <arrow />
         </div>
       </a>
     </div>
@@ -99,7 +99,7 @@
           <span :class="$style.fzXLarge">{{ $t('陰性') }}</span>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <GreenArrow />
+          <green-arrow />
         </div>
       </a>
       <a
@@ -111,7 +111,7 @@
           <span :class="$style.fzXLarge">{{ $t('陽性') }}</span>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <Arrow />
+          <arrow />
         </div>
       </a>
     </div>
@@ -130,13 +130,13 @@
     <div :class="[$style.rectContainer, $style.double]">
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
-          <House />
+          <house />
         </div>
         <p>{{ $t('自宅で安静に過ごす') }}</p>
       </div>
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
-          <Apartment />
+          <apartment />
         </div>
         <p>{{ $t('一般の医療機関を受診') }}</p>
       </div>

--- a/components/flow/FlowSpAccording.vue
+++ b/components/flow/FlowSpAccording.vue
@@ -67,7 +67,7 @@
           </i18n>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <arrow />
+          <arrow-downward-icon />
         </div>
       </a>
     </div>
@@ -111,7 +111,7 @@
           <span :class="$style.fzXLarge">{{ $t('陽性') }}</span>
         </p>
         <div :class="$style.arrow" aria-hidden="true">
-          <arrow />
+          <arrow-downward-icon />
         </div>
       </a>
     </div>
@@ -130,13 +130,13 @@
     <div :class="[$style.rectContainer, $style.double]">
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
-          <house />
+          <house-icon />
         </div>
         <p>{{ $t('自宅で安静に過ごす') }}</p>
       </div>
       <div :class="[$style.rect, $style.solution]">
         <div :class="$style.icon" aria-hidden="true">
-          <apartment />
+          <apartment-icon />
         </div>
         <p>{{ $t('一般の医療機関を受診') }}</p>
       </div>
@@ -161,16 +161,16 @@
 </template>
 
 <script>
-import Apartment from '@/static/flow/responsive/apartment.svg'
-import House from '@/static/flow/responsive/house.svg'
-import Arrow from '@/static/flow/responsive/arrow_downward.svg'
+import ApartmentIcon from '@/static/flow/responsive/apartment.svg'
+import HouseIcon from '@/static/flow/responsive/house.svg'
+import ArrowDownwardIcon from '@/static/flow/responsive/arrow_downward.svg'
 import GreenArrow from '@/static/flow/responsive/arrow_green.svg'
 
 export default {
   components: {
-    Apartment,
-    House,
-    Arrow,
+    ApartmentIcon,
+    HouseIcon,
+    ArrowDownwardIcon,
     GreenArrow
   },
   computed: {

--- a/components/flow/FlowSpAdvisory.vue
+++ b/components/flow/FlowSpAdvisory.vue
@@ -46,7 +46,7 @@
         <dd>
           <div :class="[$style.phone, $style.fzNumeric]">
             <span :class="$style.icon">
-              <PhoneIcon alt="Phone" />
+              <phone-icon alt="Phone" />
             </span>
             <a href="tel:0353204592">03-5320-4592</a>
           </div>

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -3,7 +3,7 @@
     <div :class="[$style.heading, $style.multi]">
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
-          <directions-walkIcon aria-hidden="true" />
+          <directions-walk-icon aria-hidden="true" />
         </span>
         {{ $t('ご高齢な方') }}
       </span>

--- a/components/flow/FlowSpElder.vue
+++ b/components/flow/FlowSpElder.vue
@@ -3,19 +3,19 @@
     <div :class="[$style.heading, $style.multi]">
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
-          <DirectionsWalkIcon aria-hidden="true" />
+          <directions-walkIcon aria-hidden="true" />
         </span>
         {{ $t('ご高齢な方') }}
       </span>
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
-          <AccessibleIcon aria-hidden="true" />
+          <accessible-icon aria-hidden="true" />
         </span>
         {{ $t('基礎疾患のある方') }}
       </span>
       <span :class="[$style.item, $style.fzMedium]">
         <span :class="$style.icon">
-          <PregnantWomanIcon aria-hidden="true" />
+          <pregnant-woman-icon aria-hidden="true" />
         </span>
         {{ $t('妊娠中の方') }}
       </span>
@@ -80,7 +80,7 @@
       :class="[$style.button, $style.clickable]"
     >
       <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
-      <ArrowForwardIcon :class="$style.icon" />
+      <arrow-forward-icon :class="$style.icon" />
     </a>
   </div>
 </template>

--- a/components/flow/FlowSpGeneral.vue
+++ b/components/flow/FlowSpGeneral.vue
@@ -2,7 +2,7 @@
   <div :class="$style.container">
     <p :class="$style.heading">
       <span :class="[$style.icon, $style.top]" aria-hidden="true">
-        <HumanIcon />
+        <human-icon />
       </span>
       <span :class="$style.fzMedium">{{ $t('一般の方') }}</span>
     </p>
@@ -62,7 +62,7 @@
       :class="[$style.button, $style.clickable]"
     >
       <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
-      <ArrowForwardIcon :class="$style.icon" />
+      <arrow-forward-icon :class="$style.icon" />
     </a>
   </div>
 </template>

--- a/components/flow/FlowSpHospitalized.vue
+++ b/components/flow/FlowSpHospitalized.vue
@@ -2,7 +2,7 @@
   <div id="hospitalized" :class="$style.container">
     <p :class="$style.heading">
       <span :class="[$style.icon, $style.top]">
-        <HotelIcon aria-hidden="true" />
+        <hotel-icon aria-hidden="true" />
       </span>
       <span :class="$style.fzMedium">{{ $t('入院となります') }}</span>
     </p>

--- a/components/flow/FlowSpPast.vue
+++ b/components/flow/FlowSpPast.vue
@@ -125,7 +125,7 @@
       :class="[$style.button, $style.clickable]"
     >
       <span :class="$style.text">{{ $t('新型コロナ受診相談窓口へ') }}</span>
-      <ArrowForwardIcon :class="$style.icon" />
+      <arrow-forward-icon :class="$style.icon" />
     </a>
   </div>
 </template>

--- a/components/flow/FlowSpSuspect.vue
+++ b/components/flow/FlowSpSuspect.vue
@@ -2,7 +2,7 @@
   <div :class="$style.container">
     <p :class="$style.heading">
       <span :class="[$style.icon, $style.top]">
-        <SentimentIcon aria-hidden="true" />
+        <sentiment-icon aria-hidden="true" />
       </span>
       <span :class="$style.fzMedium">{{ $t('不安に思う方') }}</span>
     </p>
@@ -28,7 +28,7 @@
       </p>
       <p :class="[$style.phone, $style.fzNumeric]">
         <span :class="$style.icon">
-          <PhoneIcon alt="Phone" />
+          <phone-icon alt="Phone" />
         </span>
         <a href="tel:0570550571">0570-550571</a>
       </p>
@@ -43,7 +43,7 @@
       :class="[$style.button, $style.clickable]"
     >
       <span :class="$style.text">{{ $t('専門的な助言が必要な場合') }}</span>
-      <ArrowForwardIcon :class="$style.icon" />
+      <arrow-forward-icon :class="$style.icon" />
     </a>
   </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -8,7 +8,7 @@
     </v-overlay>
     <div v-if="hasNavigation" class="appContainer">
       <div class="naviContainer">
-        <SideNavigation
+        <side-navigation
           :is-navi-open="isOpenNavigation"
           :class="{ open: isOpenNavigation }"
           @openNavi="openNavigation"
@@ -26,7 +26,7 @@
         <nuxt />
       </v-container>
     </div>
-    <NoScript />
+    <no-script />
     <development-mode-mark />
   </v-app>
 </template>
@@ -34,8 +34,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
-import Data from '@/data/data.json'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
+import Data from '@/data/data.json'
 import SideNavigation from '@/components/SideNavigation.vue'
 import NoScript from '@/components/NoScript.vue'
 import DevelopmentModeMark from '@/components/DevelopmentModeMark.vue'

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -13,9 +13,9 @@
         }}
       </p>
       <div class="Error-ButtonContainer">
-        <NuxtLink :to="localePath('/')" class="Error-Button">
+        <nuxt-link :to="localePath('/')" class="Error-Button">
           {{ $t('トップページへ戻る') }}
-        </NuxtLink>
+        </nuxt-link>
       </div>
     </div>
   </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -3,7 +3,7 @@
     <page-header class="mb-3">
       {{ $t('当サイトについて') }}
     </page-header>
-    <StaticCard>
+    <static-card>
       {{
         $t(
           '当サイトは新型コロナウイルス感染症 (COVID-19) に関する最新情報を提供するために、東京都が開設したものです。'
@@ -15,8 +15,8 @@
           '東京都による公式情報と客観的な数値をわかりやすく伝えることで、東京都にお住まいの方や、東京都内に拠点を持つ企業の方、東京都を訪れる方が、現状を把握して適切な対策を取れるようにすることを目的としています。'
         )
       }}
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('ブラウザ環境について') }}</h3>
       <p>
         {{ $t('当サイトは以下の環境でご覧いただくことを推奨いたします。') }}
@@ -40,12 +40,12 @@
           }}
         </span>
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('当サイトへのリンクについて') }}</h3>
       <p>{{ $t('当サイトへのリンクは自由です。') }}</p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('JavaScriptについて') }}</h3>
       <p>
         {{ $t('当サイトではJavaScriptを使用しております。') }}<br />
@@ -60,8 +60,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('クッキー (Cookie) について') }}</h3>
       <p>
         {{ $t('当サイトの一部ではクッキーを使用しています。') }}<br />
@@ -85,8 +85,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('Google Analyticsの利用について') }}</h3>
       <p>
         {{
@@ -165,8 +165,8 @@
           </a>
         </template>
       </i18n>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('免責事項') }}</h3>
       <p>
         {{
@@ -189,8 +189,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('データについて') }}</h3>
       <i18n
         tag="p"
@@ -206,8 +206,8 @@
           </a>
         </template>
       </i18n>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('ソースコードについて') }}</h3>
       <p>
         {{
@@ -227,7 +227,7 @@
           </template>
         </i18n>
       </p>
-    </StaticCard>
+    </static-card>
   </div>
 </template>
 

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="Flow">
     <div class="Flow-Heading">
-      <CovidIcon aria-hidden="true" />
+      <covid-icon aria-hidden="true" />
       <page-header class="Flow-Heading-Title">
         {{ $t('新型コロナウイルス感染症が心配なときに') }}
       </page-header>
-      <PrinterButton :wrapper-class="'Flow-PullRight'" to="/print/flow" />
+      <printer-button :wrapper-class="'Flow-PullRight'" to="/print/flow" />
     </div>
     <div>
       <div class="Flow-Card-Button-Wrapper">

--- a/pages/parent.vue
+++ b/pages/parent.vue
@@ -3,7 +3,7 @@
     <page-header class="mb-3">
       {{ $t('臨時休校中の新型コロナウイルス感染症対応についてのお願い') }}
     </page-header>
-    <StaticCard>
+    <static-card>
       <h3>
         <a
           href="https://www.kyoiku.metro.tokyo.lg.jp/school/content/learning_support.html"
@@ -12,8 +12,8 @@
           >{{ $t('学びの支援サイト') }}</a
         >
       </h3>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('感染予防・健康管理') }}</h3>
       <ul>
         <li>
@@ -41,8 +41,8 @@
           }}
         </li>
       </ul>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('感染症を疑う場合の対応') }}</h3>
       <ul>
         <li>{{ $t('各保健所にご相談ください') }}</li>
@@ -57,11 +57,11 @@
           >
         </li>
       </ul>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>{{ $t('その他.parent') }}</h3>
       <p>{{ $t('詳細は、各学校からのお知らせ等をご確認ください。') }}</p>
-    </StaticCard>
+    </static-card>
   </div>
 </template>
 

--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -3,7 +3,7 @@
     <page-header class="mb-3">
       {{ $t('企業の皆様・はたらく皆様へ') }}
     </page-header>
-    <StaticCard>
+    <static-card>
       <h3>
         <a
           href="http://www.sangyo-rodo.metro.tokyo.jp/chushou/kinyu/yuushi/yuushi/new"
@@ -19,8 +19,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.tokyo-kosha.or.jp/topics/2003/0001.html"
@@ -36,8 +36,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.tokyo-kosha.or.jp/support/josei/jigyo/kinkyu.html"
@@ -55,8 +55,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.hataraku.metro.tokyo.jp/kansensyo/index.html"
@@ -72,8 +72,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.hataraku.metro.tokyo.jp/kansensyo/index.html"
@@ -91,8 +91,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.hataraku.metro.tokyo.jp/kansensyo/index.html"
@@ -108,8 +108,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.hataraku.metro.tokyo.jp/kansensyo/index.html"
@@ -125,8 +125,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.shigotozaidan.or.jp/koyo-kankyo/joseikin/kinkyutaisaku.html"
@@ -142,8 +142,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://tokyo-telework.jp/"
@@ -159,8 +159,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="http://www.sangyo-rodo.metro.tokyo.jp/attention/2020/0305_13201.html"
@@ -172,8 +172,8 @@
       <p>
         {{ $t('資金繰りに関する相談、経営に関する相談') }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="http://www.sangyo-rodo.metro.tokyo.jp/attention/2020/0305_13201.html"
@@ -187,8 +187,8 @@
           $t('資金繰りに関する相談、経営に関する相談（契約におけるトラブル等）')
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://www.hataraku.metro.tokyo.lg.jp/sodan/sodan/index.html"
@@ -204,8 +204,8 @@
           )
         }}
       </p>
-    </StaticCard>
-    <StaticCard>
+    </static-card>
+    <static-card>
       <h3>
         <a
           href="https://smooth-biz.metro.tokyo.lg.jp/"
@@ -223,7 +223,7 @@
           )
         }}
       </p>
-    </StaticCard>
+    </static-card>
   </div>
 </template>
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3108

## ⛏ 変更内容 / Details of Changes
- ケバブケースとキャメルケースが混在していたコンポーネントタグをケバブケースに統一
- 対象となるタグ（正規表現 `/<[A-Z]/` でgrep）
  - EarthIcon
  - SelectMenuIcon
  - PrinterWhiteIcon
  - PrinterIcon
  - LanguageSelector
  - MenuList
  - GreenArrow
  - Arrow
  - House
  - Apartment
  - DirectionsWalkIcon
  - AccessibleIcon
  - PregnantWomanIcon
  - ArrowForwardIcon
  - HumanIcon
  - HotelIcon
  - SentimentIcon
  - PhoneIcon
  - SideNavigation
  - NoScript
  - NuxtLink
  - StaticCard
  - CovidIcon
  - PrinterButton

## 📸 スクリーンショット / Screenshots
コードのリファクタリングなのでスクリーンショットはありません。
