### PR TITLE
日付を nuxt-i18n (vue-i18n) で翻訳し、フォーマットを統一させる

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -9,6 +9,46 @@ const options: NuxtVueI18n.Options.AllOptionsInterface = {
   defaultLocale: 'ja',
   vueI18n: {
     fallbackLocale: 'ja',
+    dateTimeFormats: {
+      ja: {
+        datetime: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: false
+        },
+        date: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric'
+        },
+        dateWithoutYear: {
+          month: 'short',
+          day: 'numeric'
+        }
+      },
+      en: {
+        datetime: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: 'numeric',
+          hour12: false
+        },
+        date: {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric'
+        },
+        dateWithoutYear: {
+          month: 'short',
+          day: 'numeric'
+        }
+      }
+    },
     formatFallbackMessages: true
   },
   // vueI18nLoader: true,

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -11,7 +11,7 @@ const options: NuxtVueI18n.Options.AllOptionsInterface = {
     fallbackLocale: 'ja',
     dateTimeFormats: {
       ja: {
-        datetime: {
+        dateTime: {
           year: 'numeric',
           month: 'short',
           day: 'numeric',
@@ -30,7 +30,7 @@ const options: NuxtVueI18n.Options.AllOptionsInterface = {
         }
       },
       en: {
-        datetime: {
+        dateTime: {
           year: 'numeric',
           month: 'short',
           day: 'numeric',


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #3838

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- nux-i18n.config.ts に設定を追加しました

template 内で `$t()` を使う際に `{date}` のように記述するとその部分を可変にでき、`$t` 第２引数で渡した値が入ります。第２引数には script で `$d()` を使って日付をフォーマットします。

フォーマット設定はまずは現在サイト上で使用されている主要３パターン分の日本語、英語分の設定を作成しました。

- datetime（年月日 + 時刻）
- date（年月日形式）
- dateWithoutYear（月日形式） 

`nuxt-i18n.config.ts` に追記していくことでフォーマット、言語ともに自由に追加可能です

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

日本語フォーマットサンプル
![Screen Shot 2020-05-01 at 11 38 13](https://user-images.githubusercontent.com/807519/80777758-37c6ea80-8ba1-11ea-9266-4894f82a855a.png)

英語フォーマットサンプル
![Screen Shot 2020-05-01 at 11 38 28](https://user-images.githubusercontent.com/807519/80777761-3ac1db00-8ba1-11ea-9074-97ba49a60ba9.png)
