### PR TITLE
「判明日別陽性者数」グラフの最新人数に対する説明文を変更したい

### DIFF
--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -32,7 +32,7 @@
     &-date {
       white-space: wrap;
       display: inline-block;
-      line-height: 12px;
+      line-height: initial;
       color: $gray-3;
       @include font-size(12);
     }

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -29,7 +29,43 @@ import TimeBarChart from '@/components/TimeBarChart.vue'
 
 export default {
   components: {
-    TimeBarChart
+    TimeBarChart: {
+      extends: TimeBarChart,
+      computed: {
+        displayInfo() {
+          if (this.dataKind === 'transition' && this.byDate) {
+            return {
+              lText: `${this.chartData
+                .slice(-1)[0]
+                .transition.toLocaleString()}`,
+              sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+                '日別値'
+              )}（${this.$t(
+                '現在判明している人数であり、後日修正される場合がある'
+              )}）`,
+              unit: this.unit
+            }
+          } else if (this.dataKind === 'transition') {
+            return {
+              lText: `${this.chartData
+                .slice(-1)[0]
+                .transition.toLocaleString()}`,
+              sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+                '実績値'
+              )}`,
+              unit: this.unit
+            }
+          }
+          return {
+            lText: this.chartData[
+              this.chartData.length - 1
+            ].cumulative.toLocaleString(),
+            sText: `${this.chartData.slice(-1)[0].label} ${this.$t('累計値')}`,
+            unit: this.unit
+          }
+        }
+      }
+    }
   },
   data() {
     const formatData = Data.data.map(data => {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close https://github.com/tokyo-metropolitan-gov/covid19/issues/4199

この部分はほかのグラフと共通化しており、このグラフのコンポーネントのみ表示を変更しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
![2](https://user-images.githubusercontent.com/3105613/82118029-64891d80-97af-11ea-8491-ecd5bb678606.png)
![1](https://user-images.githubusercontent.com/3105613/82118026-60f59680-97af-11ea-8796-36da2da7afe7.png)


<!-- Changes in styles would be easier to review with screenshots! -->
