### PR TITLE
[WIP] 陽性患者の属性フィルター機能を追加

### DIFF
--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -1,0 +1,264 @@
+<template>
+  <div class="DataFilter">
+    <label class="filter"><input type="checkbox" v-model="isFilterEnabled"> フィルター</label>
+    <template v-if="isFilterEnabled">
+      <ul class="labels" v-if="filterLabels.length">
+        <li 
+          v-for="(item, index) in filterLabels" 
+          class="label"
+          :key="index">
+            <span class="label__remove" @click="handleRemoveLabelClick(item)">&#10005;</span>
+            <span class="label__text">{{ `${item.key}: ${item.value}`}}</span>
+        </li>
+      </ul>
+      <select ref="key" v-model="filterKey">
+        <option 
+          v-for="item in chartData.headers" 
+          :value="item.value" 
+          :key="item.value">{{ item.text }}
+        </option>
+      </select>
+      <select ref="value" v-if="filterKey">
+        <option
+          v-for="item in availableFilterValues"
+          :key="item"
+        >{{ item }}
+        </option>
+      </select>
+      <button type="button" @click.prevent="handleAddButtonClick">追加</button>
+    </template>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.DataFilter {
+  font-size: 12px;
+  margin-bottom: 10px;
+}
+
+select {
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid #999;
+}
+
+button {
+  background-color: #4d4d4d;
+  padding: 3px 6px;
+  color: #fff;
+  line-height: normal;
+  border-radius: 4px;
+}
+
+.filter {
+  display: block;
+}
+
+.labels {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0;
+  list-style-type: none;
+}
+
+.label {
+  display: inline-flex;
+  background-color: #ccc;
+  padding: 5px;
+  font-size: 10px; 
+  align-items: center;
+  line-height: 1;
+  margin: 0 5px 5px 0;
+
+  &__remove {
+    margin-right: 5px;
+    cursor: pointer;
+  }
+}
+</style>
+
+<script lang="ts">
+import Vue from 'vue'
+import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+
+type HeaderData = {
+  text: string
+  value: string
+}
+
+type Dataset = { [prop: string]: any }
+
+type KeyAndValue = { 
+  key: string
+  value: any 
+}
+
+type Data = {
+  datasets: Dataset[]
+  isFilterEnabled: boolean
+  filterKey: string
+  filters: { [key: string]: any[] }
+  
+}
+
+type Methods = {
+  handleAddButtonClick: (event: Event) => void
+  handleRemoveLabelClick: (item: KeyAndValue) => void
+}
+
+type Computed = {
+  filterKeys: string[]
+  filterLabels: KeyAndValue[]
+  filterMap: { [key: string]: any[] }
+  availableFilterValues: string[]
+  filteredDatasets: Dataset[]
+}
+
+type Props = {
+  chartData: {
+    headers: HeaderData[]
+    datasets: Dataset[]
+  }
+}
+
+const options: ThisTypedComponentOptionsWithRecordProps<
+  Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = {
+  name: 'DataFilter',
+  props: {
+    chartData: {
+      type: Object,
+      default() {
+        return {
+          headers: [],
+          datasets: []
+        }
+      }
+    }
+  },
+  data() {
+    return {
+      datasets: [],
+      isFilterEnabled: false,
+      filterKey: this.chartData.headers[0].value,
+      filters: {}
+    }
+  },
+  computed: {
+    // フィルタリングされたリストを返却します。
+    // 例）ユーザが「性別：男性」「年代:30代」「年別40代」でフィルタリングしているときは、
+    // 「30代男性」 OR 「40代男性」のリストを返却します。
+    filterKeys() { 
+      return Object.keys(this.filters) 
+    },
+    filterLabels() {
+      const reducer = (keyAndVals: KeyAndValue[], filterKey: string) => {
+        const values = this.filters[filterKey] || []
+        const keyAndValues = values.map((value) => { return { key: filterKey, value } })
+        return keyAndVals.concat(keyAndValues)
+      }
+      return this.filterKeys.length ? this.filterKeys.reduce(reducer, []) : []
+    },
+    // フィルターのキーとバリューをすべて保有するマップ
+    filterMap() {
+      const reducer = (filters: { [key: string]: any }, dataset: Dataset) => {
+        for (let key in dataset) {
+          const value = dataset[key]
+          if (filters[key] === undefined) {
+            this.$set(filters, key, [value])
+            filters[key] = [value]
+          } else {
+            if (!filters[key].some((filterValue: any) => filterValue === value)) {
+              filters[key].push(value)
+            }
+          }
+        }
+        return filters
+      }
+      return this.datasets.reduce(reducer, {})
+    },
+    // 選択中の属性名をもとに、その候補値のリストを返却します。
+    // 例） ユーザが「性別」を選択すると、「男性」「女性」「不明」「調査中」を要素とするリストを返却します。
+    availableFilterValues() {
+      const filterValues = this.filterMap[this.filterKey]
+      const selectedLabels = this.filterLabels.filter((label) => label.key === this.filterKey)
+      return filterValues.filter(filterValue => !selectedLabels.some(({ value }) => value === filterValue))
+    },
+    // 全データを「フィルタ対象」と「フィルタ対象外」に分類します。
+    filteredDatasets() {
+      // フィルター設定がない場合はすべてのデータを返却
+      if (this.isFilterEnabled && this.filterKey.length === 0) {
+        return this.datasets
+      } else {
+        return this.datasets.filter(dataset => {
+          let isMatched = true
+          for (let key in this.filters) {
+            const values = this.filters[key]
+            // 属性毎のフィルタリングは OR でマッチングさせます
+            // 例）「年代」が「30代」「40代」指定されている場合は、30代 OR 40代のデータにマッチさせます
+            isMatched = values.some((value) => value === dataset[key])
+            // マッチしない属性があった場合は、その時点でフィルタリング対象外となります。(AND検索)
+            // 例）「年代:30代」「年別40代」がマッチしなかった場合、「性別：男性」かどうかの判別は行いません
+            if (!isMatched) break
+          }
+          return isMatched
+        })
+      }
+    }
+  },
+  methods: {
+    // フィルタリング項目を、属性名を key に、属性値を要素とする配列オブジェクトに追加します。
+    // 例） filters['性別'] = ['男性', '女性']
+    handleAddButtonClick(event) {
+      const selectedKey = (this.$refs.key as HTMLSelectElement).value 
+      const selectedValue = (this.$refs.value as HTMLSelectElement).value
+      const isValid = selectedKey !== '' && selectedKey !== ''
+      if (isValid) {
+        const values = this.filters[selectedKey]
+        if (values === undefined) {
+          this.$set(this.filters, selectedKey, [selectedValue])
+          this.filters[selectedKey] = [selectedValue]
+        } else {
+          if (!values.some(value => value === selectedValue)) {
+            values.push(selectedValue)
+          }
+        }
+      }
+    },
+    // フィルタリング項目を削除します。
+    handleRemoveLabelClick({ key, value }) {
+      const values = this.filters[key]
+      if (values !== undefined) {
+        for (let i = 0, len = values.length; i < len; i++) {
+          if (values[i] === value) {
+            values.splice(i, 1)
+            break
+          }
+        }
+      }
+      // [IMPORTANT]
+      //空要素の配列はプロパティ毎削除すること
+      if (values.length === 0) {
+        delete this.filters[key]
+        this.$delete(this.filters, key)
+      }
+    }
+  },
+  watch: {
+    // フィルタリストの変更を監視し、リストを送出します。
+    filteredDatasets(): void {
+      this.$emit('update', this.filteredDatasets)
+    }
+  },
+  mounted () {
+    // プロパティで受け取ったデータセットをコピーします。
+    this.datasets = this.chartData.datasets.concat()
+  }
+}
+
+export default Vue.extend(options)
+</script>

