### PR TITLE
Fix 3021 DataSelector: btn to radio

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -8,6 +8,7 @@
   >
     <v-btn
       v-ripple="false"
+      input-type="radio"
       :aria-pressed="value === 'transition' ? 'true' : 'false'"
       value="transition"
       class="DataSelector-Button"
@@ -16,6 +17,7 @@
     </v-btn>
     <v-btn
       v-ripple="false"
+      input-type="radio"
       :aria-pressed="value === 'cumulative' ? 'true' : 'false'"
       value="cumulative"
       class="DataSelector-Button"
@@ -44,8 +46,10 @@
       background-color: inherit;
     }
 
-    &:focus {
-      outline: dotted $gray-3 1px;
+    &:hover {
+      outline-style: dotted;
+      outline-color: $gray-3;
+      outline-width: 1px;
     }
   }
 

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -26,10 +26,13 @@
 <style lang="scss">
 .DataSelector .v-input--radio-group__input {
   padding: 3px;
-  padding-left: 16px;
   border: 1px solid $gray-4;
   border-radius: 4px;
   align-items: stretch;
+
+  & .v-radio {
+    margin-right: inherit;
+  }
 
   & .v-label {
     display: block;
@@ -38,8 +41,7 @@
     border-radius: 4px;
     border-width: thin;
     box-shadow: none;
-    padding: 5px;
-    padding-bottom: 2px;
+    padding: 5px 18px 23px 18px;
     height: 24px;
     font-size: 12px;
     cursor: pointer;

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -1,61 +1,69 @@
 <template>
-  <v-btn-toggle
+  <v-radio-group
     :aria-controls="targetId"
     :value="value"
+    :column="false"
+    :row="true"
     class="DataSelector"
-    mandatory
+    mandatory="mandatory"
     @change="$emit('input', $event)"
   >
-    <v-btn
-      v-ripple="false"
-      input-type="radio"
-      :aria-pressed="value === 'transition' ? 'true' : 'false'"
+    <v-radio
+      :ripple="false"
+      :aria-checked="value === 'transition' ? 'true' : 'false'"
       value="transition"
-      class="DataSelector-Button"
-    >
-      {{ $t('日別') }}
-    </v-btn>
-    <v-btn
-      v-ripple="false"
-      input-type="radio"
-      :aria-pressed="value === 'cumulative' ? 'true' : 'false'"
+      :label="$t('日別')"
+    />
+    <v-radio
+      :ripple="false"
+      :aria-checked="value === 'cumulative' ? 'true' : 'false'"
       value="cumulative"
-      class="DataSelector-Button"
-    >
-      {{ $t('累計') }}
-    </v-btn>
-  </v-btn-toggle>
+      :label="$t('累計')"
+    />
+  </v-radio-group>
 </template>
 
 <style lang="scss">
-.DataSelector {
-  margin-top: 20px;
+.DataSelector .v-input--radio-group__input {
+  padding: 3px;
+  padding-left: 16px;
   border: 1px solid $gray-4;
-  background-color: $white;
+  border-radius: 4px;
+  align-items: stretch;
 
-  &-Button {
-    border: none !important;
-    margin: 2px;
-    border-radius: 4px !important;
-    height: 24px !important;
-    font-size: 12px !important;
-    color: $gray-1 !important;
-    background-color: $white !important;
-
-    &::before {
-      background-color: inherit;
-    }
+  & .v-label {
+    display: block;
+    line-height: normal;
+    border: 1px solid $white;
+    border-radius: 4px;
+    border-width: thin;
+    box-shadow: none;
+    padding: 5px;
+    padding-bottom: 2px;
+    height: 24px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: 0.1s;
+    color: $gray-1;
+    background-color: $white;
+    justify-content: center;
 
     &:hover {
-      outline-style: dotted;
-      outline-color: $gray-3;
-      outline-width: 1px;
+      opacity: 0.5;
+      outline: dotted $gray-3 1px;
+      border-radius: 4px;
+      color: $white;
+      background-color: $green-1;
     }
   }
 
-  & .v-btn--active {
-    background-color: $gray-2 !important;
-    color: $white !important;
+  & .v-input--selection-controls__input {
+    @include visually-hidden;
+  }
+
+  & .v-item--active .v-label {
+    background-color: $gray-2;
+    color: $white;
   }
 }
 </style>
@@ -73,8 +81,8 @@ export default Vue.extend({
     targetId: {
       type: String,
       default: (val: string | null) => {
-        // TODO: type は NullableString 型をとり、default: null とする
-        return val && val !== '' ? val : null
+        // TODO: type defaults to null when NullableString is in
+        return typeof val === 'string' && val !== '' ? val : null
       }
     }
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3021 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- (JA) グラフの日別／累計スイッチをラジオボタンに変更⇒日別／累計が相互に排他的であることをコード上で表現した
- (EN) Replaced specific web components from Button Group to Radio Button for graph toggle

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- (JA) 見た目上の大きな変更はありません。ただしボタンとラジオのデフォルト CSS の設定が異なるため、手書き設定でボタンのものに寄せています
- (EN) No major cosmetic changes but manual alignment of CSS settings toward `button` were done
![2020-04-16 105833](https://user-images.githubusercontent.com/10361533/79406783-eaf4e880-7fd2-11ea-8af4-6e82164b9139.png)

