### PR TITLE
README内のリンクテキストを具体的にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Issues にあるいろいろな修正にご協力いただけると嬉しいで�
 
 ## このサイトから派生したサイト
 
-[Link先](./FORKED_SITES.md)を御覧ください。
+[このサイトから派生したサイト](./FORKED_SITES.md)を御覧ください。
 
 ## 翻訳者向け情報
 
-翻訳をお手伝いいただける方は、[こちらのドキュメント](./TRANSLATION.md)を御覧ください。
+翻訳をお手伝いいただける方は、[How to contribute translations](./TRANSLATION.md)を御覧ください。
 
 ## 開発者向け情報
 
-開発をお手伝いいただける方は、[こちらのドキュメント](./FOR_DEVELOPERS.md)を御覧ください。
+開発をお手伝いいただける方は、[開発者向け情報](./FOR_DEVELOPERS.md)を御覧ください。


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4195

## ⛏ 変更内容 / Details of Changes
- README内のリンクテキストを、リンク先の内容を具体的に示すものに変更

## 📸 スクリーンショット / Screenshots
|before|after|
|---|---|
|![スクリーンショット 2020-05-16 0 18 42](https://user-images.githubusercontent.com/20086673/82066784-d52a2e80-970a-11ea-85d4-6c0c4a14d7d2.png)|![スクリーンショット 2020-05-16 0 18 43](https://user-images.githubusercontent.com/20086673/82066807-db200f80-970a-11ea-8e17-68d1653081b0.png)|

## 参考リンク / See also
- [総務省｜東海総合通信局｜その5　使いやすくわかりやすいリンクの提供](https://www.soumu.go.jp/soutsu/tokai/siensaku/accessibility/L5_link_text.html)