### PR TITLE
[Hotfix] 直前の木曜日以降を薄い緑色にするロジックの修正

### DIFF
--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -44,9 +44,16 @@ export default {
   data() {
     // 検査実施日別状況
     const today = new Date()
-    const lastThursday = dayjs()
-      .startOf('day')
-      .day(4) // 直前の木曜日
+    // 直前の木曜日
+    const lastThursday =
+      dayjs().day() <= 4
+        ? dayjs()
+            .startOf('day')
+            .subtract(1, 'week')
+            .day(4)
+        : dayjs()
+            .startOf('day')
+            .day(4)
     const lastAvailableDate = dayjs(
       today.getFullYear() +
         '/' +

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -76,7 +76,7 @@ export default {
         (Data.inspections_summary.data['その他'][i]
           ? Data.inspections_summary.data['その他'][i]
           : 0)
-      if (l - i - 1 > fromLastThursdayDates) {
+      if (l - i > fromLastThursdayDates) {
         beforeLastThursday.push(sum)
         afterLastThursday.push(0)
       } else {


### PR DESCRIPTION
直前の木曜日を判定するロジックを修正しました。