### PR TITLE
#4422 新規患者に関する報告件数の推移で0人の日に0人のポップアップ表示させる

### DIFF
--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -247,12 +247,30 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayData() {
       const style = getGraphSeriesStyle(1)[0]
+      const zeroMouseOverHeight = 5
+      const transparentWhite = '#FFFFFF00'
+
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
             return d.label
           }),
           datasets: [
+            {
+              label: this.dataKind,
+              data: this.chartData.map(_d => {
+                return 0
+              }),
+              backgroundColor: transparentWhite,
+              borderColor: transparentWhite,
+              borderWidth: 0,
+              minBarLength: this.chartData.map(d => {
+                if (d.transition <= 0) {
+                  return zeroMouseOverHeight
+                }
+                return 0
+              })
+            },
             {
               label: this.dataKind,
               data: this.chartData.map(d => {
@@ -268,6 +286,21 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return {
         labels: this.chartData.map(d => d.label),
         datasets: [
+          {
+            label: this.dataKind,
+            data: this.chartData.map(_d => {
+              return 0
+            }),
+            backgroundColor: transparentWhite,
+            borderColor: transparentWhite,
+            borderWidth: 0,
+            minBarLength: this.chartData.map(d => {
+              if (d.transition <= 0) {
+                return zeroMouseOverHeight
+              }
+              return 0
+            })
+          },
           {
             label: this.dataKind,
             data: this.chartData.map(d => {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -295,7 +295,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             borderColor: transparentWhite,
             borderWidth: 0,
             minBarLength: this.chartData.map(d => {
-              if (d.transition <= 0) {
+              if (d.cumulative <= 0) {
                 return zeroMouseOverHeight
               }
               return 0


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4422

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「新規患者に関する報告件数の推移」で、0人のときに0人とポップアップされるようにしました。

この問題の解決方法は、「0人のときに白色透明 `#FFFFFF00` のbarを挿入する」というものです。見た目ではわからないですが、透明の棒グラフを作ってそれをマウスオーバーすることで0人を表示させています。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![WS000002](https://user-images.githubusercontent.com/305368/82868466-a6f8ea00-9f67-11ea-9131-20b7fbf4bfa3.png)