--- a/components/DataFilter.vue
+++ b/components/DataFilter.vue
@@ -1,28 +1,28 @@
 <template>
   <div class="DataFilter">
-    <label class="filter"><input type="checkbox" v-model="isFilterEnabled"> フィルター</label>
+    <label class="filter"
+      ><input v-model="isFilterEnabled" type="checkbox" /> フィルター</label
+    >
     <template v-if="isFilterEnabled">
-      <ul class="labels" v-if="filterLabels.length">
-        <li 
-          v-for="(item, index) in filterLabels" 
-          class="label"
-          :key="index">
-            <span class="label__remove" @click="handleRemoveLabelClick(item)">&#10005;</span>
-            <span class="label__text">{{ `${item.key}: ${item.value}`}}</span>
+      <ul v-if="filterLabels.length" class="labels">
+        <li v-for="(item, index) in filterLabels" :key="index" class="label">
+          <span class="label__remove" @click="handleRemoveLabelClick(item)"
+            >&#10005;</span
+          >
+          <span class="label__text">{{ `${item.key}: ${item.value}` }}</span>
         </li>
       </ul>
       <select ref="key" v-model="filterKey">
-        <option 
-          v-for="item in chartData.headers" 
-          :value="item.value" 
-          :key="item.value">{{ item.text }}
+        <option
+          v-for="item in chartData.headers"
+          :key="item.value"
+          :value="item.value"
+          >{{ item.text }}
         </option>
       </select>
