### PR TITLE
フォントサイズを相対指定に修正

### DIFF
--- a/assets/global.scss
+++ b/assets/global.scss
@@ -1,5 +1,6 @@
 :root {
   box-sizing: border-box;
+  font-size: 62.5%;
 }
 
 body {
@@ -24,7 +25,7 @@ img {
   outline: dotted $gray-3 1px;
 }
 
-.visually-hidden { 
+.visually-hidden {
   position: fixed !important;
   top: 0 !important;
   left: 0 !important;

--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -52,9 +52,8 @@ $z-index-map: (
 
 // ==================
 // font-size
-@mixin font-size($size, $base: 16) {
-  font-size: $size + px;
-  font-size: ($size / $base) + rem;
+@mixin font-size($size, $important: false) {
+  font-size: ($size / 10) + rem #{if($important, "!important", "")};
 }
 
 @mixin card-h1 {

--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -265,8 +265,8 @@ export default Vue.extend(options)
   &Desc {
     margin-top: 10px;
     margin-bottom: 0 !important;
-    font-size: 12px;
     color: $gray-3;
+    @include font-size(12);
   }
 }
 </style>

--- a/components/ConfirmedCasesByMunicipalitiesTable.vue
+++ b/components/ConfirmedCasesByMunicipalitiesTable.vue
@@ -34,7 +34,7 @@
       height: auto;
       border-bottom: 1px solid $gray-4;
       color: $gray-2;
-      font-size: 12px;
+      @include font-size(12);
     }
 
     tbody {
@@ -48,7 +48,7 @@
         td {
           padding: 8px 10px;
           height: auto;
-          font-size: 12px;
+          @include font-size(12);
         }
 
         &:nth-child(odd) {

--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -36,9 +36,9 @@
     margin: 2px;
     border-radius: 4px !important;
     height: 24px !important;
-    font-size: 12px !important;
     color: $gray-1 !important;
     background-color: $white !important;
+    @include font-size(12, true);
 
     &::before {
       background-color: inherit;

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -59,7 +59,7 @@
       height: auto;
       border-bottom: 1px solid $gray-4;
       color: $gray-2;
-      font-size: 12px;
+      @include font-size(12);
 
       &.text-center {
         text-align: center;
@@ -77,7 +77,7 @@
         td {
           padding: 8px 10px;
           height: auto;
-          font-size: 12px;
+          @include font-size(12);
 
           &.text-center {
             text-align: center;
@@ -100,8 +100,8 @@
 
 .note {
   margin: 8px 0 0;
-  font-size: 12px;
   color: $gray-3;
+  @include font-size(12);
 
   ul,
   ol {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -359,22 +359,22 @@ export default Vue.extend({
       color: $gray-2;
       font-family: Hiragino Sans, sans-serif;
       font-style: normal;
-      font-size: 30px;
       line-height: 30px;
       white-space: nowrap;
+      @include font-size(30);
 
       &-unit {
-        font-size: 0.6em;
         width: 100%;
+        @include font-size(10);
       }
     }
 
     &-date {
-      font-size: 12px;
       line-height: 12px;
       color: $gray-3;
       width: 100%;
       display: inline-block;
+      @include font-size(12);
     }
   }
 
@@ -388,10 +388,10 @@ export default Vue.extend({
   &-Title {
     width: 100%;
     margin-bottom: 10px;
-    font-size: 1.25rem;
     line-height: 1.5;
     font-weight: normal;
     color: $gray-2;
+    @include font-size(20);
 
     @include largerThan($large) {
       margin-bottom: 0;
@@ -407,8 +407,8 @@ export default Vue.extend({
 
   &-Description {
     margin: 10px 0 0;
-    font-size: 12px;
     color: $gray-3;
+    @include font-size(12);
 
     ul,
     ol {
@@ -497,8 +497,8 @@ export default Vue.extend({
         background: $white !important;
         border-radius: 8px;
         text-align: left;
-        font-size: 1rem;
         z-index: 2;
+        @include font-size(16);
 
         > * {
           padding: 4px 0;
@@ -527,7 +527,7 @@ export default Vue.extend({
           color: rgb(3, 3, 3);
           border: solid 1px #eee;
           border-radius: 8px;
-          font-size: 12px;
+          @include font-size(12);
 
           .EmbedCode-Copy {
             position: absolute;
@@ -606,6 +606,7 @@ export default Vue.extend({
       background: $gray-2;
       border-radius: 8px;
       color: $white !important;
+      @include font-size(16);
     }
   }
 }
@@ -630,5 +631,6 @@ textarea {
 
 .expansion-panel-text {
   color: $gray-1;
+  @include font-size(14);
 }
 </style>

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -21,20 +21,20 @@
       display: inline-block;
       font-family: Hiragino Sans, sans-serif;
       font-style: normal;
-      font-size: 30px;
       line-height: 30px;
+      @include font-size(30);
 
       &-unit {
-        font-size: 0.6em;
+        @include font-size(18);
       }
     }
 
     &-date {
       white-space: wrap;
       display: inline-block;
-      font-size: 12px;
       line-height: 12px;
       color: $gray-3;
+      @include font-size(12);
     }
   }
 }

--- a/components/DevelopmentModeMark.vue
+++ b/components/DevelopmentModeMark.vue
@@ -16,7 +16,6 @@
   position: fixed;
   bottom: 0;
   left: 0;
-  font-size: 12px;
   z-index: 1;
   width: 100%;
   height: 20px;
@@ -25,6 +24,7 @@
   color: #4d4d4d;
   line-height: 20px;
   opacity: 0.9;
+  @include font-size(12);
 
   // mobile view
   @include lessThan($small) {

--- a/components/ExternalLink.vue
+++ b/components/ExternalLink.vue
@@ -3,7 +3,7 @@
     <slot />
     <v-icon
       class="ExternalLinkIcon"
-      :size="iconSize"
+      :size="`${iconSize / 10}rem`"
       :aria-label="this.$t('別タブで開く')"
       role="img"
       :aria-hidden="false"

--- a/components/LanguageSelector.vue
+++ b/components/LanguageSelector.vue
@@ -78,9 +78,9 @@ export default Vue.extend({
     content: 'Lang:';
     margin-left: 4px;
     color: $gray-1;
-    font-size: 12px;
+    @include font-size(12);
     @include lessThan($small) {
-      font-size: 16px;
+      @include font-size(16);
     }
   }
 }
@@ -106,8 +106,8 @@ export default Vue.extend({
   padding-left: 60px;
   width: 100%;
   height: 28px;
-  font-size: 12px;
   line-height: 28px;
+  @include font-size(12);
 
   &:focus {
     border: 1px dotted $gray-3;
@@ -115,7 +115,7 @@ export default Vue.extend({
   }
   @include lessThan($small) {
     padding-left: 70px;
-    font-size: 16px;
+    @include font-size(16);
   }
 }
 </style>

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -19,7 +19,7 @@
           aria-hidden="false"
           :aria-label="$t('別タブで開く')"
           class="MenuList-ExternalIcon"
-          size="12"
+          size="1.2rem"
         >
           mdi-open-in-new
         </v-icon>
@@ -78,7 +78,7 @@ export default Vue.extend({
       return icon
         ? icon.startsWith('mdi')
           ? {
-              size: 20,
+              size: '2rem',
               class: 'MenuList-MdIcon'
             }
           : {
@@ -107,12 +107,12 @@ export default Vue.extend({
 
 .MenuList-Item {
   list-style: none;
-  font-size: 0.85rem;
   line-height: 1.2;
   white-space: normal;
+  @include font-size(14);
   @include lessThan($small) {
-    font-size: 0.9rem;
     font-weight: bold;
+    @include font-size(14.5);
   }
 
   &.-border {
@@ -190,7 +190,7 @@ export default Vue.extend({
   margin-left: 5px;
   color: $gray-3;
   @include lessThan($small) {
-    font-size: 14px !important;
+    @include font-size(14, true);
   }
 }
 </style>

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -276,9 +276,9 @@ export default Vue.extend(options)
     margin-top: 10px;
     margin-bottom: 0 !important;
     padding-left: 0 !important;
-    font-size: 12px;
     color: $gray-3;
     list-style: none;
+    @include font-size(12);
   }
 }
 </style>

--- a/components/OpenDataLink.vue
+++ b/components/OpenDataLink.vue
@@ -3,7 +3,7 @@
     {{ $t('オープンデータを入手') }}
     <v-icon
       class="ExternalLinkIcon"
-      size="15"
+      size="1.5rem"
       :aria-label="this.$t('別タブで開く')"
       role="img"
       :aria-hidden="false"

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="header">
     <h2 class="pageTitle">
-      <v-icon v-if="icon" size="40" class="mr-2">
+      <v-icon v-if="icon" size="4rem" class="mr-2">
         {{ icon }}
       </v-icon>
       <slot />

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -306,8 +306,8 @@ export default Vue.extend({
 
 .SideNavigation-HeaderTitle {
   width: 100%;
-  font-size: 13px;
   color: #707070;
+  @include font-size(13);
   @include largerThan($small) {
     margin: 0;
     margin-top: 10px;
@@ -395,7 +395,7 @@ export default Vue.extend({
 .SideNavigation-LanguageLabel {
   display: block;
   margin-bottom: 5px;
-  font-size: 0.85rem;
+  @include font-size(14);
 }
 
 .SideNavigation-Footer {
@@ -439,9 +439,9 @@ export default Vue.extend({
   display: block;
   margin-top: 15px;
   color: $gray-1;
-  font-size: 10px;
   line-height: 1.3;
   font-weight: bold;
+  @include font-size(10);
 }
 
 .SideNavigation-LicenseLink {

--- a/components/SourceLink.vue
+++ b/components/SourceLink.vue
@@ -10,7 +10,7 @@
           rel="noopener noreferrer"
         >
           {{ linkString }}
-          <v-icon class="ExternalLinkIcon" size="15">
+          <v-icon class="ExternalLinkIcon" size="1.5rem">
             mdi-open-in-new
           </v-icon>
         </a>

--- a/components/StaticCard.vue
+++ b/components/StaticCard.vue
@@ -13,6 +13,7 @@ export default Vue.extend()
 <style lang="scss">
 .StaticCard {
   @include card-container();
+  @include font-size(16);
 
   padding: 20px;
   margin-bottom: 20px;

--- a/components/TestedCasesDetailsTable.vue
+++ b/components/TestedCasesDetailsTable.vue
@@ -213,6 +213,7 @@ $default-boxh: 150px;
       width: 100%;
       padding: 10px 10px 10px calc(10px + #{$default-bdw});
       border-right: $default-bdw solid $green-1;
+      @include font-size(16);
     }
 
     > .pillar {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -614,9 +614,9 @@ export default Vue.extend(options)
     margin: 0;
     margin-bottom: 0 !important;
     padding-left: 0 !important;
-    font-size: 12px;
     color: $gray-3;
     list-style: none;
+    @include font-size(12);
   }
   &Legend {
     text-align: center;
@@ -636,7 +636,7 @@ export default Vue.extend(options)
       }
       button {
         color: $gray-3;
-        font-size: 12px;
+        @include font-size(12);
       }
     }
   }
@@ -646,9 +646,9 @@ export default Vue.extend(options)
   &Desc {
     margin-top: 10px;
     margin-bottom: 0 !important;
-    font-size: 12px;
     line-height: 15px;
     color: $gray-3;
+    @include font-size(12);
   }
 }
 </style>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -2,7 +2,7 @@
   <div class="WhatsNew">
     <div class="WhatsNew-heading">
       <h3 class="WhatsNew-title">
-        <v-icon size="24" class="WhatsNew-title-icon">
+        <v-icon size="2.4rem" class="WhatsNew-title-icon">
           mdi-information
         </v-icon>
         {{ $t('最新のお知らせ') }}
@@ -11,7 +11,7 @@
         <external-link
           url="https://www.bousai.metro.tokyo.lg.jp/1007617/index.html"
         >
-          <v-icon size="20" class="WhatsNew-link-to-emergency-page-icon">
+          <v-icon size="2rem" class="WhatsNew-link-to-emergency-page-icon">
             mdi-bullhorn
           </v-icon>
           {{ $t('東京都緊急事態措置について') }}
@@ -37,7 +37,7 @@
             <v-icon
               v-if="!isInternalLink(item.url)"
               class="WhatsNew-item-ExternalLinkIcon"
-              size="12"
+              size="1.2rem"
             >
               mdi-open-in-new
             </v-icon>
@@ -108,9 +108,9 @@ export default Vue.extend({
       border: 2px solid $emergency;
       color: $gray-2;
       border-radius: 4px;
-      font-size: 1rem;
       padding: 4px 8px;
       display: inline-flex;
+      @include font-size(16);
       &:hover {
         background-color: $white;
         border-radius: 4px;
@@ -141,7 +141,7 @@ export default Vue.extend({
       &-anchor {
         text-decoration: none;
         margin: 5px;
-        font-size: 14px;
+        @include font-size(14);
 
         @include lessThan($medium) {
           display: flex;

--- a/components/cards/TestedCasesDetailsCard.vue
+++ b/components/cards/TestedCasesDetailsCard.vue
@@ -47,8 +47,8 @@ ul.notes {
   margin-top: 10px;
   margin-bottom: 0;
   padding-left: 0 !important;
-  font-size: 12px;
   color: $gray-3;
+  @include font-size(12);
 
   > li {
     list-style-type: none;

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -114,9 +114,9 @@ export default {
     margin: 0;
     margin-top: 1rem;
     padding-left: 0 !important;
-    font-size: 12px;
     color: $gray-3;
     list-style: none;
+    @include font-size(12);
   }
 }
 </style>

--- a/layouts/print.vue
+++ b/layouts/print.vue
@@ -143,10 +143,10 @@ export default Vue.extend({
   }
 
   &-Heading {
-    font-size: 13px;
     color: #898989;
     padding: 0.5em 0;
     text-decoration: none;
+    @include font-size(13);
   }
 
   &-QRWrapper {
@@ -166,18 +166,18 @@ export default Vue.extend({
   }
 
   &-Text {
-    font-size: 13px;
     color: gray;
     margin-bottom: 0;
     padding-top: 1em;
     width: max-content;
+    @include font-size(13);
   }
 
   &-Link {
-    font-size: 13px;
     color: gray;
     margin-bottom: 0;
     width: max-content;
+    @include font-size(13);
   }
 }
 </style>

--- a/pages/contacts.vue
+++ b/pages/contacts.vue
@@ -186,12 +186,12 @@ export default Vue.extend({
       border-collapse: collapse;
 
       th {
-        font-size: 14px !important;
+        @include font-size(14, true);
       }
 
       td {
         padding: 0 16px;
-        font-size: 14px;
+        @include font-size(14);
       }
 
       @include largerThan($medium) {
@@ -255,8 +255,8 @@ export default Vue.extend({
       }
 
       p.caution {
-        font-size: 12px;
         margin: 0;
+        @include font-size(12);
       }
     }
   }

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -90,7 +90,7 @@
           </li>
         </ul>
         <div :class="[$style.box, $style.bgGray]">
-          <h5 :class="$style.sxnHeading">
+          <h5 :class="$style.boxHeading">
             {{ $t('新型コロナ受診相談窓口は、24時間対応しています') }}
           </h5>
           <dl :class="$style.contact">
@@ -251,7 +251,7 @@
         :class="$style.detailButton"
         rel="noopener noreferrer"
         >{{ $t('詳細を見る（東京都福祉保健局）') }}
-        <v-icon :class="$style.icon" size="20">
+        <v-icon :class="$style.icon" size="2rem">
           mdi-open-in-new
         </v-icon>
       </a>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -44,7 +44,6 @@
       <!-- 都庁来庁者数の推移 -->
       <agency-card />
     </card-row>
-    <v-divider />
   </div>
 </template>
 


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #3865 

## ⛏ 変更内容 / Details of Changes
- rootのfont-sizeを62.5%に修正
- font-sizeのmixinを修正（px変換の部分を削除）
- フォントサイズ、v-iconのsizeをrem指定にする
- flowのclass指定が違っていたので修正
- ついでに、サイトトップの下部に横線が消し忘れたままだったので削除

## 📸 スクリーンショット / Screenshots
### miCheckerで検証
- 「問題あり」のフォントサイズ関連の指摘はなくなりました
- 代わりに「問題の可能性大」は増えたので引き続き要検討です

**miChecker「問題あり」before**
![問題ありbefore](https://user-images.githubusercontent.com/14883063/81147663-b8c51e00-8fb5-11ea-9ccf-68379e435d6e.jpg)

**miChecker「問題あり」after**
![問題ありafter](https://user-images.githubusercontent.com/14883063/81147677-c084c280-8fb5-11ea-9a65-550ff4f9e755.jpg)
