### PR TITLE
refs #3322 ベトナム語のREADME.mdから、「開発者向け情報」を別ファイルに分ける

### DIFF
--- a/docs/vi/FOR_DEVELOPERS.md
+++ b/docs/vi/FOR_DEVELOPERS.md
@@ -1,0 +1,200 @@
+# Thông tin cho nhà phát triển
+
+## 1. Xây dựng môi trường
+
+[PLEASE TRANSLATE ME]
+
+Install the following application to the environment for development.
+
+| Application name | Application version(Fill in only if specified) | Installation conditions |
+| ------- | ------- | ------- |
+|[Node.js](https://nodejs.org/en/)|10.19.0 hoặc cao hơn|Required|
+|[Visual Studio Code](https://code.visualstudio.com/)| |If you use Visual Studio Code|
+|[yarn](https://classic.yarnpkg.com/en/)| |When executing this program with `yarn`|
+|[docker compose](https://docs.docker.com/compose/install/)| |When executing this program with `docker compose`|
+|[Vagrant](https://www.vagrantup.com/)| |When executing this program with `Vagrant`|
+
+### 1-1. Extensions for Visual Studio Code
+
+To use Visual Studio Code, install the following extension.
+
+| Extensions | Installation conditions |
+| ------- | ------- |
+|[ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)|Any|
+|[Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur)|Any|
+|[TSLint](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin)|Any|
+|[Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)|Any|
+|[Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)|When developing with Visual Studio Code and Remote Containers|
+
+---
+
+## 2. Run this program
+
+The command is executed in the working copy root directory.
+
+[/PLEASE TRANSLATE ME]
+
+### 2-1. Nếu dùng `yarn`
+
+[PLEASE TRANSLATE ME]
+
+#### 2-1-1. Install dependencies
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+# install dependencies
+$ yarn install
+```
+
+[PLEASE TRANSLATE ME]
+
+#### 2-1-2. Run this program
+
+After executing the following command, you can check the program under development by accessing http://localhost:3000 .
+
+##### 2-1-2-1. Normal
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+# serve with hot reload at localhost:3000
+$ yarn dev
+```
+
+[PLEASE TRANSLATE ME]
+
+##### 2-1-2-2. Faster
+
+You can disable accessibility auditing, which would make your local server faster.
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+# serve with hot reload at localhost:3000
+$ yarn dev-no-axe
+```
+
+[PLEASE TRANSLATE ME]
+
+### 2-1-3. Troubleshoot
+
+#### 2-1-3-1. How to resolve `Cannot find module ****` error
+
+Build the dependency again and run the program.
+
+[/PLEASE TRANSLATE ME]
+
+### 2-2. Nếu dùng `docker compose`
+
+[PLEASE TRANSLATE ME]
+
+#### 2-2-1. Install dependencies and run this program
+
+After executing the following command, you can check the program under development by accessing http://localhost:3000 .
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+# serve with hot reload at localhost:3000
+$ docker-compose up --build
+```
+
+[PLEASE TRANSLATE ME]
+
+### 2-2-2. Troubleshoot
+
+#### 2-2-2-1. How to resolve `Cannot find module ****` error
+
+Stop the program and execute the following command.
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+$ docker-compose run --rm app yarn install
+```
+
+### 2-3. Nếu dùng `Vagrant`
+
+[PLEASE TRANSLATE ME]
+
+#### 2-3-1. Install dependencies and run this program
+
+After executing the following command, you can check the program under development by accessing http://localhost:3000 .
+
+[/PLEASE TRANSLATE ME]
+
+```bash
+# serve with hot reload at localhost:3000
+$ vagrant up
+```
+
+[PLEASE TRANSLATE ME]
+
+### 2-4. When developing with Visual Studio Code and Remote Containers
+
+#### 2-4-1. Install dependencies and run this program
+
+If you select the “Open Folder in Container” root of this repository (as seen in the lower left [Quick start: Try a dev container (external site)](https://code.visualstudio.com/docs/remote/containers#_quick-start-try-a-dev-container)), the environment construction will start.
+
+You can check the program under development by accessing http://localhost:3000 after building the environment.
+
+#### 2-4-2. Notes
+
+- If you want to change the settings, modify `.devcontainer/devcontainer.json`. Please refer to [devcontainer.json reference](https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference) for more details.
+- The extension "ESLint" is only valid when executing Remote Container. Please add it to the `extensions` of `.devcontainer/devcontainer.json` if necessary.
+- A detailed procedure can be found [Managing extensions (external site)](https://code.visualstudio.com/docs/remote/containers#_managing-extensions).
+- When rebuilding the development environment, please execute “Rebuild Container” which can be found at the lower left.
+
+---
+
+## 3. Detect production/others environment
+
+On the production environment, `'production'` is assigned to `process.env.GENERATE_ENV` variable, on the other case `'development'` is assigned to the variable.  
+Please use the variable to detect which enviroinment is used at the runtime.
+
+[/PLEASE TRANSLATE ME]
+
+---
+
+## 4. Triển khai lên môi trường staging và production
+
+[PLEASE TRANSLATE ME]
+
+When the branch listed in the left column of the table below is updated, the branch and website will be updated automatically.
+
+| branch | A branch where HTML is built and updated | Website updated |
+| ---- | ---- | ---- |
+|`master`|`production`|The production site https://stopcovid19.metro.tokyo.lg.jp/|
+|`staging`|`gh-pages`|The staging site https://stg-covid19-tokyo.netlify.app/|
+|`development`|`dev-pages`|The development site https://dev-covid19-tokyo.netlify.app/|
+
+---
+
+## 5. Branch rules
+
+Pull Request is allowed only for `development`.
+Please use the following naming rules for the branch when sending a Pull Request.
+
+| Types of changes | Naming rules for the branch |
+| ---- | ---- |
+|Feature implementation|`feature/#{ISSUE_ID}-#{branch_title_name}`|
+|Hotfix commit|`hotfix/#{ISSUE_ID}-#{branch_title_name}`|
+
+### 5-1. Basic branch
+
+| Purpose | Branch | Confirmation URL | People who can make pull requests | Remarks |
+| ---- | ---- | ---- | ---- | ---- |
+| Development | development | https://dev-covid19-tokyo.netlify.app/ | All developers | base branch. Basically send a Pull Request here |
+| Staging | staging | https://stg-covid19-tokyo.netlify.app/ | Only administrators | For final confirmation before production. Non-admin pull requests are prohibited. |
+| Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Only administrators | Pull Requests other than Administrators are prohibited |
+
+### 5-2. Branch used by the system
+
+| Purpose | Branch | Confirmation URL | Remarks |
+| ---- | -------- | ---- | ---- |
+| Production site HTML | production | https://stopcovid19.metro.tokyo.lg.jp/ | Location where statically built HTML is located |
+| Staging site HTML | gh-pages | https://stg-covid19-tokyo.netlify.app/ | Where to find statically built HTML |
+| For OGP working directory | deploy / new_ogp | None | For updating OGP |
+
+[/PLEASE TRANSLATE ME]

--- a/docs/vi/README.md
+++ b/docs/vi/README.md
@@ -19,98 +19,12 @@ Phần mềm này được phân phối dưới giấy phép [MIT](./../../LICEN
 
 [PLEASE TRANSLATE ME]
 
-Please check [How to translate](./../../TRANSLATION.md) doc.
+## For Translators
 
-[/PLEASE TRANSLATE ME]
+Please check [How to translate](./../../TRANSLATION.md) doc.
 
 ## Thông tin cho nhà phát triển
 
-### Xây dựng môi trường
-
-- Node.js phiên bản: 10.19.0 hoặc cao hơn
-
-**Nếu dùng yarn**
-```bash
-# install dependencies
-$ yarn install
-
-# serve with hot reload at localhost:3000
-$ yarn dev
-```
-
-
-[PLEASE TRANSLATE ME]
-
-**アクセシビリティチェック（vue-axe）を無効にする方法**
-
-- 開発用ローカルサーバが重い場合、以下のようにアクセシビリティチェックを無効にして起動することができます。
-
-```bash
-# serve with hot reload at localhost:3000
-$ yarn dev-no-axe
-```
-
-[/PLEASE TRANSLATE ME]
-
-
-**Nếu dùng docker compose**
-```bash
-# serve with hot reload at localhost:3000
-$ docker-compose up --build
-```
-
-[PLEASE TRANSLATE ME]
-### VSCode + Remote Containersで開発する場合
-
-1. VSCodeの拡張機能「[Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack)」を導入します。
-2. [この画像（外部サイト）](https://code.visualstudio.com/docs/remote/containers#_quick-start-try-a-dev-container)のように左下部の「Open Folder in Container」でこのリポジトリのルートを選択すれば環境構築が始まります。
-
-#### Topic
-- 設定を変更したい場合は、`.devcontainer/devcontainer.json`を修正してください。
-詳細は[devcontainer.jsonのリファレンス](https://code.visualstudio.com/docs/remote/containers#_devcontainerjson-reference)を参照してください。
-- Remote Container実行時のみ有効な拡張機能「ESLint」を導入していますが、必要に応じて`devcontainer.json`の`extensions`に追加してください。
-詳細な手順は[こちら（外部サイト）](https://code.visualstudio.com/docs/remote/containers#_managing-extensions)を参照してください。
-- 開発環境を再構築する場合は、左下部の「Rebuild Container」を実行してください。
-
-### Detect production/others environment
-
-On the production environment, `'production'` is assigned to `process.env.GENERATE_ENV` variable, on the other case `'development'` is assigned to the variable.  
-Please use the variable to detect which enviroinment is used at the runtime.
-
-[/PLEASE TRANSLATE ME]
-
-### Triển khai lên môi trường staging và production
-
-Khi nhánh `master` được cập nhật, file HTML sẽ tự động được build dựa trên nhánh `production`. Sau đó https://stopcovid19.metro.tokyo.lg.jp/ sẽ được cập nhật.
-
-Khi nhánh `staging` được cập nhật, file HTML sẽ tự động được build dựa trên nhánh `gh-pages`. Sau đó https://stg-covid19-tokyo.netlify.app/ sẽ được cập nhật.
-
-Khi nhánh `development` được cập nhật, file HTML sẽ tự động được build dựa trên nhánh `dev-pages`. Sau đó https://dev-covid19-tokyo.netlify.app/ sẽ được cập nhật.
-
-
-[PLEASE TRANSLATE ME]
-
-### Branch rules
-
-Pull Request is allowed only for `development` and `dev-hotfix`.
-Please use the following naming rules for the branch when sending a Pull Request.
-
-Feature implementation: feature/#{ISSUE_ID}-#{branch_title_name}
-Hotfix commit: hotfix/#{ISSUE_ID}-{branch_title_name}
-
-#### Basic branch
-| Purpose | Branch | Confirmation URL | Remarks |
-| ---- | -------- | ---- | ---- |
-| Development | development | https://dev-covid19-tokyo.netlify.app/ | base branch. Basically send a Pull Request here |
-| Hotfix branch | dev-hotfix | None | Fixes that should be applied to production in haste. Use this if requested by the administrator |
-| Staging | staging | https://stg-covid19-tokyo.netlify.app/ | For final confirmation before production. Non-admin pull requests are prohibited |
-Production | master | https://stopcovid19.metro.tokyo.lg.jp/ | Pull Requests other than Administrators are prohibited |
-
-#### Branch used by the system
-| Purpose | Branch | Confirmation URL | Remarks |
-| ---- | -------- | ---- | ---- |
-| Production site HTML | production | https://stopcovid19.metro.tokyo.lg.jp/ | Location where statically built HTML is located |
-| Staging site HTML | gh-pages | https://stg-covid19-tokyo.netlify.app/ | Where to find statically built HTML |
-| For OGP working directory | deploy / new_ogp | None | For updating OGP |
+Please check [Thông tin cho nhà phát triển](./../../TRANSLATION.md) doc.
 
 [/PLEASE TRANSLATE ME]

--- a/docs/vi/README.md
+++ b/docs/vi/README.md
@@ -25,6 +25,6 @@ Please check [How to translate](./../../TRANSLATION.md) doc.
 
 ## Thông tin cho nhà phát triển
 
-Please check [Thông tin cho nhà phát triển](./../../TRANSLATION.md) doc.
+Please check [Thông tin cho nhà phát triển](./FOR_DEVELOPERS.md) doc.
 
 [/PLEASE TRANSLATE ME]


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #3322 (他言語の変更が終わったら、チケットをマージする)

## 📝 関連する issue / Related Issues
- #3143

## ⛏ 変更内容 / Details of Changes
ベトナム語の`README.md`から開発者向け情報を`FOR_DEVELOPERS.md`に分けた (#3143 のポーティング)

## 📸 スクリーンショット / Screenshots
なし