-      <select ref="value" v-if="filterKey">
-        <option
-          v-for="item in availableFilterValues"
-          :key="item"
-        >{{ item }}
+      <select v-if="filterKey" ref="value">
+        <option v-for="item in availableFilterValues" :key="item"
+          >{{ item }}
         </option>
       </select>
       <button type="button" @click.prevent="handleAddButtonClick">追加</button>
@@ -65,7 +65,7 @@ button {
   display: inline-flex;
   background-color: #ccc;
   padding: 5px;
-  font-size: 10px; 
+  font-size: 10px;
   align-items: center;
   line-height: 1;
   margin: 0 5px 5px 0;
@@ -88,9 +88,9 @@ type HeaderData = {
 
 type Dataset = { [prop: string]: any }
 
-type KeyAndValue = { 
+type KeyAndValue = {
   key: string
-  value: any 
+  value: any
 }
 
 type Data = {
@@ -98,7 +98,6 @@ type Data = {
   isFilterEnabled: boolean
   filterKey: string
   filters: { [key: string]: any[] }
-  
 }
 
 type Methods = {
@@ -152,13 +151,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     // フィルタリングされたリストを返却します。
     // 例）ユーザが「性別：男性」「年代:30代」「年別40代」でフィルタリングしているときは、
     // 「30代男性」 OR 「40代男性」のリストを返却します。
-    filterKeys() { 
-      return Object.keys(this.filters) 
+    filterKeys() {
+      return Object.keys(this.filters)
     },
     filterLabels() {
       const reducer = (keyAndVals: KeyAndValue[], filterKey: string) => {
         const values = this.filters[filterKey] || []
-        const keyAndValues = values.map((value) => { return { key: filterKey, value } })
+        const keyAndValues = values.map(value => {
+          return { key: filterKey, value }
+        })
         return keyAndVals.concat(keyAndValues)
       }
       return this.filterKeys.length ? this.filterKeys.reduce(reducer, []) : []
@@ -166,15 +167,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     // フィルターのキーとバリューをすべて保有するマップ
     filterMap() {
       const reducer = (filters: { [key: string]: any }, dataset: Dataset) => {
-        for (let key in dataset) {
+        for (const key in dataset) {
           const value = dataset[key]
           if (filters[key] === undefined) {
             this.$set(filters, key, [value])
             filters[key] = [value]
-          } else {
-            if (!filters[key].some((filterValue: any) => filterValue === value)) {
-              filters[key].push(value)
-            }
+          } else if (
+            !filters[key].some((filterValue: any) => filterValue === value)
+          ) {
+            filters[key].push(value)
           }
         }
         return filters
@@ -185,8 +186,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     // 例） ユーザが「性別」を選択すると、「男性」「女性」「不明」「調査中」を要素とするリストを返却します。
     availableFilterValues() {
       const filterValues = this.filterMap[this.filterKey]
-      const selectedLabels = this.filterLabels.filter((label) => label.key === this.filterKey)
-      return filterValues.filter(filterValue => !selectedLabels.some(({ value }) => value === filterValue))
+      const selectedLabels = this.filterLabels.filter(
+        label => label.key === this.filterKey
+      )
+      return filterValues.filter(
+        filterValue =>
+          !selectedLabels.some(({ value }) => value === filterValue)
+      )
     },
     // 全データを「フィルタ対象」と「フィルタ対象外」に分類します。
     filteredDatasets() {
@@ -196,11 +202,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       } else {
         return this.datasets.filter(dataset => {
           let isMatched = true
-          for (let key in this.filters) {
+          for (const key in this.filters) {
             const values = this.filters[key]
             // 属性毎のフィルタリングは OR でマッチングさせます
             // 例）「年代」が「30代」「40代」指定されている場合は、30代 OR 40代のデータにマッチさせます
-            isMatched = values.some((value) => value === dataset[key])
+            isMatched = values.some(value => value === dataset[key])
             // マッチしない属性があった場合は、その時点でフィルタリング対象外となります。(AND検索)
             // 例）「年代:30代」「年別40代」がマッチしなかった場合、「性別：男性」かどうかの判別は行いません
             if (!isMatched) break
@@ -213,8 +219,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   methods: {
     // フィルタリング項目を、属性名を key に、属性値を要素とする配列オブジェクトに追加します。
     // 例） filters['性別'] = ['男性', '女性']
-    handleAddButtonClick(event) {
-      const selectedKey = (this.$refs.key as HTMLSelectElement).value 
+    handleAddButtonClick() {
+      const selectedKey = (this.$refs.key as HTMLSelectElement).value
       const selectedValue = (this.$refs.value as HTMLSelectElement).value
       const isValid = selectedKey !== '' && selectedKey !== ''
       if (isValid) {
@@ -222,10 +228,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         if (values === undefined) {
           this.$set(this.filters, selectedKey, [selectedValue])
           this.filters[selectedKey] = [selectedValue]
-        } else {
-          if (!values.some(value => value === selectedValue)) {
-            values.push(selectedValue)
-          }
+        } else if (!values.some(value => value === selectedValue)) {
+          values.push(selectedValue)
         }
       }
     },
@@ -241,7 +245,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         }
       }
       // [IMPORTANT]
-      //空要素の配列はプロパティ毎削除すること
+      // 空要素の配列はプロパティ毎削除すること
       if (values.length === 0) {
         delete this.filters[key]
         this.$delete(this.filters, key)
@@ -254,7 +258,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       this.$emit('update', this.filteredDatasets)
     }
   },
-  mounted () {
+  mounted() {
     // プロパティで受け取ったデータセットをコピーします。
     this.datasets = this.chartData.datasets.concat()
   }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -3,6 +3,10 @@
     <template v-slot:button>
       <span />
     </template>
+    <data-filter 
+      :chart-data="chartData" 
+      @update="(datasets) => $emit('datafiltered', datasets)" 
+    />
     <v-data-table
       :ref="'displayedTable'"
       :headers="chartData.headers"
@@ -28,14 +32,7 @@
       </template>
     </v-data-table>
     <div class="note">
-      <ul>
-        <li>
-          {{ $t('※退院は、保健所から報告があり、確認ができているものを反映') }}
-        </li>
-        <li>
-          {{ $t('※死亡退院を含む') }}
-        </li>
-      </ul>
+      {{ $t('※退院には、死亡退院を含む') }}
     </div>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -99,26 +96,21 @@
 }
 
 .note {
-  margin: 8px 0 0;
+  padding: 8px;
   font-size: 12px;
   color: $gray-3;
-
-  ul,
-  ol {
-    list-style-type: none;
-    padding: 0;
-  }
 }
 </style>
 
 <script lang="ts">
 import Vue from 'vue'
+import DataFilter from '@/components/DataFilter.vue'
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 
 export default Vue.extend({
-  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
+  components: { DataFilter, DataView, DataViewBasicInfoPanel, OpenDataLink },
   props: {
     title: {
       type: String,

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -3,9 +3,9 @@
     <template v-slot:button>
       <span />
     </template>
-    <data-filter 
-      :chart-data="chartData" 
-      @update="(datasets) => $emit('datafiltered', datasets)" 
+    <data-filter
+      :chart-data="chartData"
+      @update="datasets => $emit('datafiltered', datasets)"
     />
     <v-data-table
       :ref="'displayedTable'"

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -32,7 +32,14 @@
       </template>
     </v-data-table>
     <div class="note">
-      {{ $t('※退院には、死亡退院を含む') }}
+      <ul>
+        <li>
+          {{ $t('※退院は、保健所から報告があり、確認ができているものを反映') }}
+        </li>
+        <li>
+          {{ $t('※死亡退院を含む') }}
+        </li>
+      </ul>
     </div>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -96,9 +103,15 @@
 }
 
 .note {
-  padding: 8px;
+  margin: 8px 0 0;
   font-size: 12px;
   color: $gray-3;
+
+  ul,
+  ol {
+    list-style-type: none;
+    padding: 0;
+  }
 }
 </style>
 

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -13,6 +13,7 @@
         "
         :source="$t('オープンデータを入手')"
         :custom-sort="customSort"
+        @datafiltered="handlerDataFiltered"
       />
     </client-only>
   </v-col>
@@ -149,6 +150,9 @@ export default {
         return isDesc[0] ? comparison * -1 : comparison
       })
       return items
+    },
+    handlerDataFiltered(datasets) {
+      this.patientsTable.datasets = datasets
     }
   }
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2526
- close #2799

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性患者の属性」にフィルター用の「属性プルダウン」を追加
- 「属性プルダウン」から選んだフィルター項目はラベルとして表示される

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![capture](https://user-images.githubusercontent.com/228423/79693408-6c839980-82a5-11ea-9106-2a0d5a297ce3.gif)

## :heavy_check_mark: To Do

- [ ] 多言語化対応
- [ ] デザイン適用
- [x] 一意の属性から、すべての要素をフィルター対象にした際のフォールバック
- [ ] カードに表示する累計数の表示を検討
- [ ] 対象ブラウザでの動作確認
- [ ] フィルタ項目のソート（現在は成り行き。基本なり行きで良いが、年代などはソートをしないと不自然。また「ー」のようなものはリストの最後に配置するのが自然）