### PR TITLE
[refactor] `DataView.vue` から DataTable に関するコードを分離

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card ref="dataView" class="DataView" :loading="loading">
+  <v-card class="DataView" :loading="loading">
     <div class="DataView-Inner">
       <div class="DataView-Header">
         <h3
@@ -22,32 +22,11 @@
       <div class="DataView-Description">
         <slot name="additionalDescription" />
       </div>
-      <div v-if="this.$slots.dataTable" class="DataView-Details">
-        <v-expansion-panels v-if="showDetails" flat>
-          <v-expansion-panel>
-            <v-expansion-panel-header
-              :hide-actions="true"
-              :style="{ transition: 'none' }"
-              @click="toggleDetails"
-            >
-              <template slot:actions>
-                <div class="v-expansion-panel-header__icon">
-                  <v-icon left>mdi-chevron-right</v-icon>
-                </div>
-              </template>
-              <span class="expansion-panel-text">
-                {{ $t('テーブルを表示') }}
-              </span>
-            </v-expansion-panel-header>
-            <v-expansion-panel-content>
-              <slot name="dataTable" />
-            </v-expansion-panel-content>
-          </v-expansion-panel>
-        </v-expansion-panels>
-        <template v-else>
-          <slot name="dataTable" />
-        </template>
-      </div>
+
+      <data-view-table v-if="this.$slots.dataTable" class="DataView-Details">
+        <slot name="dataTable" />
+      </data-view-table>
+
       <div class="DataView-Description">
         <slot name="footer-description" />
       </div>
@@ -77,11 +56,11 @@
 <script lang="ts">
 import Vue from 'vue'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
-import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
+import DataViewTable from '@/components/DataViewTable.vue'
 import DataViewShare from '@/components/DataViewShare.vue'
 
 export default Vue.extend({
-  components: { DataViewShare },
+  components: { DataViewTable, DataViewShare },
   props: {
     title: {
       type: String,
@@ -101,12 +80,6 @@ export default Vue.extend({
       default: false
     }
   },
-  data() {
-    return {
-      showDetails: false,
-      openDetails: false
-    }
-  },
   computed: {
     formattedDate(): string {
       return convertDatetimeToISO8601Format(this.date)
@@ -114,15 +87,6 @@ export default Vue.extend({
     permalink(): string {
       const permalink = '/cards/' + this.titleId
       return this.localePath(permalink)
-    }
-  },
-  mounted() {
-    this.showDetails = true
-  },
-  methods: {
-    toggleDetails() {
-      this.openDetails = !this.openDetails
-      EventBus.$emit(TOGGLE_EVENT, { dataView: this.$refs.dataView })
     }
   }
 })
@@ -238,10 +202,6 @@ export default Vue.extend({
 
   &-Details {
     margin: 10px 0;
-
-    .v-data-table .text-end {
-      text-align: right;
-    }
   }
 
   &-DetailsSummary {
@@ -292,22 +252,5 @@ export default Vue.extend({
       align-items: flex-end;
     }
   }
-}
-
-.v-expansion-panel-header__icon {
-  margin-left: -5px !important;
-
-  & .v-icon--left {
-    margin-right: 5px;
-  }
-
-  .v-expansion-panel--active & .v-icon {
-    transform: rotate(90deg) !important;
-  }
-}
-
-.expansion-panel-text {
-  color: $gray-1;
-  @include font-size(14);
 }
 </style>

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -5,6 +5,7 @@
         <v-expansion-panel-header
           :hide-actions="true"
           :style="{ transition: 'none' }"
+          @click="toggleDetails"
         >
           <template slot:actions>
             <div class="v-expansion-panel-header__icon">

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -1,0 +1,69 @@
+<template>
+  <div>
+    <v-expansion-panels v-if="showDetails" flat>
+      <v-expansion-panel>
+        <v-expansion-panel-header
+          :hide-actions="true"
+          :style="{ transition: 'none' }"
+        >
+          <template slot:actions>
+            <div class="v-expansion-panel-header__icon">
+              <v-icon left>mdi-chevron-right</v-icon>
+            </div>
+          </template>
+          <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <slot />
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+    <template v-else>
+      <slot />
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
+
+export default Vue.extend({
+  data() {
+    return {
+      showDetails: false
+    }
+  },
+  mounted() {
+    this.showDetails = true
+  },
+  methods: {
+    toggleDetails() {
+      EventBus.$emit(TOGGLE_EVENT, { dataView: this.$parent })
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.v-expansion-panel-header__icon {
+  margin-left: -5px !important;
+
+  & .v-icon--left {
+    margin-right: 5px;
+  }
+
+  .v-expansion-panel--active & .v-icon {
+    transform: rotate(90deg) !important;
+  }
+}
+
+.expansion-panel-text {
+  color: $gray-1;
+  @include font-size(14);
+}
+
+.v-data-table .text-end {
+  text-align: right;
+}
+</style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4484

## 📝 関連する issue / Related Issues
- #4436

## ⛏ 変更内容 / Details of Changes
- `DataView.vue` から DataTable（各カードのテーブルを表示する部分） に関するコードを分離して、`DataViewTable.vue` コンポーネントを作成しました

## 📸 スクリーンショット / Screenshots
リファクタリングなので見た目の変更はありませんが、
Deploy Preview で動作を確認しました。

[![Image from Gyazo](https://i.gyazo.com/6e0a0583a5b7506b185a0d63ab035d06.gif)](https://gyazo.com/6e0a0583a5b7506b185a0d63ab035d06)