### PR TITLE
「陽性患者数」グラフのタイトル名及び注釈の変更

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -132,6 +132,7 @@ type Props = {
   url: string
   scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
+  byDate: boolean
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -185,6 +186,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     yAxesBgPlugin: {
       type: Array,
       default: () => yAxesBgPlugin
+    },
+    byDate: {
+      type: Boolean,
+      default: false
     }
   },
   data: () => ({
@@ -204,7 +209,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
-      if (this.dataKind === 'transition') {
+      if (this.dataKind === 'transition' && this.byDate) {
+        return {
+          lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
+          sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+            '日別値'
+          )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      } else if (this.dataKind === 'transition') {
         return {
           lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
           sText: `${this.chartData.slice(-1)[0].label} ${this.$t(

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,6 +7,7 @@
       :chart-data="patientsGraph"
       :date="Data.patients.date"
       :unit="$t('人')"
+      :by-date="true"
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
     >
       <template v-slot:description>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <time-bar-chart
-      :title="$t('陽性患者数')"
+      :title="$t('新規患者に関する報告件数の推移')"
       :title-id="'number-of-confirmed-cases'"
       :chart-id="'time-bar-chart-patients'"
       :chart-data="patientsGraph"
@@ -11,6 +11,9 @@
     >
       <template v-slot:description>
         <ul>
+          <li>
+            {{ $t('（注）保健所から発生届が提出された日を基準とする') }}
+          </li>
           <li>
             {{ $t('（注）医療機関等が行った検査も含む') }}
           </li>

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-col cols="12" md="6" class="DataCard">
+    <time-bar-chart
+      :title="$t('陽性患者数（検査結果判明日別）')"
+      :title-id="'positive-number-by-diagnosed-date'"
+      :chart-id="'positive-number-by-diagnosed-date'"
+      :chart-data="graphData"
+      :date="data.date"
+      :unit="$t('人')"
+      :by-date="true"
+    >
+      <template v-slot:description>
+        <ul>
+          <li>
+            {{ $t('（注）検査結果の判明日を基準とする') }}
+          </li>
+          <li>
+            {{ $t('（注）医療機関等が行った検査も含む') }}
+          </li>
+          <li>
+            {{
+              $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
+            }}
+          </li>
+        </ul>
+      </template>
+    </time-bar-chart>
+  </v-col>
+</template>
+
+<script>
+import Data from '@/data/positive_by_diagnosed.json'
+import formatGraph from '@/utils/formatGraph'
+import TimeBarChart from '@/components/TimeBarChart.vue'
+
+export default {
+  components: {
+    TimeBarChart
+  },
+  data() {
+    const formatData = Data.data.map(data => {
+      return {
+        日付: data.diagnosed_date,
+        小計: data.count
+      }
+    })
+
+    // 陽性患者数グラフ
+    const graphData = formatGraph(formatData)
+
+    return {
+      data: Data,
+      graphData
+    }
+  }
+}
+</script>

--- a/data/positive_by_diagnosed.json
+++ b/data/positive_by_diagnosed.json
@@ -1,0 +1,425 @@
+{
+    "date": "2020\/5\/9 20:00",
+    "data": [
+        {
+            "diagnosed_date": "2020-01-24",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-25",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-26",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-27",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-28",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-29",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-30",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-01-31",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-01",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-02",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-03",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-04",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-05",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-06",
+            "count": 2
+        },
+        {
+            "diagnosed_date": "2020-02-07",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-02-08",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-09",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-10",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-11",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-12",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-02-13",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-02-14",
+            "count": 2
+        },
+        {
+            "diagnosed_date": "2020-02-15",
+            "count": 7
+        },
+        {
+            "diagnosed_date": "2020-02-16",
+            "count": 5
+        },
+        {
+            "diagnosed_date": "2020-02-17",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-02-18",
+            "count": 3
+        },
+        {
+            "diagnosed_date": "2020-02-19",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-02-20",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-21",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-02-22",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-23",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-24",
+            "count": 3
+        },
+        {
+            "diagnosed_date": "2020-02-25",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-26",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-02-27",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-28",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-02-29",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-03-01",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-03-02",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-03-03",
+            "count": 2
+        },
+        {
+            "diagnosed_date": "2020-03-04",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-05",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-06",
+            "count": 8
+        },
+        {
+            "diagnosed_date": "2020-03-07",
+            "count": 6
+        },
+        {
+            "diagnosed_date": "2020-03-08",
+            "count": 1
+        },
+        {
+            "diagnosed_date": "2020-03-09",
+            "count": 0
+        },
+        {
+            "diagnosed_date": "2020-03-10",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-11",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-12",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-13",
+            "count": 5
+        },
+        {
+            "diagnosed_date": "2020-03-14",
+            "count": 5
+        },
+        {
+            "diagnosed_date": "2020-03-15",
+            "count": 3
+        },
+        {
+            "diagnosed_date": "2020-03-16",
+            "count": 4
+        },
+        {
+            "diagnosed_date": "2020-03-17",
+            "count": 10
+        },
+        {
+            "diagnosed_date": "2020-03-18",
+            "count": 10
+        },
+        {
+            "diagnosed_date": "2020-03-19",
+            "count": 9
+        },
+        {
+            "diagnosed_date": "2020-03-20",
+            "count": 8
+        },
+        {
+            "diagnosed_date": "2020-03-21",
+            "count": 7
+        },
+        {
+            "diagnosed_date": "2020-03-22",
+            "count": 3
+        },
+        {
+            "diagnosed_date": "2020-03-23",
+            "count": 20
+        },
+        {
+            "diagnosed_date": "2020-03-24",
+            "count": 29
+        },
+        {
+            "diagnosed_date": "2020-03-25",
+            "count": 47
+        },
+        {
+            "diagnosed_date": "2020-03-26",
+            "count": 35
+        },
+        {
+            "diagnosed_date": "2020-03-27",
+            "count": 53
+        },
+        {
+            "diagnosed_date": "2020-03-28",
+            "count": 60
+        },
+        {
+            "diagnosed_date": "2020-03-29",
+            "count": 51
+        },
+        {
+            "diagnosed_date": "2020-03-30",
+            "count": 52
+        },
+        {
+            "diagnosed_date": "2020-03-31",
+            "count": 63
+        },
+        {
+            "diagnosed_date": "2020-04-01",
+            "count": 93
+        },
+        {
+            "diagnosed_date": "2020-04-02",
+            "count": 83
+        },
+        {
+            "diagnosed_date": "2020-04-03",
+            "count": 150
+        },
+        {
+            "diagnosed_date": "2020-04-04",
+            "count": 125
+        },
+        {
+            "diagnosed_date": "2020-04-05",
+            "count": 85
+        },
+        {
+            "diagnosed_date": "2020-04-06",
+            "count": 82
+        },
+        {
+            "diagnosed_date": "2020-04-07",
+            "count": 124
+        },
+        {
+            "diagnosed_date": "2020-04-08",
+            "count": 179
+        },
+        {
+            "diagnosed_date": "2020-04-09",
+            "count": 255
+        },
+        {
+            "diagnosed_date": "2020-04-10",
+            "count": 171
+        },
+        {
+            "diagnosed_date": "2020-04-11",
+            "count": 222
+        },
+        {
+            "diagnosed_date": "2020-04-12",
+            "count": 136
+        },
+        {
+            "diagnosed_date": "2020-04-13",
+            "count": 172
+        },
+        {
+            "diagnosed_date": "2020-04-14",
+            "count": 124
+        },
+        {
+            "diagnosed_date": "2020-04-15",
+            "count": 188
+        },
+        {
+            "diagnosed_date": "2020-04-16",
+            "count": 221
+        },
+        {
+            "diagnosed_date": "2020-04-17",
+            "count": 188
+        },
+        {
+            "diagnosed_date": "2020-04-18",
+            "count": 151
+        },
+        {
+            "diagnosed_date": "2020-04-19",
+            "count": 85
+        },
+        {
+            "diagnosed_date": "2020-04-20",
+            "count": 111
+        },
+        {
+            "diagnosed_date": "2020-04-21",
+            "count": 112
+        },
+        {
+            "diagnosed_date": "2020-04-22",
+            "count": 126
+        },
+        {
+            "diagnosed_date": "2020-04-23",
+            "count": 114
+        },
+        {
+            "diagnosed_date": "2020-04-24",
+            "count": 106
+        },
+        {
+            "diagnosed_date": "2020-04-25",
+            "count": 87
+        },
+        {
+            "diagnosed_date": "2020-04-26",
+            "count": 53
+        },
+        {
+            "diagnosed_date": "2020-04-27",
+            "count": 64
+        },
+        {
+            "diagnosed_date": "2020-04-28",
+            "count": 98
+        },
+        {
+            "diagnosed_date": "2020-04-29",
+            "count": 66
+        },
+        {
+            "diagnosed_date": "2020-04-30",
+            "count": 86
+        },
+        {
+            "diagnosed_date": "2020-05-01",
+            "count": 51
+        },
+        {
+            "diagnosed_date": "2020-05-02",
+            "count": 75
+        },
+        {
+            "diagnosed_date": "2020-05-03",
+            "count": 54
+        },
+        {
+            "diagnosed_date": "2020-05-04",
+            "count": 35
+        },
+        {
+            "diagnosed_date": "2020-05-05",
+            "count": 28
+        },
+        {
+            "diagnosed_date": "2020-05-06",
+            "count": 9
+        },
+        {
+            "diagnosed_date": "2020-05-07",
+            "count": 0
+        }
+    ]
+}

--- a/data/positive_rate.json
+++ b/data/positive_rate.json
@@ -1,0 +1,635 @@
+{
+    "date": "2020\/5\/9 20:00",
+    "data": [
+        {
+            "diagnosed_date": "2020-01-24",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-25",
+            "positive_count": 1,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-26",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-27",
+            "positive_count": 0,
+            "negative_count": 1,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-28",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-29",
+            "positive_count": 0,
+            "negative_count": 5,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-30",
+            "positive_count": 1,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-01-31",
+            "positive_count": 0,
+            "negative_count": 2,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-01",
+            "positive_count": 0,
+            "negative_count": 1,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-02",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-03",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-04",
+            "positive_count": 0,
+            "negative_count": 4,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-05",
+            "positive_count": 0,
+            "negative_count": 3,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-06",
+            "positive_count": 0,
+            "negative_count": 5,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-07",
+            "positive_count": 0,
+            "negative_count": 4,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-08",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-09",
+            "positive_count": 0,
+            "negative_count": 3,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-10",
+            "positive_count": 0,
+            "negative_count": 1,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-11",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-12",
+            "positive_count": 0,
+            "negative_count": 1,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-13",
+            "positive_count": 1,
+            "negative_count": 3,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-14",
+            "positive_count": 2,
+            "negative_count": 1,
+            "positive_rate": 0
+        },
+        {
+            "diagnosed_date": "2020-02-15",
+            "positive_count": 8,
+            "negative_count": 122,
+            "positive_rate": 10
+        },
+        {
+            "diagnosed_date": "2020-02-16",
+            "positive_count": 5,
+            "negative_count": 69,
+            "positive_rate": 6.7
+        },
+        {
+            "diagnosed_date": "2020-02-17",
+            "positive_count": 3,
+            "negative_count": 4,
+            "positive_rate": 9.7
+        },
+        {
+            "diagnosed_date": "2020-02-18",
+            "positive_count": 0,
+            "negative_count": 24,
+            "positive_rate": 8.6
+        },
+        {
+            "diagnosed_date": "2020-02-19",
+            "positive_count": 3,
+            "negative_count": 77,
+            "positive_rate": 6.5
+        },
+        {
+            "diagnosed_date": "2020-02-20",
+            "positive_count": 2,
+            "negative_count": 58,
+            "positive_rate": 5.6
+        },
+        {
+            "diagnosed_date": "2020-02-21",
+            "positive_count": 2,
+            "negative_count": 33,
+            "positive_rate": 5.1
+        },
+        {
+            "diagnosed_date": "2020-02-22",
+            "positive_count": 1,
+            "negative_count": 33,
+            "positive_rate": 4.4
+        },
+        {
+            "diagnosed_date": "2020-02-23",
+            "positive_count": 1,
+            "negative_count": 6,
+            "positive_rate": 5.7
+        },
+        {
+            "diagnosed_date": "2020-02-24",
+            "positive_count": 1,
+            "negative_count": 13,
+            "positive_rate": 2.8
+        },
+        {
+            "diagnosed_date": "2020-02-25",
+            "positive_count": 0,
+            "negative_count": 44,
+            "positive_rate": 2.6
+        },
+        {
+            "diagnosed_date": "2020-02-26",
+            "positive_count": 3,
+            "negative_count": 48,
+            "positive_rate": 2.9
+        },
+        {
+            "diagnosed_date": "2020-02-27",
+            "positive_count": 1,
+            "negative_count": 67,
+            "positive_rate": 2.8
+        },
+        {
+            "diagnosed_date": "2020-02-28",
+            "positive_count": 0,
+            "negative_count": 64,
+            "positive_rate": 2.5
+        },
+        {
+            "diagnosed_date": "2020-02-29",
+            "positive_count": 1,
+            "negative_count": 55,
+            "positive_rate": 2.3
+        },
+        {
+            "diagnosed_date": "2020-03-01",
+            "positive_count": 2,
+            "negative_count": 12,
+            "positive_rate": 2.3
+        },
+        {
+            "diagnosed_date": "2020-03-02",
+            "positive_count": 0,
+            "negative_count": 32,
+            "positive_rate": 2.1
+        },
+        {
+            "diagnosed_date": "2020-03-03",
+            "positive_count": 1,
+            "negative_count": 73,
+            "positive_rate": 2
+        },
+        {
+            "diagnosed_date": "2020-03-04",
+            "positive_count": 4,
+            "negative_count": 78,
+            "positive_rate": 1.8
+        },
+        {
+            "diagnosed_date": "2020-03-05",
+            "positive_count": 8,
+            "negative_count": 71,
+            "positive_rate": 3.5
+        },
+        {
+            "diagnosed_date": "2020-03-06",
+            "positive_count": 6,
+            "negative_count": 65,
+            "positive_rate": 5.2
+        },
+        {
+            "diagnosed_date": "2020-03-07",
+            "positive_count": 6,
+            "negative_count": 88,
+            "positive_rate": 6.2
+        },
+        {
+            "diagnosed_date": "2020-03-08",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 6.5
+        },
+        {
+            "diagnosed_date": "2020-03-09",
+            "positive_count": 0,
+            "negative_count": 23,
+            "positive_rate": 6.7
+        },
+        {
+            "diagnosed_date": "2020-03-10",
+            "positive_count": 3,
+            "negative_count": 62,
+            "positive_rate": 6.8
+        },
+        {
+            "diagnosed_date": "2020-03-11",
+            "positive_count": 5,
+            "negative_count": 114,
+            "positive_rate": 6.2
+        },
+        {
+            "diagnosed_date": "2020-03-12",
+            "positive_count": 2,
+            "negative_count": 82,
+            "positive_rate": 4.6
+        },
+        {
+            "diagnosed_date": "2020-03-13",
+            "positive_count": 2,
+            "negative_count": 56,
+            "positive_rate": 4.8
+        },
+        {
+            "diagnosed_date": "2020-03-14",
+            "positive_count": 7,
+            "negative_count": 64,
+            "positive_rate": 5
+        },
+        {
+            "diagnosed_date": "2020-03-15",
+            "positive_count": 0,
+            "negative_count": 0,
+            "positive_rate": 5
+        },
+        {
+            "diagnosed_date": "2020-03-16",
+            "positive_count": 0,
+            "negative_count": 19,
+            "positive_rate": 5.1
+        },
+        {
+            "diagnosed_date": "2020-03-17",
+            "positive_count": 11,
+            "negative_count": 60,
+            "positive_rate": 6.7
+        },
+        {
+            "diagnosed_date": "2020-03-18",
+            "positive_count": 4,
+            "negative_count": 101,
+            "positive_rate": 6.9
+        },
+        {
+            "diagnosed_date": "2020-03-19",
+            "positive_count": 5,
+            "negative_count": 44,
+            "positive_rate": 7.5
+        },
+        {
+            "diagnosed_date": "2020-03-20",
+            "positive_count": 6,
+            "negative_count": 9,
+            "positive_rate": 10.6
+        },
+        {
+            "diagnosed_date": "2020-03-21",
+            "positive_count": 0,
+            "negative_count": 44,
+            "positive_rate": 9.3
+        },
+        {
+            "diagnosed_date": "2020-03-22",
+            "positive_count": 0,
+            "negative_count": 1,
+            "positive_rate": 9.3
+        },
+        {
+            "diagnosed_date": "2020-03-23",
+            "positive_count": 12,
+            "negative_count": 44,
+            "positive_rate": 10.2
+        },
+        {
+            "diagnosed_date": "2020-03-24",
+            "positive_count": 14,
+            "negative_count": 60,
+            "positive_rate": 12.2
+        },
+        {
+            "diagnosed_date": "2020-03-25",
+            "positive_count": 27,
+            "negative_count": 68,
+            "positive_rate": 18.8
+        },
+        {
+            "diagnosed_date": "2020-03-26",
+            "positive_count": 27,
+            "negative_count": 60,
+            "positive_rate": 22.6
+        },
+        {
+            "diagnosed_date": "2020-03-27",
+            "positive_count": 32,
+            "negative_count": 111,
+            "positive_rate": 22.5
+        },
+        {
+            "diagnosed_date": "2020-03-28",
+            "positive_count": 49,
+            "negative_count": 195,
+            "positive_rate": 23
+        },
+        {
+            "diagnosed_date": "2020-03-29",
+            "positive_count": 46,
+            "negative_count": 285,
+            "positive_rate": 20.4
+        },
+        {
+            "diagnosed_date": "2020-03-30",
+            "positive_count": 0,
+            "negative_count": 41,
+            "positive_rate": 19.3
+        },
+        {
+            "diagnosed_date": "2020-03-31",
+            "positive_count": 46,
+            "negative_count": 99,
+            "positive_rate": 20.6
+        },
+        {
+            "diagnosed_date": "2020-04-01",
+            "positive_count": 54,
+            "negative_count": 110,
+            "positive_rate": 21.8
+        },
+        {
+            "diagnosed_date": "2020-04-02",
+            "positive_count": 69,
+            "negative_count": 400,
+            "positive_rate": 19.1
+        },
+        {
+            "diagnosed_date": "2020-04-03",
+            "positive_count": 78,
+            "negative_count": 473,
+            "positive_rate": 17.6
+        },
+        {
+            "diagnosed_date": "2020-04-04",
+            "positive_count": 4,
+            "negative_count": 61,
+            "positive_rate": 16.7
+        },
+        {
+            "diagnosed_date": "2020-04-05",
+            "positive_count": 61,
+            "negative_count": 1,
+            "positive_rate": 21
+        },
+        {
+            "diagnosed_date": "2020-04-06",
+            "positive_count": 79,
+            "negative_count": 277,
+            "positive_rate": 21.6
+        },
+        {
+            "diagnosed_date": "2020-04-07",
+            "positive_count": 60,
+            "negative_count": 211,
+            "positive_rate": 20.9
+        },
+        {
+            "diagnosed_date": "2020-04-08",
+            "positive_count": 125,
+            "negative_count": 241,
+            "positive_rate": 22.2
+        },
+        {
+            "diagnosed_date": "2020-04-09",
+            "positive_count": 90,
+            "negative_count": 254,
+            "positive_rate": 24.7
+        },
+        {
+            "diagnosed_date": "2020-04-10",
+            "positive_count": 143,
+            "negative_count": 219,
+            "positive_rate": 30.7
+        },
+        {
+            "diagnosed_date": "2020-04-11",
+            "positive_count": 159,
+            "negative_count": 344,
+            "positive_rate": 31.6
+        },
+        {
+            "diagnosed_date": "2020-04-12",
+            "positive_count": 6,
+            "negative_count": 51,
+            "positive_rate": 29.4
+        },
+        {
+            "diagnosed_date": "2020-04-13",
+            "positive_count": 74,
+            "negative_count": 176,
+            "positive_rate": 30.5
+        },
+        {
+            "diagnosed_date": "2020-04-14",
+            "positive_count": 26,
+            "negative_count": 65,
+            "positive_rate": 31.6
+        },
+        {
+            "diagnosed_date": "2020-04-15",
+            "positive_count": 33,
+            "negative_count": 127,
+            "positive_rate": 30.2
+        },
+        {
+            "diagnosed_date": "2020-04-16",
+            "positive_count": 136,
+            "negative_count": 374,
+            "positive_rate": 29.7
+        },
+        {
+            "diagnosed_date": "2020-04-17",
+            "positive_count": 84,
+            "negative_count": 245,
+            "positive_rate": 27.3
+        },
+        {
+            "diagnosed_date": "2020-04-18",
+            "positive_count": 75,
+            "negative_count": 284,
+            "positive_rate": 24.7
+        },
+        {
+            "diagnosed_date": "2020-04-19",
+            "positive_count": 60,
+            "negative_count": 244,
+            "positive_rate": 24.5
+        },
+        {
+            "diagnosed_date": "2020-04-20",
+            "positive_count": 59,
+            "negative_count": 237,
+            "positive_rate": 23.2
+        },
+        {
+            "diagnosed_date": "2020-04-21",
+            "positive_count": 25,
+            "negative_count": 142,
+            "positive_rate": 22
+        },
+        {
+            "diagnosed_date": "2020-04-22",
+            "positive_count": 40,
+            "negative_count": 221,
+            "positive_rate": 21.4
+        },
+        {
+            "diagnosed_date": "2020-04-23",
+            "positive_count": 75,
+            "negative_count": 417,
+            "positive_rate": 19
+        },
+        {
+            "diagnosed_date": "2020-04-24",
+            "positive_count": 40,
+            "negative_count": 280,
+            "positive_rate": 16.9
+        },
+        {
+            "diagnosed_date": "2020-04-25",
+            "positive_count": 47,
+            "negative_count": 255,
+            "positive_rate": 16
+        },
+        {
+            "diagnosed_date": "2020-04-26",
+            "positive_count": 35,
+            "negative_count": 279,
+            "positive_rate": 15
+        },
+        {
+            "diagnosed_date": "2020-04-27",
+            "positive_count": 28,
+            "negative_count": 270,
+            "positive_rate": 13.3
+        },
+        {
+            "diagnosed_date": "2020-04-28",
+            "positive_count": 4,
+            "negative_count": 98,
+            "positive_rate": 12.8
+        },
+        {
+            "diagnosed_date": "2020-04-29",
+            "positive_count": 31,
+            "negative_count": 175,
+            "positive_rate": 12.7
+        },
+        {
+            "diagnosed_date": "2020-04-30",
+            "positive_count": 46,
+            "negative_count": 454,
+            "positive_rate": 11.3
+        },
+        {
+            "diagnosed_date": "2020-05-01",
+            "positive_count": 21,
+            "negative_count": 258,
+            "positive_rate": 10.5
+        },
+        {
+            "diagnosed_date": "2020-05-02",
+            "positive_count": 17,
+            "negative_count": 199,
+            "positive_rate": 9.5
+        },
+        {
+            "diagnosed_date": "2020-05-03",
+            "positive_count": 30,
+            "negative_count": 380,
+            "positive_rate": 8.7
+        },
+        {
+            "diagnosed_date": "2020-05-04",
+            "positive_count": 7,
+            "negative_count": 242,
+            "positive_rate": 7.9
+        },
+        {
+            "diagnosed_date": "2020-05-05",
+            "positive_count": 8,
+            "negative_count": 103,
+            "positive_rate": 8.2
+        },
+        {
+            "diagnosed_date": "2020-05-06",
+            "positive_count": 4,
+            "negative_count": 61,
+            "positive_rate": 7.3
+        },
+        {
+            "diagnosed_date": "2020-05-07",
+            "positive_count": 69,
+            "negative_count": 647,
+            "positive_rate": 7.5
+        }
+    ]
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -177,7 +177,8 @@ const config: Configuration = {
         '/cards/number-of-reports-to-covid19-telephone-advisory-center',
         '/cards/number-of-reports-to-covid19-consultation-desk',
         '/cards/predicted-number-of-toei-subway-passengers',
-        '/cards/agency'
+        '/cards/agency',
+        '/cards/positive-number-by-diagnosed-date'
       ]
 
       const routes: string[] = []

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -41,6 +41,9 @@
       "
     />
     <agency-card v-else-if="this.$route.params.card == 'agency'" />
+    <positive-number-by-diagnosed-date-card
+      v-else-if="this.$route.params.card == 'positive-number-by-diagnosed-date'"
+    />
   </div>
 </template>
 
@@ -49,6 +52,7 @@ import Data from '@/data/data.json'
 import MetroData from '@/data/metro.json'
 import agencyData from '@/data/agency.json'
 import patientData from '@/data/patient.json'
+import PositiveByDiagnosedData from '@/data/positive_by_diagnosed.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
@@ -60,6 +64,7 @@ import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvi
 import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
 import MetroCard from '@/components/cards/MetroCard.vue'
 import AgencyCard from '@/components/cards/AgencyCard.vue'
+import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
 
 export default {
   components: {
@@ -73,7 +78,8 @@ export default {
     TelephoneAdvisoryReportsNumberCard,
     ConsultationDeskReportsNumberCard,
     MetroCard,
-    AgencyCard
+    AgencyCard,
+    PositiveNumberByDiagnosedDateCard
   },
   data() {
     let title, updatedAt
@@ -121,6 +127,10 @@ export default {
       case 'agency':
         title = this.$t('都庁来庁者数の推移')
         updatedAt = agencyData.date
+        break
+      case 'positive-number-by-diagnosed-date':
+        title = this.$t('陽性患者数（検査結果判明日別）')
+        updatedAt = PositiveByDiagnosedData.date
         break
     }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,6 +25,8 @@
       <confirmed-cases-details-card />
       <!-- 陽性患者数 -->
       <confirmed-cases-number-card />
+      <!-- 陽性患者数（検査結果判明日別） -->
+      <positive-number-by-diagnosed-date-card />
       <!-- 陽性患者の属性 -->
       <confirmed-cases-attributes-card />
       <!-- 区市町村別患者数 -->
@@ -69,6 +71,7 @@ import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvi
 import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
 import MetroCard from '@/components/cards/MetroCard.vue'
 import AgencyCard from '@/components/cards/AgencyCard.vue'
+import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 
 export default Vue.extend({
@@ -87,7 +90,8 @@ export default Vue.extend({
     TelephoneAdvisoryReportsNumberCard,
     ConsultationDeskReportsNumberCard,
     MetroCard,
-    AgencyCard
+    AgencyCard,
+    PositiveNumberByDiagnosedDateCard
   },
   data() {
     const data = {

--- a/ui-test/ogp_screenshot.py
+++ b/ui-test/ogp_screenshot.py
@@ -17,7 +17,8 @@ PATHS = {
     "/cards/predicted-number-of-toei-subway-passengers": (959, 750),
     "/cards/agency": (959, 730),
     "/cards/details-of-tested-cases": (959, 500),
-    "/cards/number-of-inspection-persons": (959, 600)
+    "/cards/number-of-inspection-persons": (959, 600),
+    "/cards/positive-number-by-diagnosed-date":(959, 730)
 }
 
 options = webdriver.ChromeOptions()


### PR DESCRIPTION
"日別値"を表示する実装を取り込むため `data/add-positive_rate-and-diagnosed` ブランチをマージしました。

## 👏 解決する issue / Resolved Issues
- close #4092 

## ⛏ 変更内容 / Details of Changes
- 「陽性患者数」グラフのタイトル名及び注釈を変更しました。

## 📸 スクリーンショット / Screenshots
![「陽性患者数」グラフのタイトル名及び注釈の変更](https://user-images.githubusercontent.com/1763230/81655747-6a11fb00-9471-11ea-8f1b-d0b454165d92.png)
