### PR TITLE
日本語以外の設定の場合、区市町村別の陽性患者数表からふりがな表記の欄を外す

### DIFF
--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -73,7 +73,7 @@ export default {
       if (d.label === '小計') {
         continue
       }
-      if (this.$i18n.locale = 'ja') {
+      if (this.$i18n.locale == 'ja') {
         municipalitiesTable.datasets.push({
           area: this.$t(d.area),
           ruby: this.$t(d.ruby),

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -40,12 +40,20 @@ export default {
     }
 
     // ヘッダーを設定
-    municipalitiesTable.headers = [
-      { text: this.$t('地域'), value: 'area' },
-      { text: this.$t('ふりがな'), value: 'ruby' },
-      { text: this.$t('区市町村'), value: 'label' },
-      { text: this.$t('陽性患者数'), value: 'count', align: 'end' }
-    ]
+    if (this.$i18n.locale == 'ja') {
+      municipalitiesTable.headers = [
+        { text: this.$t('地域'), value: 'area' },
+        { text: this.$t('ふりがな'), value: 'ruby' },
+        { text: this.$t('区市町村'), value: 'label' },
+        { text: this.$t('陽性患者数'), value: 'count', align: 'end' }
+      ]
+    } else {
+      municipalitiesTable.headers = [
+        { text: this.$t('地域'), value: 'area' },
+        { text: this.$t('区市町村'), value: 'label' },
+        { text: this.$t('陽性患者数'), value: 'count', align: 'end' }
+      ]
+    }
 
     // データをソート
     const areaOrder = ['特別区', '多摩地域', '島しょ地域', null]
@@ -65,12 +73,20 @@ export default {
       if (d.label === '小計') {
         continue
       }
-      municipalitiesTable.datasets.push({
-        area: this.$t(d.area),
-        ruby: this.$t(d.ruby),
-        label: this.$t(d.label),
-        count: d.count
-      })
+      if (this.$i18n.locale = 'ja') {
+        municipalitiesTable.datasets.push({
+          area: this.$t(d.area),
+          ruby: this.$t(d.ruby),
+          label: this.$t(d.label),
+          count: d.count
+        })
+      } else {
+        municipalitiesTable.datasets.push({
+          area: this.$t(d.area),          
+          label: this.$t(d.label),
+          count: d.count
+        })
+      }
     }
 
     const date = dayjs(Data.date).format('YYYY/MM/DD HH:mm')

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -82,7 +82,7 @@ export default {
         })
       } else {
         municipalitiesTable.datasets.push({
-          area: this.$t(d.area),          
+          area: this.$t(d.area),
           label: this.$t(d.label),
           count: d.count
         })

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -40,7 +40,7 @@ export default {
     }
 
     // ヘッダーを設定
-    if (this.$i18n.locale == 'ja') {
+    if (this.$i18n.locale === 'ja') {
       municipalitiesTable.headers = [
         { text: this.$t('地域'), value: 'area' },
         { text: this.$t('ふりがな'), value: 'ruby' },
@@ -73,7 +73,7 @@ export default {
       if (d.label === '小計') {
         continue
       }
-      if (this.$i18n.locale == 'ja') {
+      if (this.$i18n.locale === 'ja') {
         municipalitiesTable.datasets.push({
           area: this.$t(d.area),
           ruby: this.$t(d.ruby),


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3703 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `ConfirmedCasesByMunicipalitiesCard` にlocaleの設定のif文を追加

日本語以外の言語でページを閲覧する場合、区市町村別の陽性患者数の表のふりがな欄が表示されません。
