### PR TITLE
「東京都緊急事態措置について」をコンポーネント化

### DIFF
--- a/components/LinkToInformationAboutEmergencyMeasure.vue
+++ b/components/LinkToInformationAboutEmergencyMeasure.vue
@@ -1,0 +1,55 @@
+<template>
+  <span class="link-to-information-about-emergency-measure">
+    <external-link
+      url="https://www.bousai.metro.tokyo.lg.jp/1007617/index.html"
+    >
+      <v-icon
+        size="2rem"
+        class="link-to-information-about-emergency-measure-icon"
+      >
+        mdi-bullhorn
+      </v-icon>
+      {{ $t('東京都緊急事態措置について') }}
+    </external-link>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import ExternalLink from '@/components/ExternalLink.vue'
+
+export default Vue.extend({
+  components: { ExternalLink }
+})
+</script>
+
+<style lang="scss">
+.link-to-information-about-emergency-measure {
+  background-color: $emergency;
+  border: 2px solid $emergency;
+  color: $gray-2;
+  border-radius: 4px;
+  padding: 4px 8px;
+  display: inline-flex;
+  @include font-size(16);
+  &:hover {
+    background-color: $white;
+    border-radius: 4px;
+  }
+
+  .ExternalLink {
+    color: $gray-2 !important;
+    text-decoration: none;
+    margin: -10px;
+    padding: 10px;
+  }
+
+  > span {
+    @include button-text('sm');
+  }
+
+  @include lessThan($small) {
+    margin-top: 4px;
+  }
+}
+</style>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -7,16 +7,7 @@
         </v-icon>
         {{ $t('最新のお知らせ') }}
       </h3>
-      <span class="WhatsNew-link-to-emergency-page">
-        <external-link
-          url="https://www.bousai.metro.tokyo.lg.jp/1007617/index.html"
-        >
-          <v-icon size="2rem" class="WhatsNew-link-to-emergency-page-icon">
-            mdi-bullhorn
-          </v-icon>
-          {{ $t('東京都緊急事態措置について') }}
-        </external-link>
-      </span>
+      <link-to-information-about-emergency-measure />
     </div>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
@@ -50,7 +41,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import ExternalLink from '@/components/ExternalLink.vue'
+import LinkToInformationAboutEmergencyMeasure from '@/components/LinkToInformationAboutEmergencyMeasure.vue'
 
 import {
   convertDateByCountryPreferTimeFormat,
@@ -58,7 +49,7 @@ import {
 } from '@/utils/formatDate'
 
 export default Vue.extend({
-  components: { ExternalLink },
+  components: { LinkToInformationAboutEmergencyMeasure },
   props: {
     items: {
       type: Array,
@@ -100,35 +91,6 @@ export default Vue.extend({
       @include card-h2();
       &-icon {
         margin: 3px;
-      }
-    }
-
-    .WhatsNew-link-to-emergency-page {
-      background-color: $emergency;
-      border: 2px solid $emergency;
-      color: $gray-2;
-      border-radius: 4px;
-      padding: 4px 8px;
-      display: inline-flex;
-      @include font-size(16);
-      &:hover {
-        background-color: $white;
-        border-radius: 4px;
-      }
-
-      .ExternalLink {
-        color: $gray-2 !important;
-        text-decoration: none;
-        margin: -10px;
-        padding: 10px;
-      }
-
-      > span {
-        @include button-text('sm');
-      }
-
-      @include lessThan($small) {
-        margin-top: 4px;
       }
     }
   }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4425

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 「東京都緊急事態措置について」の黄色いボタンをコンポーネントに分離
  - component `LinkToInformationAboutEmergencyMeasure` を作成した．

## 📸 スクリーンショット / Screenshots
スタイルは変更なし
