### PR TITLE
「ロードマップについて」の外部リンクボタン作成

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -98,7 +98,7 @@ $z-index-map: (
   }
 }
 
-@mixin button-text($size: 'md') {
+@mixin button-text($size: 'md', $font-size: 14) {
   @if ($size == 'sm') {
     padding: 4px 8px;
   }
@@ -107,7 +107,7 @@ $z-index-map: (
     padding: 24px 36px;
   }
 
-  @include font-size(14);
+  @include font-size($font-size);
 
   display: inline-block;
   border-radius: 4px;

--- a/components/LinkToInformationAboutRoadmap.vue
+++ b/components/LinkToInformationAboutRoadmap.vue
@@ -1,29 +1,21 @@
 <template>
   <span :class="$style.linkButton">
-    <a
-      :class="$style.externalLink"
-      href="https://www.bousai.metro.tokyo.lg.jp/1007942/index.html"
-      target="_blank"
-      rel="noopener noreferrer"
+    <external-link
+      :class="$style.TextLink"
+      url="https://www.bousai.metro.tokyo.lg.jp/1007942/index.html"
     >
       {{ $t('ロードマップについて') }}
-      <v-icon
-        :class="$style.externalLinkIcon"
-        size="1.5rem"
-        :aria-label="this.$t('別タブで開く')"
-        role="img"
-        :aria-hidden="false"
-      >
-        mdi-open-in-new
-      </v-icon>
-    </a>
+    </external-link>
   </span>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
+import ExternalLink from '@/components/ExternalLink.vue'
 
-export default Vue.extend()
+export default Vue.extend({
+  components: { ExternalLink }
+})
 </script>
 
 <style lang="scss" module>
@@ -36,10 +28,12 @@ export default Vue.extend()
   }
 }
 
-.externalLink {
+.TextLink {
   @include button-text('sm', 16);
 
   color: $green-1 !important;
-  text-decoration: none;
+  &:hover {
+    color: $white !important;
+  }
 }
 </style>

--- a/components/LinkToInformationAboutRoadmap.vue
+++ b/components/LinkToInformationAboutRoadmap.vue
@@ -39,6 +39,7 @@ export default Vue.extend()
 .externalLink {
   @include button-text('sm', 16);
 
+  color: $green-1 !important;
   text-decoration: none;
 }
 </style>

--- a/components/LinkToInformationAboutRoadmap.vue
+++ b/components/LinkToInformationAboutRoadmap.vue
@@ -30,9 +30,6 @@ export default Vue.extend()
 .linkButton {
   display: inline-flex;
   flex: 0 1 auto;
-  a {
-    @include button-text('sm', 16);
-  }
 
   @include lessThan($small) {
     margin-top: 4px;
@@ -40,6 +37,8 @@ export default Vue.extend()
 }
 
 .externalLink {
+  @include button-text('sm', 16);
+
   text-decoration: none;
 }
 </style>

--- a/components/LinkToInformationAboutRoadmap.vue
+++ b/components/LinkToInformationAboutRoadmap.vue
@@ -1,0 +1,45 @@
+<template>
+  <span :class="$style.linkButton">
+    <a
+      :class="$style.externalLink"
+      href="https://www.bousai.metro.tokyo.lg.jp/1007942/index.html"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {{ $t('ロードマップについて') }}
+      <v-icon
+        :class="$style.externalLinkIcon"
+        size="1.5rem"
+        :aria-label="this.$t('別タブで開く')"
+        role="img"
+        :aria-hidden="false"
+      >
+        mdi-open-in-new
+      </v-icon>
+    </a>
+  </span>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend()
+</script>
+
+<style lang="scss" module>
+.linkButton {
+  display: inline-flex;
+  flex: 0 1 auto;
+  a {
+    @include button-text('sm', 16);
+  }
+
+  @include lessThan($small) {
+    margin-top: 4px;
+  }
+}
+
+.externalLink {
+  text-decoration: none;
+}
+</style>

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -7,7 +7,8 @@
         </v-icon>
         {{ $t('最新のお知らせ') }}
       </h3>
-      <link-to-information-about-emergency-measure />
+      <link-to-information-about-emergency-measure v-if="isEmergency" />
+      <link-to-information-about-roadmap v-else />
     </div>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">
@@ -42,6 +43,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import LinkToInformationAboutEmergencyMeasure from '@/components/LinkToInformationAboutEmergencyMeasure.vue'
+import LinkToInformationAboutRoadmap from '@/components/LinkToInformationAboutRoadmap.vue'
 
 import {
   convertDateByCountryPreferTimeFormat,
@@ -49,11 +51,19 @@ import {
 } from '@/utils/formatDate'
 
 export default Vue.extend({
-  components: { LinkToInformationAboutEmergencyMeasure },
+  components: {
+    LinkToInformationAboutEmergencyMeasure,
+    LinkToInformationAboutRoadmap
+  },
   props: {
     items: {
       type: Array,
       required: true
+    },
+    isEmergency: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   methods: {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,7 @@
         <span>{{ $t('注釈') }}</span>
       </div>
     </div>
-    <whats-new class="mb-4" :items="newsItems" />
+    <whats-new class="mb-4" :items="newsItems" :is-emergency="false" />
     <static-info
       class="mb-4"
       :url="localePath('/flow')"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4488 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「ロードマップについて」の外部リンクボタンのコンポーネントを作成
- 「東京都緊急事態措置について」のボタンと、属性で切り替えるように修正
- 見た目は「相談の手順を見る」と同様（フォントサイズのみ変更なし）

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
`:is-emergency="false"` のとき
![スクリーンショット 2020-05-25 23 20 22](https://user-images.githubusercontent.com/14883063/82821476-2393b600-9edf-11ea-97ac-349e3da3557f.png)

hover時
![スクリーンショット 2020-05-25 22 46 42](https://user-images.githubusercontent.com/14883063/82818648-fee90f80-9ed9-11ea-9e1b-fdbea143ab14.png)

`:is-emergency="true"` のとき
![スクリーンショット 2020-05-25 22 48 18](https://user-images.githubusercontent.com/14883063/82818711-1627fd00-9eda-11ea-8739-504d93465a76.png)
