### PR TITLE
[ruby] グラフ凡例のルビ対応

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -5,6 +5,27 @@
         <slot name="description" />
       </small>
     </template>
+    <ul
+      :class="$style.GraphLegend"
+      :style="{ display: canvas ? 'block' : 'none' }"
+    >
+      <li v-for="(item, i) in agencies" :key="i" @click="onClickLegend(i)">
+        <button>
+          <div
+            :style="{
+              backgroundColor: colors[i].fillColor,
+              borderColor: colors[i].strokeColor
+            }"
+          />
+          <t-i18n
+            :style="{
+              textDecoration: displayLegends[i] ? 'none' : 'line-through'
+            }"
+            >{{ item }}</t-i18n
+          >
+        </button>
+      </li>
+    </ul>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
@@ -14,6 +35,7 @@
       :chart-id="chartId"
       :chart-data="displayData"
       :options="displayOption"
+      :display-legends="displayLegends"
       :height="240"
     />
     <v-data-table
@@ -32,17 +54,6 @@
   </data-view>
 </template>
 
-<style module lang="scss">
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    font-size: 12px;
-    color: $gray-3;
-  }
-}
-</style>
-
 <script lang="ts">
 import Vue from 'vue'
 import VueI18n from 'vue-i18n'
@@ -50,11 +61,12 @@ import { ChartOptions } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
-import { getGraphSeriesStyle } from '@/utils/colors'
-import type { DisplayData, DataSets } from '@/plugins/vue-chart';
+import TI18n from '@/components/TI18n.vue'
+import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
+import { DisplayData, DataSets } from '@/plugins/vue-chart'
 
 interface AgencyDataSets extends DataSets {
-  label: string;
+  label: string
 }
 interface AgencyDisplayData extends DisplayData {
   datasets: AgencyDataSets[]
@@ -68,8 +80,12 @@ type Data = {
   chartData: typeof agencyData
   date: string
   agencies: VueI18n.TranslateResult[]
+  displayLegends: boolean[]
+  colors: SurfaceStyle[]
 }
-type Methods = {}
+type Methods = {
+  onClickLegend: (i: number) => void
+}
 type Computed = {
   displayData: AgencyDisplayData
   displayOption: ChartOptions
@@ -98,7 +114,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView },
+  components: { DataView, TI18n },
   props: {
     title: {
       type: String,
@@ -132,20 +148,21 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       canvas: true,
       chartData: agencyData,
       date: agencyData.date,
-      agencies
+      agencies,
+      displayLegends: [true, true, true],
+      colors: getGraphSeriesStyle(agencyData.datasets.length)
     }
   },
   computed: {
     displayData() {
-      const graphSeries = getGraphSeriesStyle(this.chartData.datasets.length)
       return {
-        labels: this.chartData.labels as string[],
+        labels: this.chartData.labels,
         datasets: this.chartData.datasets.map((item, index) => {
           return {
             label: this.agencies[index] as string,
             data: item.data,
-            backgroundColor: graphSeries[index].fillColor,
-            borderColor: graphSeries[index].strokeColor,
+            backgroundColor: this.colors[index].fillColor,
+            borderColor: this.colors[index].strokeColor,
             borderWidth: 1
           }
         })
@@ -173,16 +190,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           }
         },
         legend: {
-          display: true,
-          onHover: (e: HTMLElementEvent<HTMLInputElement>) => {
-            e.currentTarget!.style!.cursor = 'pointer'
-          },
-          onLeave: (e: HTMLElementEvent<HTMLInputElement>) => {
-            e.currentTarget!.style!.cursor = 'default'
-          },
-          labels: {
-            boxWidth: 20
-          }
+          display: false
         },
         scales: {
           xAxes: [
@@ -241,6 +249,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       })
     }
   },
+  methods: {
+    onClickLegend(i) {
+      this.displayLegends[i] = !this.displayLegends[i]
+      this.displayLegends = this.displayLegends.slice()
+    }
+  },
   mounted() {
     const barChart = this.$refs.barChart as Vue
     const barElement = barChart.$el
@@ -256,3 +270,48 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
 export default Vue.extend(options)
 </script>
+
+<style module lang="scss">
+.Graph {
+  &Desc {
+    width: 100%;
+    margin: 0;
+    margin-bottom: 0 !important;
+    padding-left: 0 !important;
+    font-size: 12px;
+    color: $gray-3;
+    list-style: none;
+  }
+  &Legend {
+    text-align: center;
+    list-style: none;
+    padding: 0 !important;
+    li {
+      display: inline-block;
+      margin: 0 3px;
+      div {
+        height: 12px;
+        margin: 2px 4px;
+        width: 40px;
+        display: inline-block;
+        vertical-align: middle;
+        border-width: 1px;
+        border-style: solid;
+      }
+      button {
+        color: $gray-3;
+        font-size: 12px;
+      }
+    }
+  }
+}
+
+.DataView {
+  &Desc {
+    margin-top: 10px;
+    margin-bottom: 0 !important;
+    font-size: 12px;
+    color: $gray-3;
+  }
+}
+</style>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -40,11 +40,11 @@
               borderColor: colors[i].strokeColor
             }"
           />
-          <span
+          <t-i18n
             :style="{
               textDecoration: displayLegends[i] ? 'none' : 'line-through'
             }"
-            >{{ item }}</span
+            >{{ item }}</t-i18n
           >
         </button>
       </li>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3153

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 「検査実施件数」「都庁来庁者数の推移」の凡例にルビをふりました
  - 実装については既存のものを参考にしました https://github.com/tokyo-metropolitan-gov/covid19/issues/2764#issuecomment-610388513

## 📸 スクリーンショット / Screenshots
### 検査実施件数
![スクリーンショット 2020-04-12 10 16 45](https://user-images.githubusercontent.com/5207601/79058281-00060a80-7ca7-11ea-8a34-b176dd0668e8.png)

### 都庁来庁者数の推移
![スクリーンショット 2020-04-12 10 16 51](https://user-images.githubusercontent.com/5207601/79058282-01373780-7ca7-11ea-8a35-e5b6a2c6dd4f.png)