### PR TITLE
[ruby] 当サイトについてのルビタグ生成エラー修正

### DIFF
--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -88,8 +88,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         const texts = this.createRubyTexts(node.text)
         return createRubyNode(texts)
       }
-      const vnodes = node.children!.map(node => createVNode(node))
-      return createElement(node.tag, node.data, vnodes)
+      if (node.children) {
+        const vnodes = node.children.map(node => createVNode(node))
+        return createElement(node.tag, node.data, vnodes)
+      }
+      return node
     }
 
     return createVNode(slot)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3297 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 「当サイトについて」で一部ルビが振られていない文章があったので、ルビを振りました

## 📸 スクリーンショット / Screenshots

### Before
![スクリーンショット 2020-04-14 20 59 28](https://user-images.githubusercontent.com/5207601/79222709-00fb8f80-7e93-11ea-8309-1929dca174a1.png)

### After
![スクリーンショット 2020-04-14 20 59 34](https://user-images.githubusercontent.com/5207601/79222715-035de980-7e93-11ea-8ed7-9c73d96e6901.png)

