### PR TITLE
「陽性患者の属性」テーブルで使用されている全角ダッシュを翻訳対象から外す

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -68,10 +68,11 @@ export default {
   },
   methods: {
     getTranslatedWording(value) {
-      if (value === '-' || value === '‐' || value == null) {
+      if (value === '-' || value === '‐' || value === '―' || value == null) {
         // 翻訳しようとしている文字列が以下のいずれかだった場合、翻訳しない
         // - 全角のハイフン
         // - 半角のハイフン
+        // - 全角のダッシュ
         // - null
         return value
       }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #3177
  - Issueを根本的に解決するPRではありません

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性患者の属性」テーブルに含まれる全角ダッシュを翻訳しないようにした
  - #2749 で当時「陽性患者の属性」テーブルで使用されていたハイフンについては翻訳対象から外された
  - この後にハイフンに加えて全角ダッシュが用いられるようになったため、vue-i18nの警告が発生している

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
なし