### PR TITLE
「陽性患者の属性」表において、無効な日付を取得した場合の動作を修正

### DIFF
--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -41,9 +41,9 @@ export default (data: DataType[]) => {
     datasets: []
   }
   data.forEach(d => {
-    const releaseDate = dayjs(d['リリース日']).format('M/D')
+    const releaseDate = dayjs(d['リリース日'])
     const TableRow: TableDataType = {
-      公表日: releaseDate !== 'Invalid Date' ? releaseDate : '不明',
+      公表日: releaseDate.isValid() ? releaseDate.format('M/D') : '不明',
       居住地: d['居住地'] ?? '調査中',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明',

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -41,8 +41,9 @@ export default (data: DataType[]) => {
     datasets: []
   }
   data.forEach(d => {
+    const releaseDate = dayjs(d['リリース日']).format('M/D')
     const TableRow: TableDataType = {
-      公表日: dayjs(d['リリース日']).format('M/D') ?? '不明',
+      公表日: releaseDate !== 'Invalid Date' ? releaseDate : '不明',
       居住地: d['居住地'] ?? '調査中',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3422 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 日付取得に失敗した場合に「Invalid Date」と表示される部分を「不明」と表示されるように修正
  - なお、これが正しく動作することを確認するには、以下のようなダミーデータを挿入する必要があり、デプロイプレビューでは確認不可能です。
```
{
    "リリース日": null,
    "居住地": null,
    "年代": "10代",
    "性別": "男性",
    "退院": null,
    "date": null
}
```
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34832037/79580168-93a26580-8103-11ea-8d02-d73e8abfdf3d.png)
