### PR TITLE
「陽性患者の属性」表において、公表日、年代、更に性別と居住地も正しくソートされるように修正する

### DIFF
--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -92,8 +92,9 @@ export default {
           return 0
         }
 
-        // 「10歳未満」同士を比較する場合、そうでない場合に場合分け
         let comparison = 0
+
+        // 「10歳未満」同士を比較する場合、そうでない場合に場合分け
         if (
           index[0] === '年代' &&
           (a[index[0]] === lt10 || b[index[0]] === lt10)
@@ -101,6 +102,26 @@ export default {
           comparison = a[index[0]] === lt10 ? -1 : 1
         } else {
           comparison = String(a[index[0]]) < String(b[index[0]]) ? -1 : 1
+        }
+
+        // 公表日のソートを正しくする
+        if (index[0] === '公表日') {
+          // 2/29と3/1が正しくソートできないため、以下は使えない。
+          // 公表日に年まで含む場合は以下が使用可能になり、逆に今使用しているコードが使用不可能となる。
+          // comparison = new Date(a[index[0]]) < new Date(b[index[0]]) ? -1 : 1
+
+          const aDate = a[index[0]].split('/').map(d => {
+            return parseInt(d)
+          })
+          const bDate = b[index[0]].split('/').map(d => {
+            return parseInt(d)
+          })
+          comparison = aDate[1] > bDate[1] ? 1 : -1
+          if (aDate[0] > bDate[0]) {
+            comparison = 1
+          } else if (aDate[0] < bDate[0]) {
+            comparison = -1
+          }
         }
 
         return isDesc[0] ? comparison * -1 : comparison

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -83,9 +83,11 @@ export default {
 
       return this.$t(value)
     },
-    // '10歳未満' < '10代' となるようにソートする
     customSort(items, index, isDesc) {
       const lt10 = this.$t('10歳未満').toString()
+      const lt100 = this.$t('100歳以上').toString()
+      const unknown = this.$t('不明').toString()
+      const investigating = this.$t('調査中').toString()
       items.sort((a, b) => {
         // 両者が等しい場合は 0 を返す
         if (a[index[0]] === b[index[0]]) {
@@ -94,12 +96,18 @@ export default {
 
         let comparison = 0
 
-        // 「10歳未満」同士を比較する場合、そうでない場合に場合分け
+        // '10歳未満' < '10代' ... '90代' < '100歳以上' となるようにソートする
+        // 「10歳未満」同士を比較する場合、と「100歳以上」同士を比較する場合、更にそうでない場合に場合分け
         if (
           index[0] === '年代' &&
           (a[index[0]] === lt10 || b[index[0]] === lt10)
         ) {
           comparison = a[index[0]] === lt10 ? -1 : 1
+        } else if (
+          index[0] === '年代' &&
+          (a[index[0]] === lt100 || b[index[0]] === lt100)
+        ) {
+          comparison = a[index[0]] === lt100 ? 1 : -1
         } else {
           comparison = String(a[index[0]]) < String(b[index[0]]) ? -1 : 1
         }
@@ -122,6 +130,20 @@ export default {
           } else if (aDate[0] < bDate[0]) {
             comparison = -1
           }
+        }
+
+        // 「調査中」は年代に限らず、居住地にも存在するので、年代ソートの外に置いている。
+        // 内容としては、「不明」の次に高い(大きい)ものとして扱う。
+        // 日本語の場合、「調査中」は「不明」より低い(小さい)ものとして扱われるが、
+        // 他言語の場合はそうではないため、ここで統一している。
+        if (a[index[0]] === investigating || b[index[0]] === investigating) {
+          comparison = a[index[0]] === investigating ? 1 : -1
+        }
+
+        // 「不明」は年代に限らず、性別にも存在するので、年代ソートの外に置いている。
+        // 内容としては一番高い(大きい)ものとして扱う。
+        if (a[index[0]] === unknown || b[index[0]] === unknown) {
+          comparison = a[index[0]] === unknown ? 1 : -1
         }
 
         return isDesc[0] ? comparison * -1 : comparison


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3303 
- close #3320 

## 📝 関連する issue / Related Issues
- #3304 (PRです)

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 公表日、年代と性別、居住地のソートが正しくなるように修正
  ※性別と居住地に関しては、「不明」と「調査中」の扱いを含むためです。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
公表日
![image](https://user-images.githubusercontent.com/34832037/79240541-e33b2400-7eac-11ea-9efc-d12a175124fd.png)
年代
![image](https://user-images.githubusercontent.com/34832037/79327468-775dc780-7f4f-11ea-871a-3075d497925c.png)
