### PR TITLE
表の英語表記時に適切な位置で改行が行われるように変更

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -275,7 +275,7 @@ $default-boxdiff: 35px;
     }
 
     &:not(:last-child) {
-      word-break: break-all;
+      overflow-wrap: break-word;
     }
   }
   span strong {

--- a/components/TestedCasesDetailsTable.vue
+++ b/components/TestedCasesDetailsTable.vue
@@ -177,7 +177,7 @@ $default-boxh: 150px;
     }
 
     &:not(:last-child) {
-      word-break: break-all;
+      overflow-wrap: break-word;
     }
   }
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3387

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
~~- `break-all`を`break-word`に変更~~
- `word-break: break-all;`を`overflow-wrap: break-word;`に変更
## 📸 スクリーンショット / Screenshots
変更前の英語表記
![before](https://user-images.githubusercontent.com/61964503/79458576-f543d080-802c-11ea-8892-e34380e91701.png)

変更後の英語表記
![after](https://user-images.githubusercontent.com/61964503/79458540-e9580e80-802c-11ea-891b-d162ccfe225c.png)
#3387のものと同じ