### PR TITLE
[ruby] グラフのツールチップのルビ対応

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -40,54 +40,46 @@ img {
 }
 
 #chartjs-tooltip {
-  $size: 5px;
-
-  position: relative;
+  $border-size: 5px;
 
   &::before {
     content: '';
     position: absolute;
-    width: $size;
-    height: $size;
+    width: $border-size;
+    height: $border-size;
+    border-color: #000;
+    border-width: $border-size;
   }
 
-  &.left {
-    &::before {
-      top: calc(50% - #{$size});
-      right: $size * -1;
-      border-left: $size solid #000;
-      border-top: $size solid transparent;
-      border-bottom: $size solid transparent;
-    }
+  &.top::before {
+    bottom: 100%;
+    left: 50%;
+    border-bottom-style: solid;
+    border-left: solid transparent;
+    border-right: solid transparent;
   }
 
-  &.right {
-    &::before {
-      top: calc(50% - #{$size});
-      left: $size * -1;
-      border-right: $size solid #000;
-      border-top: $size solid transparent;
-      border-bottom: $size solid transparent;
-    }
+  &.bottom::before {
+    top: 100%;
+    left: 50%;
+    border-top-style: solid;
+    border-left: solid transparent;
+    border-right: solid transparent;
   }
 
-  &.top {
-    &::before {
-      bottom: 100%;
-      left: 50%;
-      border-bottom: $size solid #000;
-      border-left: $size solid transparent;
-      border-right: $size solid transparent;
-    }
+  &.right::before {
+    top: calc(50% - #{$border-size});
+    left: $border-size * -1;
+    border-right-style: solid;
+    border-top: solid transparent;
+    border-bottom: solid transparent;
   }
 
-  &.bottom {
-    &::before {
-      top: 100%;
-      left: 50%;
-      border-top: $size solid #000;
-      border-left: $size solid transparent;
-      border-right: $size solid transparent;
-    }
+  &.left::before {
+    top: calc(50% - #{$border-size});
+    right: $border-size * -1;
+    border-left-style: solid;
+    border-top: solid transparent;
+    border-bottom: solid transparent;
   }
 }

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -38,3 +38,21 @@ img {
   display: block !important;
   visibility: visible !important;
 }
+
+.chartjs-tooltip {
+  position: relative;
+
+  &::before {
+    $size: 5px;
+
+    content: '';
+    position: absolute;
+    top: calc(50% - #{$size});
+    left: $size * -1;
+    width: $size;
+    height: $size;
+    border-top: $size solid transparent;
+    border-bottom: $size solid transparent;
+    border-right: $size solid #000;
+  }
+}

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -39,20 +39,33 @@ img {
   visibility: visible !important;
 }
 
-.chartjs-tooltip {
+#chartjs-tooltip {
+  $size: 5px;
+
   position: relative;
 
   &::before {
-    $size: 5px;
-
     content: '';
     position: absolute;
     top: calc(50% - #{$size});
-    left: $size * -1;
     width: $size;
     height: $size;
     border-top: $size solid transparent;
     border-bottom: $size solid transparent;
-    border-right: $size solid #000;
+  }
+
+  &.left,
+  &.center:not(.right) {
+    &::before {
+      right: $size * -1;
+      border-left: $size solid #000;
+    }
+  }
+
+  &.right {
+    &::before {
+      left: $size * -1;
+      border-right: $size solid #000;
+    }
   }
 }

--- a/assets/global.scss
+++ b/assets/global.scss
@@ -47,25 +47,47 @@ img {
   &::before {
     content: '';
     position: absolute;
-    top: calc(50% - #{$size});
     width: $size;
     height: $size;
-    border-top: $size solid transparent;
-    border-bottom: $size solid transparent;
   }
 
-  &.left,
-  &.center:not(.right) {
+  &.left {
     &::before {
+      top: calc(50% - #{$size});
       right: $size * -1;
       border-left: $size solid #000;
+      border-top: $size solid transparent;
+      border-bottom: $size solid transparent;
     }
   }
 
   &.right {
     &::before {
+      top: calc(50% - #{$size});
       left: $size * -1;
       border-right: $size solid #000;
+      border-top: $size solid transparent;
+      border-bottom: $size solid transparent;
+    }
+  }
+
+  &.top {
+    &::before {
+      bottom: 100%;
+      left: 50%;
+      border-bottom: $size solid #000;
+      border-left: $size solid transparent;
+      border-right: $size solid transparent;
+    }
+  }
+
+  &.bottom {
+    &::before {
+      top: 100%;
+      left: 50%;
+      border-top: $size solid #000;
+      border-left: $size solid transparent;
+      border-right: $size solid transparent;
     }
   }
 }

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -200,7 +200,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               const title = self.$t(data.datasets![index].label!)
               const num = parseInt(tooltipItem.value!).toLocaleString()
               const unit = self.$t(self.unit)
-
               return `${title}: ${num} ${unit}`
             }
           }

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -186,9 +186,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const options: ChartOptions = {
         tooltips: {
           enabled: false,
-          custom: tooltipModel => {
-            customTooltip(this, tooltipModel)
-          },
+          custom: tooltipModel => customTooltip(this, tooltipModel),
           displayColors: false,
           callbacks: {
             title(tooltipItem) {

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -76,6 +76,7 @@ import DataView from '@/components/DataView.vue'
 import TI18n from '@/components/TI18n.vue'
 import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
 import { DisplayData, DataSets } from '@/plugins/vue-chart'
+import { customTooltip } from '@/utils/ruby'
 
 interface AgencyDataSets extends DataSets {
   label: string
@@ -184,6 +185,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const self = this
       const options: ChartOptions = {
         tooltips: {
+          enabled: false,
+          custom: tooltipModel => {
+            customTooltip(this, tooltipModel)
+          },
           displayColors: false,
           callbacks: {
             title(tooltipItem) {
@@ -197,6 +202,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               const title = self.$t(data.datasets![index].label!)
               const num = parseInt(tooltipItem.value!).toLocaleString()
               const unit = self.$t(self.unit)
+
               return `${title}: ${num} ${unit}`
             }
           }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -60,6 +60,7 @@ import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import ExternalLink from '@/components/ExternalLink.vue'
 import { DisplayData } from '@/plugins/vue-chart'
+import { customTooltip } from '@/utils/ruby'
 
 interface HTMLElementEvent<T extends HTMLElement> extends MouseEvent {
   currentTarget: T
@@ -232,7 +233,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ]
         },
         tooltips: {
-          displayColors: false,
+          enabled: false,
+          custom: tooltipModel => customTooltip(this, tooltipModel),
           callbacks: {
             title: self.tooltipsTitle,
             label: self.tooltipsLabel

--- a/components/TI18n.vue
+++ b/components/TI18n.vue
@@ -1,18 +1,12 @@
 <script lang="ts">
 import Vue, { VNode } from 'vue'
-import XRegExp from 'xregexp/'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import { createRubyObject, RubyText } from '@/utils/ruby'
 
-type RubyText = {
-  ja: string
-  kana?: string
-}
 type Data = {
   locale: string
 }
-type Methods = {
-  createRubyTexts: (text: string) => RubyText[]
-}
+type Methods = {}
 type Computed = {}
 type Props = {}
 
@@ -26,26 +20,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   data() {
     return {
       locale: ''
-    }
-  },
-  methods: {
-    createRubyTexts(text) {
-      let match: RegExpExecArray | null
-      let lastText: string
-      let pos = 0
-      const texts: RubyText[] = []
-      const regp = /([\p{sc=Han}|\s|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/gu
-
-      // ふりがなを含んだ文字列をパースしてオブジェクトを生成
-      while ((match = XRegExp.exec(text, regp, pos))) {
-        if (match.index > 0) {
-          texts.push({ ja: match.input.slice(pos, match.index) })
-        }
-        texts.push({ ja: match[1], kana: match[2] })
-        pos = match.index + match[0].length
-      }
-      if ((lastText = text.slice(pos))) texts.push({ ja: lastText })
-      return texts
     }
   },
   mounted() {
@@ -85,7 +59,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
     const createVNode = (node: VNode): VNode => {
       if (node.text) {
-        const texts = this.createRubyTexts(node.text)
+        const texts = createRubyObject(node.text)
         return createRubyNode(texts)
       }
       if (node.children) {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -87,6 +87,7 @@ import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { customTooltip } from '@/utils/ruby'
 
 import { getGraphSeriesStyle } from '@/utils/colors'
 
@@ -267,7 +268,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options: Chart.ChartOptions = {
         tooltips: {
-          displayColors: false,
+          enabled: false,
+          custom: tooltipModel => customTooltip(this, tooltipModel),
           callbacks: {
             label(tooltipItem) {
               const labelText = `${parseInt(

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -125,6 +125,7 @@ import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import TI18n from '@/components/TI18n.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
+import { customTooltip } from '@/utils/ruby'
 
 interface HTMLElementEvent<T extends HTMLElement> extends MouseEvent {
   currentTarget: T
@@ -342,7 +343,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const cumulativeSumArray = this.eachArraySum(cumulativeData)
       const options: Chart.ChartOptions = {
         tooltips: {
-          displayColors: false,
+          enabled: false,
+          custom: tooltipModel => customTooltip(this, tooltipModel),
           callbacks: {
             label: tooltipItem => {
               let casesTotal, cases

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -141,7 +141,13 @@ const config: Configuration = {
             './node_modules/vuetify/dist/vuetify.js',
             './node_modules/vue-spinner/src/ScaleLoader.vue'
           ],
-          whitelist: ['html', 'body', 'nuxt-progress', 'DataCard'],
+          whitelist: [
+            'html',
+            'body',
+            'nuxt-progress',
+            'DataCard',
+            'chartjs-tooltip'
+          ],
           whitelistPatterns: [/(col|row)/]
         })
       ]

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -1,0 +1,25 @@
+import XRegExp from 'xregexp/'
+
+export type RubyText = {
+  ja: string
+  kana?: string
+}
+
+export const createRubyObject = (text: string) => {
+  let match: RegExpExecArray | null
+  let lastText: string
+  let pos = 0
+  const texts: RubyText[] = []
+  const regp = /([\p{sc=Han}|\s|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/gu
+
+  // ふりがなを含んだ文字列をパースしてオブジェクトを生成
+  while ((match = XRegExp.exec(text, regp, pos))) {
+    if (match.index > 0) {
+      texts.push({ ja: match.input.slice(pos, match.index) })
+    }
+    texts.push({ ja: match[1], kana: match[2] })
+    pos = match.index + match[0].length
+  }
+  if ((lastText = text.slice(pos))) texts.push({ ja: lastText })
+  return texts
+}

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -1,4 +1,6 @@
 import XRegExp from 'xregexp/'
+import Vue from 'vue'
+import { ChartTooltipModel } from 'chart.js'
 
 export type RubyText = {
   ja: string
@@ -24,11 +26,15 @@ export const createRubyObject = (text: string) => {
   return texts
 }
 
-export const customTooltip = (self: any, tooltipModel: any) => {
+interface TooltipModel extends ChartTooltipModel {
+  title?: string
+}
+
+export const customTooltip = (self: Vue, tooltipModel: TooltipModel) => {
   // Tooltip Element
   let tooltipEl = document.getElementById('chartjs-tooltip')
-  let titleEl = tooltipEl?.querySelector('.chartjs-tooltip-title')
-  let bodyEl = tooltipEl?.querySelector('.chartjs-tooltip-body')
+  let titleEl: HTMLElement | null
+  let bodyEl: HTMLElement | null
 
   // Create element on first render
   if (!tooltipEl) {
@@ -38,79 +44,61 @@ export const customTooltip = (self: any, tooltipModel: any) => {
   }
 
   if (tooltipModel.opacity === 0) {
-    tooltipEl.style.opacity = 0
+    tooltipEl.style.opacity = '0'
     return
   }
 
-  if (!titleEl) {
+  if ((titleEl = tooltipEl.querySelector('.chartjs-tooltip-title'))) {
+    titleEl!.textContent = ''
+  } else {
     titleEl = document.createElement('div')
     titleEl.classList.add('chartjs-tooltip-title')
     titleEl.style.fontFamily = tooltipModel._titleFontFamily
     titleEl.style.fontSize = tooltipModel.titleFontSize + 'px'
     titleEl.style.fontStyle = tooltipModel._titleFontStyle
     tooltipEl.appendChild(titleEl)
-  } else {
-    titleEl.textContent = ''
   }
 
-  if (!bodyEl) {
+  if ((bodyEl = tooltipEl.querySelector('.chartjs-tooltip-body'))) {
+    bodyEl!.textContent = ''
+  } else {
     bodyEl = document.createElement('div')
     bodyEl.classList.add('chartjs-tooltip-body')
     bodyEl.style.fontFamily = tooltipModel._bodyFontFamily
     bodyEl.style.fontSize = tooltipModel.bodyFontSize + 'px'
     bodyEl.style.fontStyle = tooltipModel._bodyFontStyle
-  } else {
-    bodyEl.textContent = ''
+    tooltipEl.appendChild(bodyEl)
   }
 
+  // titie
   const title = tooltipModel.title && tooltipModel.title[0]
-  if (!title) return
-  const t = createRubyObject(title as string)
 
-  t.forEach(a => {
-    let dom: HTMLElement
-    if (!a.kana) {
-      dom = document.createElement('span')
-      dom.textContent = a.ja
-    } else {
-      dom = document.createElement('ruby')
-      const rt = document.createElement('rt')
-      rt.textContent = a.kana || ''
-      dom.textContent = a.ja
-      dom.appendChild(rt)
-    }
-    titleEl.appendChild(dom)
-  })
+  if (title) {
+    createRubyObject(title).forEach(text => {
+      const dom = createDom(text)
+      titleEl!.appendChild(dom)
+    })
+  }
 
+  // body
   const bodyLines = tooltipModel.body.map(b => b.lines).join()
-  const b = createRubyObject(bodyLines as string)
 
-  b.forEach(a => {
-    let dom: HTMLElement
-    if (!a.kana) {
-      dom = document.createElement('span')
-      dom.textContent = a.ja
-    } else {
-      dom = document.createElement('ruby')
-      const rt = document.createElement('rt')
-      rt.textContent = a.kana || ''
-      dom.textContent = a.ja
-      dom.appendChild(rt)
-    }
-    bodyEl!.appendChild(dom)
-  })
-  tooltipEl.appendChild(bodyEl)
+  if (bodyLines) {
+    createRubyObject(bodyLines).forEach(text => {
+      const dom = createDom(text)
+      bodyEl!.appendChild(dom)
+    })
+  }
 
   const chart = self.$refs.barChart as Vue
   const el = chart.$el
   const canvas = el.querySelector('canvas')
-  const position = canvas.getBoundingClientRect()
+  const position = canvas!.getBoundingClientRect()
 
   tooltipEl.style.opacity = '1'
   tooltipEl.style.position = 'absolute'
   tooltipEl.style.left =
     position.left + window.pageXOffset + tooltipModel.caretX + 'px'
-
   tooltipEl.style.top =
     position.top + window.pageYOffset + tooltipModel.caretY + 'px'
   tooltipEl.style.color = tooltipModel.titleFontColor
@@ -119,4 +107,19 @@ export const customTooltip = (self: any, tooltipModel: any) => {
   tooltipEl.style.pointerEvents = 'none'
   tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
   tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
+}
+
+function createDom(text: RubyText) {
+  let dom: HTMLElement
+  if (!text.kana) {
+    dom = document.createElement('span')
+    dom.textContent = text.ja
+  } else {
+    dom = document.createElement('ruby')
+    const rt = document.createElement('rt')
+    rt.textContent = text.kana || ''
+    dom.textContent = text.ja
+    dom.appendChild(rt)
+  }
+  return dom
 }

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -39,14 +39,14 @@ export const customTooltip = (
   tooltipModel: TooltipModel
 ) => {
   // Tooltip Element
-  let tooltipEl = document.getElementById('chartjs-tooltip')
+  let tooltipEl: HTMLElement | null = document.querySelector('.chartjs-tooltip')
   let titleEl: HTMLElement | null
   let bodyEl: HTMLElement | null
 
   // Create element on first render
   if (!tooltipEl) {
     tooltipEl = document.createElement('div')
-    tooltipEl.id = 'chartjs-tooltip'
+    tooltipEl.classList.add('chartjs-tooltip')
     document.body.appendChild(tooltipEl)
   }
 
@@ -62,9 +62,13 @@ export const customTooltip = (
 
     tooltipEl.style.position = 'absolute'
     tooltipEl.style.left =
-      position.left + window.pageXOffset + tooltipModel.caretX + 'px'
+      position.left + window.pageXOffset + tooltipModel.caretX + 5 + 'px'
     tooltipEl.style.top =
-      position.top + window.pageYOffset + tooltipModel.caretY + 'px'
+      position.top +
+      window.pageYOffset +
+      tooltipModel.caretY -
+      tooltipModel.height / 2 +
+      'px'
     tooltipEl.style.color = tooltipModel.titleFontColor
     tooltipEl.style.padding =
       tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -43,14 +43,14 @@ export const customTooltip = (
   let titleEl: HTMLElement | null
   let bodyEl: HTMLElement | null
 
-  // Create element on first render
+  // Create tooltip element on first render
   if (!tooltipEl) {
     tooltipEl = document.createElement('div')
     tooltipEl.id = 'chartjs-tooltip'
     document.body.appendChild(tooltipEl)
   }
 
-  // opacity
+  // Hide if no tooltip
   if (tooltipModel.opacity === 0) {
     tooltipEl.style.opacity = '0'
     return
@@ -58,6 +58,7 @@ export const customTooltip = (
     tooltipEl.style.opacity = '1'
   }
 
+  // Create title element on first render
   if ((titleEl = tooltipEl.querySelector('.chartjs-tooltip-title'))) {
     titleEl!.textContent = ''
   } else {
@@ -69,6 +70,7 @@ export const customTooltip = (
     tooltipEl.appendChild(titleEl)
   }
 
+  // Create body element on first render
   if ((bodyEl = tooltipEl.querySelector('.chartjs-tooltip-body'))) {
     bodyEl!.textContent = ''
   } else {
@@ -80,9 +82,8 @@ export const customTooltip = (
     tooltipEl.appendChild(bodyEl)
   }
 
-  // titie
+  // Appned ruby texts to title
   const title = tooltipModel.title && tooltipModel.title[0]
-
   if (title) {
     createRubyObject(title).forEach(text => {
       const dom = createDom(text)
@@ -90,9 +91,8 @@ export const customTooltip = (
     })
   }
 
-  // body
+  // Appned ruby texts to body
   const bodyLines = tooltipModel.body.map(b => b.lines).join()
-
   if (bodyLines) {
     createRubyObject(bodyLines).forEach(text => {
       const dom = createDom(text)
@@ -100,7 +100,7 @@ export const customTooltip = (
     })
   }
 
-  // base
+  // base styles
   tooltipEl.style.position = 'absolute'
   tooltipEl.style.color = tooltipModel.titleFontColor
   tooltipEl.style.padding =
@@ -109,47 +109,50 @@ export const customTooltip = (
   tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
   tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
 
-  // position
-  const position = (() => {
+  // tooltip position
+  const canvas = (() => {
     const chart = self.$refs.barChart as Vue
     const el = chart.$el
     const canvas = el.querySelector('canvas')
     return canvas!.getBoundingClientRect()
   })()
 
-  const left = position.left + tooltipModel.caretX
-  const top = position.top + window.pageYOffset + tooltipModel.caretY
-  const borderSize = 5
+  const baseLeft = canvas.left + tooltipModel.caretX
+  const baseTop = canvas.top + window.pageYOffset + tooltipModel.caretY
+  const borderSize = 5 // caret border-size defined by css
 
   const align = (() => {
-    const rightSide = left + borderSize + tooltipEl.offsetWidth
-    const isRightSideOver = rightSide > position.right
+    const rightSide = baseLeft + borderSize + tooltipEl.offsetWidth
+    const isRightSideOver = rightSide > canvas.right
     const yAlign = tooltipModel.yAlign === 'center' ? '' : tooltipModel.yAlign
     return yAlign || (isRightSideOver ? 'left' : 'right')
   })()
 
   switch (align) {
     case 'top':
-      tooltipEl.style.top = top + borderSize + 'px'
+      tooltipEl.style.top = baseTop + borderSize + 'px'
       tooltipEl.style.left =
-        left - tooltipEl.offsetWidth / 2 - borderSize + 'px'
+        baseLeft - tooltipEl.offsetWidth / 2 - borderSize / 2 + 'px'
       break
     case 'bottom':
-      tooltipEl.style.top = top - tooltipEl.offsetHeight - borderSize + 'px'
+      tooltipEl.style.top = baseTop - tooltipEl.offsetHeight - borderSize + 'px'
       tooltipEl.style.left =
-        left - tooltipEl.offsetWidth / 2 - borderSize + 'px'
+        baseLeft - tooltipEl.offsetWidth / 2 - borderSize / 2 + 'px'
       break
     case 'right':
-      tooltipEl.style.top = top - tooltipEl.offsetHeight / 2 + 'px'
-      tooltipEl.style.left = left + borderSize + 'px'
+      tooltipEl.style.top =
+        baseTop - tooltipEl.offsetHeight / 2 + borderSize / 2 + 'px'
+      tooltipEl.style.left = baseLeft + borderSize + 'px'
       break
     case 'left':
-      tooltipEl.style.top = top - tooltipEl.offsetHeight / 2 + 'px'
-      tooltipEl.style.left = left - tooltipEl.offsetWidth - borderSize + 'px'
+      tooltipEl.style.top =
+        baseTop - tooltipEl.offsetHeight / 2 + borderSize / 2 + 'px'
+      tooltipEl.style.left =
+        baseLeft - tooltipEl.offsetWidth - borderSize + 'px'
       break
   }
 
-  // animation
+  // fade animation
   if (tooltipEl.dataset.chartId === self.chartId) {
     tooltipEl.style.transition = 'all 0.3s ease'
   } else {
@@ -157,7 +160,7 @@ export const customTooltip = (
     tooltipEl.dataset.chartId = self.chartId
   }
 
-  // css class
+  // css class for caret
   tooltipEl.className = ''
   tooltipEl.classList.add(align)
 }

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -39,50 +39,23 @@ export const customTooltip = (
   tooltipModel: TooltipModel
 ) => {
   // Tooltip Element
-  let tooltipEl: HTMLElement | null = document.querySelector('.chartjs-tooltip')
+  let tooltipEl: HTMLElement | null = document.querySelector('#chartjs-tooltip')
   let titleEl: HTMLElement | null
   let bodyEl: HTMLElement | null
 
   // Create element on first render
   if (!tooltipEl) {
     tooltipEl = document.createElement('div')
-    tooltipEl.classList.add('chartjs-tooltip')
+    tooltipEl.id = 'chartjs-tooltip'
     document.body.appendChild(tooltipEl)
   }
 
-  // Hide if no tooltip
+  // opacity
   if (tooltipModel.opacity === 0) {
     tooltipEl.style.opacity = '0'
     return
   } else {
-    const chart = self.$refs.barChart as Vue
-    const el = chart.$el
-    const canvas = el.querySelector('canvas')
-    const position = canvas!.getBoundingClientRect()
-
-    tooltipEl.style.position = 'absolute'
-    tooltipEl.style.left =
-      position.left + window.pageXOffset + tooltipModel.caretX + 5 + 'px'
-    tooltipEl.style.top =
-      position.top +
-      window.pageYOffset +
-      tooltipModel.caretY -
-      tooltipModel.height / 2 +
-      'px'
-    tooltipEl.style.color = tooltipModel.titleFontColor
-    tooltipEl.style.padding =
-      tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
-    tooltipEl.style.pointerEvents = 'none'
-    tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
-    tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
     tooltipEl.style.opacity = '1'
-  }
-
-  if (tooltipEl.dataset.chartId === self.chartId) {
-    tooltipEl.style.transition = 'all 0.3s ease'
-  } else {
-    tooltipEl.style.transition = 'opacity 0.3s ease'
-    tooltipEl.dataset.chartId = self.chartId
   }
 
   if ((titleEl = tooltipEl.querySelector('.chartjs-tooltip-title'))) {
@@ -126,6 +99,48 @@ export const customTooltip = (
       bodyEl!.appendChild(dom)
     })
   }
+
+  // base
+  tooltipEl.style.position = 'absolute'
+  tooltipEl.style.color = tooltipModel.titleFontColor
+  tooltipEl.style.padding =
+    tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
+  tooltipEl.style.pointerEvents = 'none'
+  tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
+  tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
+
+  // position
+  const chart = self.$refs.barChart as Vue
+  const el = chart.$el
+  const canvas = el.querySelector('canvas')
+  const position = canvas!.getBoundingClientRect()
+  const borderSize = 5
+  const left = position.left + tooltipModel.caretX
+  const rightSide = left + borderSize + tooltipEl.offsetWidth
+  const isRightSideOver = rightSide > position.right
+
+  tooltipEl.style.left = isRightSideOver
+    ? left - tooltipEl.offsetWidth - borderSize + 'px'
+    : left + borderSize + 'px'
+
+  tooltipEl.style.top =
+    position.top +
+    window.pageYOffset +
+    tooltipModel.caretY -
+    tooltipEl.offsetHeight / 2 +
+    'px'
+
+  // animation
+  if (tooltipEl.dataset.chartId === self.chartId) {
+    tooltipEl.style.transition = 'all 0.3s ease'
+  } else {
+    tooltipEl.style.transition = 'opacity 0.3s ease'
+    tooltipEl.dataset.chartId = self.chartId
+  }
+
+  // css class
+  tooltipEl.className = ''
+  tooltipEl.classList.add(isRightSideOver ? 'left' : 'right')
 }
 
 function createDom(text: RubyText) {

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -110,25 +110,44 @@ export const customTooltip = (
   tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
 
   // position
-  const chart = self.$refs.barChart as Vue
-  const el = chart.$el
-  const canvas = el.querySelector('canvas')
-  const position = canvas!.getBoundingClientRect()
-  const borderSize = 5
+  const position = (() => {
+    const chart = self.$refs.barChart as Vue
+    const el = chart.$el
+    const canvas = el.querySelector('canvas')
+    return canvas!.getBoundingClientRect()
+  })()
+
   const left = position.left + tooltipModel.caretX
-  const rightSide = left + borderSize + tooltipEl.offsetWidth
-  const isRightSideOver = rightSide > position.right
+  const top = position.top + window.pageYOffset + tooltipModel.caretY
+  const borderSize = 5
 
-  tooltipEl.style.left = isRightSideOver
-    ? left - tooltipEl.offsetWidth - borderSize + 'px'
-    : left + borderSize + 'px'
+  const align = (() => {
+    const rightSide = left + borderSize + tooltipEl.offsetWidth
+    const isRightSideOver = rightSide > position.right
+    const yAlign = tooltipModel.yAlign === 'center' ? '' : tooltipModel.yAlign
+    return yAlign || (isRightSideOver ? 'left' : 'right')
+  })()
 
-  tooltipEl.style.top =
-    position.top +
-    window.pageYOffset +
-    tooltipModel.caretY -
-    tooltipEl.offsetHeight / 2 +
-    'px'
+  switch (align) {
+    case 'top':
+      tooltipEl.style.top = top + borderSize + 'px'
+      tooltipEl.style.left =
+        left - tooltipEl.offsetWidth / 2 - borderSize + 'px'
+      break
+    case 'bottom':
+      tooltipEl.style.top = top - tooltipEl.offsetHeight - borderSize + 'px'
+      tooltipEl.style.left =
+        left - tooltipEl.offsetWidth / 2 - borderSize + 'px'
+      break
+    case 'right':
+      tooltipEl.style.top = top - tooltipEl.offsetHeight / 2 + 'px'
+      tooltipEl.style.left = left + borderSize + 'px'
+      break
+    case 'left':
+      tooltipEl.style.top = top - tooltipEl.offsetHeight / 2 + 'px'
+      tooltipEl.style.left = left - tooltipEl.offsetWidth - borderSize + 'px'
+      break
+  }
 
   // animation
   if (tooltipEl.dataset.chartId === self.chartId) {
@@ -140,7 +159,7 @@ export const customTooltip = (
 
   // css class
   tooltipEl.className = ''
-  tooltipEl.classList.add(isRightSideOver ? 'left' : 'right')
+  tooltipEl.classList.add(align)
 }
 
 function createDom(text: RubyText) {

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -65,7 +65,7 @@ export const customTooltip = (
     titleEl.classList.add('chartjs-tooltip-title')
     titleEl.style.fontFamily = tooltipModel._titleFontFamily
     titleEl.style.fontSize = tooltipModel.titleFontSize + 'px'
-    titleEl.style.fontStyle = tooltipModel._titleFontStyle
+    titleEl.style.fontWeight = tooltipModel._titleFontStyle
     tooltipEl.appendChild(titleEl)
   }
 
@@ -76,7 +76,7 @@ export const customTooltip = (
     bodyEl.classList.add('chartjs-tooltip-body')
     bodyEl.style.fontFamily = tooltipModel._bodyFontFamily
     bodyEl.style.fontSize = tooltipModel.bodyFontSize + 'px'
-    bodyEl.style.fontStyle = tooltipModel._bodyFontStyle
+    bodyEl.style.fontWeight = tooltipModel._bodyFontStyle
     tooltipEl.appendChild(bodyEl)
   }
 

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -30,7 +30,14 @@ interface TooltipModel extends ChartTooltipModel {
   title?: string
 }
 
-export const customTooltip = (self: Vue, tooltipModel: TooltipModel) => {
+interface ChartObject extends Vue {
+  chartId: string
+}
+
+export const customTooltip = (
+  self: ChartObject,
+  tooltipModel: TooltipModel
+) => {
   // Tooltip Element
   let tooltipEl = document.getElementById('chartjs-tooltip')
   let titleEl: HTMLElement | null
@@ -43,9 +50,35 @@ export const customTooltip = (self: Vue, tooltipModel: TooltipModel) => {
     document.body.appendChild(tooltipEl)
   }
 
+  // Hide if no tooltip
   if (tooltipModel.opacity === 0) {
     tooltipEl.style.opacity = '0'
     return
+  } else {
+    const chart = self.$refs.barChart as Vue
+    const el = chart.$el
+    const canvas = el.querySelector('canvas')
+    const position = canvas!.getBoundingClientRect()
+
+    tooltipEl.style.position = 'absolute'
+    tooltipEl.style.left =
+      position.left + window.pageXOffset + tooltipModel.caretX + 'px'
+    tooltipEl.style.top =
+      position.top + window.pageYOffset + tooltipModel.caretY + 'px'
+    tooltipEl.style.color = tooltipModel.titleFontColor
+    tooltipEl.style.padding =
+      tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
+    tooltipEl.style.pointerEvents = 'none'
+    tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
+    tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
+    tooltipEl.style.opacity = '1'
+  }
+
+  if (tooltipEl.dataset.chartId === self.chartId) {
+    tooltipEl.style.transition = 'all 0.3s ease'
+  } else {
+    tooltipEl.style.transition = 'opacity 0.3s ease'
+    tooltipEl.dataset.chartId = self.chartId
   }
 
   if ((titleEl = tooltipEl.querySelector('.chartjs-tooltip-title'))) {
@@ -89,24 +122,6 @@ export const customTooltip = (self: Vue, tooltipModel: TooltipModel) => {
       bodyEl!.appendChild(dom)
     })
   }
-
-  const chart = self.$refs.barChart as Vue
-  const el = chart.$el
-  const canvas = el.querySelector('canvas')
-  const position = canvas!.getBoundingClientRect()
-
-  tooltipEl.style.opacity = '1'
-  tooltipEl.style.position = 'absolute'
-  tooltipEl.style.left =
-    position.left + window.pageXOffset + tooltipModel.caretX + 'px'
-  tooltipEl.style.top =
-    position.top + window.pageYOffset + tooltipModel.caretY + 'px'
-  tooltipEl.style.color = tooltipModel.titleFontColor
-  tooltipEl.style.padding =
-    tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
-  tooltipEl.style.pointerEvents = 'none'
-  tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
-  tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
 }
 
 function createDom(text: RubyText) {

--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -23,3 +23,100 @@ export const createRubyObject = (text: string) => {
   if ((lastText = text.slice(pos))) texts.push({ ja: lastText })
   return texts
 }
+
+export const customTooltip = (self: any, tooltipModel: any) => {
+  // Tooltip Element
+  let tooltipEl = document.getElementById('chartjs-tooltip')
+  let titleEl = tooltipEl?.querySelector('.chartjs-tooltip-title')
+  let bodyEl = tooltipEl?.querySelector('.chartjs-tooltip-body')
+
+  // Create element on first render
+  if (!tooltipEl) {
+    tooltipEl = document.createElement('div')
+    tooltipEl.id = 'chartjs-tooltip'
+    document.body.appendChild(tooltipEl)
+  }
+
+  if (tooltipModel.opacity === 0) {
+    tooltipEl.style.opacity = 0
+    return
+  }
+
+  if (!titleEl) {
+    titleEl = document.createElement('div')
+    titleEl.classList.add('chartjs-tooltip-title')
+    titleEl.style.fontFamily = tooltipModel._titleFontFamily
+    titleEl.style.fontSize = tooltipModel.titleFontSize + 'px'
+    titleEl.style.fontStyle = tooltipModel._titleFontStyle
+    tooltipEl.appendChild(titleEl)
+  } else {
+    titleEl.textContent = ''
+  }
+
+  if (!bodyEl) {
+    bodyEl = document.createElement('div')
+    bodyEl.classList.add('chartjs-tooltip-body')
+    bodyEl.style.fontFamily = tooltipModel._bodyFontFamily
+    bodyEl.style.fontSize = tooltipModel.bodyFontSize + 'px'
+    bodyEl.style.fontStyle = tooltipModel._bodyFontStyle
+  } else {
+    bodyEl.textContent = ''
+  }
+
+  const title = tooltipModel.title && tooltipModel.title[0]
+  if (!title) return
+  const t = createRubyObject(title as string)
+
+  t.forEach(a => {
+    let dom: HTMLElement
+    if (!a.kana) {
+      dom = document.createElement('span')
+      dom.textContent = a.ja
+    } else {
+      dom = document.createElement('ruby')
+      const rt = document.createElement('rt')
+      rt.textContent = a.kana || ''
+      dom.textContent = a.ja
+      dom.appendChild(rt)
+    }
+    titleEl.appendChild(dom)
+  })
+
+  const bodyLines = tooltipModel.body.map(b => b.lines).join()
+  const b = createRubyObject(bodyLines as string)
+
+  b.forEach(a => {
+    let dom: HTMLElement
+    if (!a.kana) {
+      dom = document.createElement('span')
+      dom.textContent = a.ja
+    } else {
+      dom = document.createElement('ruby')
+      const rt = document.createElement('rt')
+      rt.textContent = a.kana || ''
+      dom.textContent = a.ja
+      dom.appendChild(rt)
+    }
+    bodyEl!.appendChild(dom)
+  })
+  tooltipEl.appendChild(bodyEl)
+
+  const chart = self.$refs.barChart as Vue
+  const el = chart.$el
+  const canvas = el.querySelector('canvas')
+  const position = canvas.getBoundingClientRect()
+
+  tooltipEl.style.opacity = '1'
+  tooltipEl.style.position = 'absolute'
+  tooltipEl.style.left =
+    position.left + window.pageXOffset + tooltipModel.caretX + 'px'
+
+  tooltipEl.style.top =
+    position.top + window.pageYOffset + tooltipModel.caretY + 'px'
+  tooltipEl.style.color = tooltipModel.titleFontColor
+  tooltipEl.style.padding =
+    tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
+  tooltipEl.style.pointerEvents = 'none'
+  tooltipEl.style.backgroundColor = tooltipModel.backgroundColor
+  tooltipEl.style.borderRadius = tooltipModel.cornerRadius + 'px'
+}


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3154

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- グラフのツールチップにルビを振りました
  - 実装については Chart.js のドキュメントに習いました
  - [Tooltip · Chart.js documentation](https://www.chartjs.org/docs/latest/configuration/tooltip.html#external-custom-tooltips)
- `<TI18n>` コンポーネントの `createRubyTexts` メソッドをユーティリティに切り出しました
  - ツールチップの実装で再利用できるようにするためです

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-04-16 18 20 34](https://user-images.githubusercontent.com/5207601/79438807-fc5be600-800e-11ea-859f-cfa13822bb3a.png)

![スクリーンショット 2020-04-16 18 19 56](https://user-images.githubusercontent.com/5207601/79438760-ec440680-800e-11ea-9462-d2b2ec0ce29d.png)

![スクリーンショット 2020-04-16 18 20 04](https://user-images.githubusercontent.com/5207601/79438768-ed753380-800e-11ea-9b58-854ec9d38ad9.png)

