### PR TITLE
[hotfix]「検査実施状況」と「検査実施人数」の間で区切る

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -31,6 +31,8 @@
       <confirmed-cases-by-municipalities-card />
       <!-- 検査実施状況 -->
       <tested-cases-details-card />
+    </card-row>
+    <card-row class="DataBlock">
       <!-- 検査実施人数 -->
       <inspection-persons-number-card />
       <!-- 検査実施件数 -->


### PR DESCRIPTION
hotfix対応です。「検査実施人数」と「検査実施件数」が左右に並ぶように `card-row` のタグで区切りました。