### PR TITLE
issue-4124/検査陽性者の状況の右側が切れていて読めない

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -193,6 +193,7 @@ $default-boxdiff: 35px;
 
 .box {
   display: flex;
+  overflow: auto;
 
   &.parent {
     border-top: $default-bdw solid $green-1;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- 検査陽性者の状況の右側読めるように修正

## 📸 スクリーンショット / Screenshots
Chrome
<img width="682" alt="chrome" src="https://user-images.githubusercontent.com/3105613/81779879-89bc2880-9530-11ea-93a0-70050ebca49f.png">

Firefox
<img width="694" alt="firefox" src="https://user-images.githubusercontent.com/3105613/81779883-8aed5580-9530-11ea-8250-6c15c137d71e.png">

日本語版
<img width="1014" alt="japanese" src="https://user-images.githubusercontent.com/3105613/81780007-bf611180-9530-11ea-9673-b5e04906a734.png">


