### PR TITLE
y軸固定グラフ 軸と本体とで suggestedMax は同じ値で固定

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -401,6 +401,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               },
               ticks: {
                 suggestedMin: 0,
+                suggestedMax: this.scaledTicksYAxisMax,
                 maxTicksLimit: 8,
                 fontColor: '#808080'
               }
@@ -446,7 +447,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options: Chart.ChartOptions = {
         responsive: false,
         maintainAspectRatio: false,
@@ -524,7 +524,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080', // #808080
-                suggestedMax: scaledTicksYAxisMax
+                suggestedMax: this.scaledTicksYAxisMax
               }
             }
           ]


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3202 

## ⛏ 変更内容 / Details of Changes
- 上述Issue「TimeStackedBarChartにおいて、一部の凡例を消すと目盛りがずれる」の修正
  （凡例の選択状況によらずy軸のラベルは固定する）