### PR TITLE
Docker, Vagrant を利用時，軽量モードでのサーバー起動をデフォルトとする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY . $PROJECT_ROOTDIR
 EXPOSE 3000
 ENV HOST 0.0.0.0
 
-CMD ["yarn", "dev"]
+CMD ["yarn", "dev-no-axe"]

--- a/FOR_DEVELOPERS.md
+++ b/FOR_DEVELOPERS.md
@@ -70,6 +70,8 @@ $ yarn dev-no-axe
 #### 2-2-1. 依存関係を構築し、プログラムを実行する
 
 以下のコマンドを実行した後、 http://localhost:3000 にアクセスすると、開発中のプログラムを確認する事ができます。
+
+デフォルトで軽量モードで起動するように `Dockerfile` を設定しています。
 ```bash
 # serve with hot reload at localhost:3000
 $ docker-compose up --build
@@ -90,6 +92,8 @@ $ docker-compose run --rm app yarn install
 #### 2-3-1. 依存関係を構築し、プログラムを実行する
 
 以下のコマンドを実行した後、 http://localhost:3000 にアクセスすると、開発中のプログラムを確認する事ができます。
+
+デフォルトで軽量モードで起動するように `vagrant_provision.sh` を設定しています。
 ```bash
 # serve with hot reload at localhost:3000
 $ vagrant up
@@ -124,7 +128,7 @@ $ docker-compose run --rm app yarn install
 
 ## 3. 本番環境/その他の判定
 
-`process.env.GENERATE_ENV` の値が、本番の場合は`'production'`に、それ以外の場合は `'development'` になっています。  
+`process.env.GENERATE_ENV` の値が、本番の場合は`'production'`に、それ以外の場合は `'development'` になっています。
 テスト環境のみで実行したい処理がある場合は、こちらの値をご利用ください。
 
 ---
@@ -143,7 +147,7 @@ $ docker-compose run --rm app yarn install
 
 ## 5. ブランチルール
 
-development 以外は、Pull Request は禁止です。  
+development 以外は、Pull Request は禁止です。
 Pull Request を送る際のブランチは、以下のネーミングルールに従ったブランチにしてください。
 
 | 種類 | ブランチのネーミングルール |

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -26,7 +26,7 @@ yarn install
 cat << EOF > /home/vagrant/covid19.sh
 #!/bin/bash
 cd /home/vagrant/covid19
-HOST=0.0.0.0 /usr/bin/yarn dev
+HOST=0.0.0.0 /usr/bin/yarn dev-no-axe
 EOF
 
 # systemd定義


### PR DESCRIPTION
#2689  👏 解決する issue / Resolved Issues
- close #3212

## ⛏ 変更内容 / Details of Changes
- `yarn dev` を実行するとページの表示までに時間がかかるため，実際に開発に使用するのはほぼ `yarn dev-no-axe` と思われる．
  - `yarn dev-no-axe` を使うことを Docker, Vagrant 利用時のデフォルトとしたいため，`Dockefile`, `vagrant_provision.sh` を書き換える．
 xxx
