### PR TITLE
[ruby] TI18n コンポーネントの正規表現改善

### DIFF
--- a/utils/ruby.ts
+++ b/utils/ruby.ts
@@ -12,7 +12,7 @@ export const createRubyObject = (text: string) => {
   let lastText: string
   let pos = 0
   const texts: RubyText[] = []
-  const regp = /([\p{sc=Han}|\s|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/gu
+  const regp = /([\p{sc=Han}|・]+?)（([\p{sc=Hiragana}|\s|・]+?)）/gu
 
   // ふりがなを含んだ文字列をパースしてオブジェクトを生成
   while ((match = XRegExp.exec(text, regp, pos))) {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3133

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
- 漢字の直前に中点や空白があった際にルビがずれるバグを修正しました
- こちらの PR で現在対応が必要なルビ対応は出揃っているかと思います

## ja-Hira.json
「お問い合わせ先一覧」の翻訳で漢字の直後に改行 `\n`と空白 `\s` が入っている箇所があり、
ここがルビを抽出する正規表現にうまくはまりませんでした。

https://github.com/tokyo-metropolitan-gov/covid19/blob/a6c2270fca9982a40ad5d302d65cb2931708ae6b/assets/locales/ja-Hira.json#L265-L292

Transifex で管理している翻訳の方で、「局名」や「総務局」にあるような、漢字の直後にある改行と空白を削除することは可能でしょうか？

| ja-Hira.json | screenshot |
| --- | --- |
| "総務局": "総務局\n （そうむ きょく）", |  ![スクリーンショット 2020-04-23 0 22 37](https://user-images.githubusercontent.com/5207601/80000796-8ec12580-84f8-11ea-8ffa-a0f97b30055e.png) |
| "総務局": "総務局（そうむ きょく）",  | ![スクリーンショット 2020-04-23 0 23 09](https://user-images.githubusercontent.com/5207601/80000854-a13b5f00-84f8-11ea-9c10-2673a082c2a6.png)


## 📸 スクリーンショット / Screenshots
- 中点
![](https://user-images.githubusercontent.com/5207601/79047218-41b79680-7c50-11ea-9a31-ec2279397d7b.png)

- 空白
![](https://user-images.githubusercontent.com/5207601/79047219-42e8c380-7c50-11ea-9dba-4226f7578f0e.png)

- 漢字の前後の半角スペース
![](https://user-images.githubusercontent.com/5207601/79047221-4419f080-7c50-11ea-9544-5cd955547f91.png)

