### PR TITLE
[ruby] 陽性患者の属性 のテーブルのレンダリングでエラー修正

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -15,9 +15,9 @@
       :custom-sort="customSort"
       class="cardTable"
     >
-      <template v-slot:body="{ items }">
+      <template v-slot:body="slotProps">
         <tbody>
-          <tr v-for="item in items" :key="item.text">
+          <tr v-for="item in slotProps.items" :key="item.text">
             <th class="text-start">
               <t-i18n>{{ item['公表日'] }}</t-i18n>
             </th>

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -88,8 +88,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         const texts = this.createRubyTexts(node.text)
         return createRubyNode(texts)
       }
-      const vnodes = node.children!.map(node => createVNode(node))
-      return createElement(node.tag, node.data, vnodes)
+      if (node.children) {
+        const vnodes = node.children.map(node => createVNode(node))
+        return createElement(node.tag, node.data, vnodes)
+      }
+      return node
     }
 
     return createVNode(slot)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3292

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

- ~~`<TI18n>` に空の文字列や slot が渡された場合のエラーを解消しました~~
  - ~~陽性患者の属性で退院の列のように空になるところで `<TI18n>` が使われた場合の対応です。~~
  - ~~https://github.com/tokyo-metropolitan-gov/covid19/blob/c2e13ea922772c92d391b8b425f4d0aaea9c1814/components/DataTable.vue#L34~~
  - #3298 の修正で対応できた & そちらのほうが出力される Node がシンプルだったので、こちらのコードは削除しましたmm
- IE 11 に対応するために分割代入ではなく、スロットプロパティを渡すようにしました。

## 📸 スクリーンショット / Screenshots
Deploy Preview で Console に issue に起票したエラーなくページが表示されることと確認しました。
（表示されているエラーは Production でも出ているエラーです）

![スクリーンショット 2020-04-15 1 19 43](https://user-images.githubusercontent.com/5207601/79248811-492ca900-7eb7-11ea-9607-25c576fcd06d.png)
