### PR TITLE
noscriptの時の表示を見やすくしました

### DIFF
--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- eslint-disable vue/html-indent -->
   <noscript inline-template>
-    <div class="noscript">
+    <div>
       <style>
         .loader {
           display: none;
@@ -9,11 +9,17 @@
         .v-overlay {
           display: none;
         }
+        @media screen and (max-width: 600px) {
+          .appContainer {
+            margin-bottom: 150px;
+          }
+        }
+        @media screen and (min-width: 601px) {
+          .appContainer {
+            margin-top: 100px;
+          }
+        }
       </style>
-      <div class="noscript-heading">
-        <img src="/logo.svg" :alt="$t('東京都')" />
-        {{ $t('新型コロナウイルス感染症') }}<br />{{ $t('対策サイト') }}
-      </div>
       <div class="noscript-body">
         {{ $t('当サイトではJavaScriptを使用しております。') }}<br />
         {{
@@ -33,26 +39,27 @@
 </template>
 
 <style lang="scss" scoped>
-.noscript {
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  min-width: 310px;
-  max-width: 440px;
-  transform: translateY(-50%) translateX(-50%);
+@include lessThan($small) {
+  .noscript-body {
+    position: fixed;
+    bottom: 0;
+    color: rgba(0, 0, 0, 0.87);
+  }
 }
 
-.noscript-heading {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+@include largerThan($small) {
+  .noscript-body {
+    position: fixed;
+    top: 0;
+    margin-left: 240px;
+    width: calc(100% - 240px);
+  }
+}
 
-  @include font-size(13);
-
-  color: #898989;
-
-  img {
-    margin-right: 16px;
+@include largerThan($huge) {
+  .noscript-body {
+    margin-left: 324px;
+    width: calc(100% - 324px);
   }
 }
 
@@ -60,10 +67,10 @@
   @include font-size(13);
   @include card-container();
 
+  background-color: $emergency;
   border-radius: 4px;
-  margin-top: 16px;
   padding: 1em;
-  color: rgba(0, 0, 0, 0.87);
+  z-index: 3;
 }
 </style>
 

--- a/components/NoScript.vue
+++ b/components/NoScript.vue
@@ -60,6 +60,7 @@
   .noscript-body {
     margin-left: 324px;
     width: calc(100% - 324px);
+    max-width: 1100px;
   }
 }
 
@@ -67,7 +68,7 @@
   @include font-size(13);
   @include card-container();
 
-  background-color: $emergency;
+  background-color: #ffe200;
   border-radius: 4px;
   padding: 1em;
   z-index: 3;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2789 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- Noscriptの東京都の画像を消去
- 背景を黄色に変更
- モバイル時は下部の表示
- デスクトップ時は上部に表示

## 📸 スクリーンショット / Screenshots
変更前
![Screenshot from 2020-04-11 21-03-26](https://user-images.githubusercontent.com/11341768/79042182-dca47680-7c38-11ea-8f9e-747009c8c0e0.png)
![Screenshot from 2020-04-11 21-03-43](https://user-images.githubusercontent.com/11341768/79042185-df9f6700-7c38-11ea-880b-2f60755e72fb.png)
変更後
![Screenshot from 2020-04-11 21-04-14](https://user-images.githubusercontent.com/11341768/79042189-e4641b00-7c38-11ea-8a12-2ec8fb4710aa.png)
![Screenshot from 2020-04-11 21-04-36](https://user-images.githubusercontent.com/11341768/79042190-e6c67500-7c38-11ea-897a-948670e2066f.png)
