### PR TITLE
[refactor] `SevereCaseBarChart.vue` から累計値に関するコードを削除

### DIFF
--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -40,18 +40,15 @@ export default {
   },
   data() {
     const graphData = []
-    let patSum = 0
     Data.data
       .filter(d => new Date(d.date) > new Date('2020-04-26'))
       .forEach(d => {
         const date = new Date(d.date)
         const subTotal = d.severe_case
         if (!isNaN(subTotal)) {
-          patSum += subTotal
           graphData.push({
             label: `${date.getMonth() + 1}/${date.getDate()}`,
-            transition: subTotal,
-            cumulative: patSum
+            transition: subTotal
           })
         }
       })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4450

## 📝 関連する issue / Related Issues
- #4329（PR）

## ⛏ 変更内容 / Details of Changes
- `SevereCaseBarChart.vue` から累計値に関するコードを削除しました
  - こちらのコメントから不要と判断しました https://github.com/tokyo-metropolitan-gov/covid19/pull/4329#issuecomment-631541227
- 未使用の `slot` も削除しました
  - `description`
  - `footer`

## 📸 スクリーンショット / Screenshots
リファクタリングなので見た目の変更はありませんが、
Deploy Preview で表示に変わりがないことを確認しました。

![スクリーンショット 2020-05-24 11 26 15](https://user-images.githubusercontent.com/5207601/82744293-69eaf700-9db1-11ea-8323-72ab1f64af0b.png)
