### PR TITLE
カードの共有ボタンから表示するSNSボタンのズレを修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -558,7 +558,6 @@ export default Vue.extend({
 
           .icon-resize {
             border-radius: 50%;
-            font-size: 30px;
 
             &.twitter {
               color: #fff;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3688

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `DataView.vue`の`font-size: 30px;`を削除

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

### Firefox
<img width="564" alt="スクリーンショット 2020-04-26 5 50 45" src="https://user-images.githubusercontent.com/19218690/80290672-e2926f80-8781-11ea-94c4-5c486e17e786.png">

### Chrome
<img width="564" alt="スクリーンショット 2020-04-26 5 51 44" src="https://user-images.githubusercontent.com/19218690/80290693-05bd1f00-8782-11ea-9fc5-88295bff76f6.png">

---
#### 以下はmac版Firefoxの開発者ツールから端末を選択してスクショを取りました

### Galaxy S9/S9+ Android7.0
<img width="453" alt="スクリーンショット 2020-04-26 5 52 43" src="https://user-images.githubusercontent.com/19218690/80290706-27b6a180-8782-11ea-902d-654684106e51.png">

### iPhone 6/7/8 Plus iOS 11
<img width="453" alt="スクリーンショット 2020-04-26 5 56 35" src="https://user-images.githubusercontent.com/19218690/80290771-b1ff0580-8782-11ea-910b-c7a575ea4f26.png">

### iPhone X/XS iOS 12
<img width="452" alt="スクリーンショット 2020-04-26 5 58 11" src="https://user-images.githubusercontent.com/19218690/80290802-ebd00c00-8782-11ea-87d0-9a46170e00e4.png">

### Kindle Fire HDX Linux
<img width="818" alt="スクリーンショット 2020-04-26 5 57 24" src="https://user-images.githubusercontent.com/19218690/80290783-d0650100-8782-11ea-8ab9-9a24ee74e3d9.png">
