### PR TITLE
fix: テーブルのデータを日付の降順で表示する

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -80,6 +80,7 @@ import Vue from 'vue'
 import { TranslateResult } from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { Chart } from 'chart.js'
+import dayjs from 'dayjs'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
@@ -487,13 +488,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     tableData() {
       return this.chartData
         .map((d, _) => {
-          return Object.assign(
-            { text: d.label },
-            { transition: d.transition.toLocaleString() },
-            { cumulative: d.cumulative.toLocaleString() }
-          )
+          return {
+            text: d.label,
+            transition: d.transition.toLocaleString(),
+            cumulative: d.cumulative.toLocaleString()
+          }
         })
-        .sort((a, b) => (a.text > b.text ? -1 : 1))
+        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
+        .reverse()
     }
   },
   methods: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -114,6 +114,7 @@ import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { TranslateResult } from 'vue-i18n'
 import { Chart } from 'chart.js'
+import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
@@ -323,7 +324,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             })
           )
         })
-        .sort((a, b) => (a.text > b.text ? -1 : 1))
+        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
+        .reverse()
     },
     displayOption() {
       const unit = this.unit

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -50,8 +50,8 @@ export default (data: DataType[]) => {
     }
     tableDate.datasets.push(TableRow)
   })
-  tableDate.datasets.sort((a, b) =>
-    a.公表日 === b.公表日 ? 0 : a.公表日 < b.公表日 ? 1 : -1
-  )
+  tableDate.datasets
+    .sort((a, b) => dayjs(a.公表日).unix() - dayjs(b.公表日).unix())
+    .reverse()
   return tableDate
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3259

## 📝 関連する issue / Related Issues
- #2447 （PR）

## ⛏ 変更内容 / Details of Changes
- テーブルのデータを日付の降順で表示するように修正しました

## 📸 スクリーンショット / Screenshots
### 検査実施件数
![スクリーンショット 2020-04-14 10 35 45](https://user-images.githubusercontent.com/5207601/79176734-f9f56280-7e3b-11ea-9769-254cea5742d3.png)

### 陽性患者の属性
![スクリーンショット 2020-04-14 10 37 58](https://user-images.githubusercontent.com/5207601/79176751-08dc1500-7e3c-11ea-8e2e-fa50b1d0c640.png)