### PR TITLE
FORKED_SITES.mdに記載されている横浜市版のGitHubプロジェクト名を変更

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -26,7 +26,7 @@
 [](12)市原市|https://covid19-ichihara.netlify.app/|個人|[YanaseT/covid19-ichihara/](https://github.com/YanaseT/covid19-ichihara/)|
 [](12)八千代市|https://yachiyo-covid19.netlify.app/|有志（学生）|[taichi1222/covid19-yachiyo](https://github.com/taichi1222/covid19-yachiyo)|
 [](14)神奈川県|https://www.pref.kanagawa.jp/osirase/1369/|神奈川県（**公式**）||
-[](14)横浜市|https://covid19.yokohama/|個人|[code-for-yokohama/covid19](https://github.com/code-for-yokohama/covid19)|
+[](14)横浜市|https://covid19.yokohama/|個人|[covid19yokohama/covid19](https://github.com/covid19yokohama/covid19)|
 [](15)新潟県|https://niigata.stopcovid19.jp/|Code for Niigata|[CodeForNiigata/covid19](https://github.com/CodeForNiigata/covid19)|
 [](15)新潟県|https://stopcovid19-niigata-unofficial.netlify.app|air-h-128k-il|[air-h-128k-il/covid19](https://github.com/air-h-128k-il/covid19)|
 [](17)石川県|https://ishikawa-covid19.netlify.app/|個人|[Retsuki/covid19-ishikawa/](https://github.com/Retsuki/covid19-ishikawa/)|


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3761 

## ⛏ 変更内容 / Details of Changes
- FORKED_SITES.mdに記載されている横浜市版のGitHubプロジェクト名を以下の通り変更
変更前：code-for-yokohama
変更後：covid19yokohama
## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
- 変更前
<img width="954" alt="スクリーンショット 2020-04-27 20 53 13" src="https://user-images.githubusercontent.com/63949175/80372333-5cd00a80-88ce-11ea-97da-ce9fea992550.png">

- 変更後
<img width="928" alt="スクリーンショット 2020-04-27 21 29 43" src="https://user-images.githubusercontent.com/63949175/80372275-3f9b3c00-88ce-11ea-9f85-c42591a6ef24.png">