### PR TITLE
グラフの埋め込み用コードをコピーした際に表示される文字を非表示に修正。

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -163,10 +163,6 @@
       <div class="overlay-text">
         {{ $t('埋め込み用コードをコピーしました') }}
       </div>
-      <v-footer class="DataView-Footer">
-        <time :datetime="date">{{ $t('{date} 更新', { date }) }}</time>
-        <slot name="footer" />
-      </v-footer>
     </div>
   </v-card>
 </template>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3667 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- グラフの埋め込み用コードをコピーするアイコンをクリックした際に表示される、更新時刻や「オープンデータを入手」などの文字を非表示に修正しました。（文字を表示させるコードを削除。）
- 「埋め込み用コードをコピーしました」の文言は、残しています。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="430" alt="スクリーンショット 2020-04-25 15 57 51" src="https://user-images.githubusercontent.com/32950371/80274056-a8d65000-8712-11ea-8a50-36e5097d1fb5.png">
