### PR TITLE
fix: グラフのテーブルでデータを日付の降順でソートする

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -49,6 +49,7 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import { ChartOptions } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import dayjs from 'dayjs'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
@@ -241,11 +242,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             })
           )
         })
-        .sort((a, b) => {
-          const aDate = a.text.split('~')[0]
-          const bDate = b.text.split('~')[0]
-          return aDate > bDate ? -1 : 1
-        })
+        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
+        .reverse()
     }
   },
   mounted() {

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -49,7 +49,6 @@ import Vue from 'vue'
 import VueI18n from 'vue-i18n'
 import { ChartOptions } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-import dayjs from 'dayjs'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
@@ -242,7 +241,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             })
           )
         })
-        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
         .reverse()
     }
   },

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -56,7 +56,6 @@ import Vue from 'vue'
 import { TranslateResult } from 'vue-i18n'
 import { ChartOptions, ChartData, Chart } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import ExternalLink from '@/components/ExternalLink.vue'
@@ -178,7 +177,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             })
           )
         })
-        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
         .reverse()
     },
     displayOption() {

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -56,6 +56,7 @@ import Vue from 'vue'
 import { TranslateResult } from 'vue-i18n'
 import { ChartOptions, ChartData, Chart } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import ExternalLink from '@/components/ExternalLink.vue'
@@ -177,11 +178,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             })
           )
         })
-        .sort((a, b) => {
-          const aDate = a.text.split('~')[0]
-          const bDate = b.text.split('~')[0]
-          return aDate > bDate ? -1 : 1
-        })
+        .sort((a, b) => dayjs(a.text).unix() - dayjs(b.text).unix())
+        .reverse()
     },
     displayOption() {
       const self = this


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3672

## 📝 関連する issue / Related Issues
- #3261（PR）

## ⛏ 変更内容 / Details of Changes
- 「都営地下鉄の利用者数の推移」「都庁来庁者数の推移」のテーブルのデータを日付の降順でソート

## 📸 スクリーンショット / Screenshots
- 都営地下鉄の利用者数の推移
![スクリーンショット 2020-04-25 16 01 31](https://user-images.githubusercontent.com/5207601/80273554-0fa53a80-870e-11ea-8f69-61121eb79a19.png)

- 都庁来庁者数の推移
![スクリーンショット 2020-04-25 16 01 36](https://user-images.githubusercontent.com/5207601/80273555-10d66780-870e-11ea-8c38-79fa35d251d3.png)

