### PR TITLE
「新型コロナウイルス感染症に関する東京都の支援策」のアイテム変更

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -197,9 +197,8 @@ export default Vue.extend({
             'https://www.bousai.metro.tokyo.lg.jp/taisaku/saigai/1007261/index.html'
         },
         {
-          title: this.$t('新型コロナウイルス感染症に関する東京都の支援策'),
-          link:
-            'https://www.seisakukikaku.metro.tokyo.lg.jp/information/corona-support.html'
+          title: this.$t('東京都 新型コロナウイルス感染症 支援情報ナビ'),
+          link: 'https://covid19.supportnavi.metro.tokyo.lg.jp/'
         },
         {
           title: this.$t('東京都主催等 中止又は延期するイベント等'),


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #3809

## 📝 関連する issue / Related Issues
- #3809

## ⛏ 変更内容 / Details of Changes
サイドナビバーの「新型コロナウイルス感染症に関する東京都の支援策」を以下の通り変更

- タイトル: 東京都 新型コロナウイルス感染症 支援情報ナビ
- リンク先: https://covid19.supportnavi.metro.tokyo.lg.jp/

## 📸 スクリーンショット / Screenshots
<img width="244" alt="スクリーンショット 2020-05-01 11 43 06" src="https://user-images.githubusercontent.com/36391432/80777878-968c6400-8ba1-11ea-9e5c-ade240527130.png">

