### PR TITLE
「検査実施状況」チャートに保健所分と民間分を掲載

### DIFF
--- a/components/TestedCasesDetailsTable.vue
+++ b/components/TestedCasesDetailsTable.vue
@@ -38,9 +38,11 @@
         <li :class="[$style.box, $style.inside]">
           <div :class="$style.pillar">
             <div :class="$style.content">
-              <span>{{ $t('都内発生') }}</span>
+              <span>{{ $t('健康安全研究センター実施分') }}</span>
               <span>
-                <strong>{{ 都内発生件数.toLocaleString() }}</strong>
+                <strong>{{
+                  健康安全研究センター実施分.toLocaleString()
+                }}</strong>
                 <span :class="$style.unit">{{ $t('件.tested') }}</span>
               </span>
             </div>
@@ -49,12 +51,9 @@
         <li :class="[$style.box, $style.others]">
           <div :class="$style.pillar">
             <div :class="$style.content">
-              <span>{{ $t('その他.graph') }}</span>
-              <span :class="$style.small">{{
-                $t('（チャーター機・クルーズ船等）')
-              }}</span>
+              <span>{{ $t('医療機関等実施分') }}</span>
               <span>
-                <strong>{{ その他件数.toLocaleString() }}</strong>
+                <strong>{{ 医療機関等実施分.toLocaleString() }}</strong>
                 <span :class="$style.unit">{{ $t('件.tested') }}</span>
               </span>
             </div>
@@ -79,11 +78,11 @@ export default Vue.extend({
       type: Number,
       required: true
     },
-    都内発生件数: {
+    健康安全研究センター実施分: {
       type: Number,
       required: true
     },
-    その他件数: {
+    医療機関等実施分: {
       type: Number,
       required: true
     }

--- a/utils/formatTestedCases.ts
+++ b/utils/formatTestedCases.ts
@@ -7,11 +7,11 @@ type DataType = {
       value: number
       children: [
         {
-          attr: '都内発生件数'
+          attr: '健康安全研究センター実施分'
           value: number
         },
         {
-          attr: 'その他件数'
+          attr: '医療機関等実施分'
           value: number
         }
       ]
@@ -22,8 +22,8 @@ type DataType = {
 type TestedCasesType = {
   累計人数: number
   合計件数: number
-  都内発生件数: number
-  その他件数: number
+  健康安全研究センター実施分: number
+  医療機関等実施分: number
 }
 
 /**
@@ -35,8 +35,8 @@ export default (data: DataType) => {
   const formattedData: TestedCasesType = {
     累計人数: data.value,
     合計件数: data.children[0].value,
-    都内発生件数: data.children[0].children[0].value,
-    その他件数: data.children[0].children[1].value
+    健康安全研究センター実施分: data.children[0].children[0].value,
+    医療機関等実施分: data.children[0].children[1].value
   }
   return formattedData
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4005


## 📝 関連する issue / Related Issues
- #4005


## ⛏ 変更内容 / Details of Changes
「検査実施状況」チャートのデータの分け方を以下の通り変更
- 都内発生→健康安全研究センター実施分
- その他→医療機関等実施分

## 📸 スクリーンショット / Screenshots
<img width="426" alt="スクリーンショット 2020-05-09 14 56 43" src="https://user-images.githubusercontent.com/36391432/81465475-5a8e7a00-9205-11ea-971c-7ffbb4611818.png">
