### PR TITLE
[refactor] `DataView.vue` から不要なスタイルやスロットなどを削除

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,9 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:infoPanel>
-      <small :class="$style.DataViewDesc">
-        <slot name="description" />
-      </small>
+    <template v-slot:description>
+      <slot name="description" />
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -137,30 +137,6 @@ export default Vue.extend({
     }
   }
 
-  &-DataInfo {
-    &-summary {
-      color: $gray-2;
-      font-family: Hiragino Sans, sans-serif;
-      font-style: normal;
-      line-height: 30px;
-      white-space: nowrap;
-      @include font-size(30);
-
-      &-unit {
-        width: 100%;
-        @include font-size(10);
-      }
-    }
-
-    &-date {
-      line-height: 12px;
-      color: $gray-3;
-      width: 100%;
-      display: inline-block;
-      @include font-size(12);
-    }
-  }
-
   &-Inner {
     display: flex;
     flex-flow: column;

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -10,15 +10,19 @@
         </h3>
         <slot name="infoPanel" />
       </div>
+
       <div class="DataView-Description">
         <slot name="description" />
       </div>
+
       <div>
         <slot name="button" />
       </div>
+
       <div class="DataView-CardText">
         <slot />
       </div>
+
       <div class="DataView-Description">
         <slot name="additionalDescription" />
       </div>
@@ -27,9 +31,8 @@
         <slot name="dataTable" />
       </data-view-table>
 
-      <div class="DataView-Description">
-        <slot name="footer-description" />
-      </div>
+      <div class="DataView-Description" />
+
       <div class="DataView-Footer">
         <div class="Footer-Left">
           <slot name="footer" />
@@ -158,6 +161,10 @@ export default Vue.extend({
         width: 50%;
       }
     }
+  }
+
+  &-CardText {
+    margin: 16px 0;
   }
 
   &-Description {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -97,30 +97,8 @@ export default Vue.extend({
 
 <style lang="scss">
 .DataView {
-  @include card-container();
-
   height: 100%;
-
-  .LegendStickyChart {
-    margin: 16px 0;
-    position: relative;
-    overflow: hidden;
-    .scrollable {
-      overflow-x: scroll;
-      &::-webkit-scrollbar {
-        height: 4px;
-        background-color: rgba(0, 0, 0, 0.01);
-      }
-      &::-webkit-scrollbar-thumb {
-        background-color: rgba(0, 0, 0, 0.07);
-      }
-    }
-    .sticky-legend {
-      position: absolute;
-      top: 0;
-      pointer-events: none;
-    }
-  }
+  @include card-container();
 
   &-Header {
     display: flex;
@@ -187,12 +165,11 @@ export default Vue.extend({
   }
 
   &-Footer {
-    @include font-size(12);
-
     display: flex;
     justify-content: space-between;
     margin-top: auto;
     color: $gray-3;
+    @include font-size(12);
 
     .Permalink {
       color: $gray-3 !important;
@@ -201,6 +178,31 @@ export default Vue.extend({
     .Footer-Right {
       display: flex;
       align-items: flex-end;
+    }
+  }
+
+  .LegendStickyChart {
+    margin: 16px 0;
+    position: relative;
+    overflow: hidden;
+
+    .scrollable {
+      overflow-x: scroll;
+
+      &::-webkit-scrollbar {
+        height: 4px;
+        background-color: rgba(0, 0, 0, 0.01);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(0, 0, 0, 0.07);
+      }
+    }
+
+    .sticky-legend {
+      position: absolute;
+      top: 0;
+      pointer-events: none;
     }
   }
 }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -19,7 +19,7 @@
         <slot name="button" />
       </div>
 
-      <div class="DataView-CardText">
+      <div class="DataView-Content">
         <slot />
       </div>
 
@@ -34,7 +34,7 @@
       <div class="DataView-Description" />
 
       <div class="DataView-Footer">
-        <div class="Footer-Left">
+        <div>
           <slot name="footer" />
           <div>
             <a class="Permalink" :href="permalink">
@@ -133,9 +133,7 @@ export default Vue.extend({
     }
 
     @include largerThan($large) {
-      width: 100%;
       flex-flow: row;
-      flex-wrap: wrap;
       padding: 0;
     }
   }
@@ -157,18 +155,19 @@ export default Vue.extend({
 
     @include largerThan($large) {
       margin-bottom: 0;
+
       &.with-infoPanel {
         width: 50%;
       }
     }
   }
 
-  &-CardText {
+  &-Content {
     margin: 16px 0;
   }
 
   &-Description {
-    margin: 10px 0 0;
+    margin-top: 10px;
     color: $gray-3;
     @include font-size(12);
 
@@ -186,20 +185,14 @@ export default Vue.extend({
   &-Footer {
     @include font-size(12);
 
-    padding: 0 !important;
     display: flex;
     justify-content: space-between;
+    padding: 0;
     margin-top: auto;
-    color: $gray-3 !important;
-    text-align: right;
-    background-color: $white !important;
+    color: $gray-3;
 
     .Permalink {
       color: $gray-3 !important;
-    }
-
-    .Footer-Left {
-      text-align: left;
     }
 
     .Footer-Right {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -191,14 +191,6 @@ export default Vue.extend({
       color: $gray-3 !important;
     }
 
-    .OpenDataLink {
-      text-decoration: none;
-
-      .ExternalLinkIcon {
-        vertical-align: text-bottom;
-      }
-    }
-
     .Footer-Left {
       text-align: left;
     }

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -184,10 +184,6 @@ export default Vue.extend({
     }
   }
 
-  &-CardText {
-    margin: 16px 0;
-  }
-
   &-Description {
     margin: 10px 0 0;
     color: $gray-3;
@@ -202,22 +198,6 @@ export default Vue.extend({
 
   &-Details {
     margin: 10px 0;
-  }
-
-  &-DetailsSummary {
-    @include font-size(14);
-
-    color: $gray-2;
-    cursor: pointer;
-  }
-
-  &-CardTextForXS {
-    margin-bottom: 46px;
-    margin-top: 70px;
-  }
-
-  &-Embed {
-    background-color: $gray-5;
   }
 
   &-Footer {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="DataView" :loading="loading">
+  <v-card class="DataView">
     <div class="DataView-Inner">
       <div class="DataView-Header">
         <h3
@@ -76,11 +76,6 @@ export default Vue.extend({
     date: {
       type: String,
       default: ''
-    },
-    loading: {
-      type: Boolean,
-      required: false,
-      default: false
     }
   },
   computed: {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -27,11 +27,11 @@
         <slot name="additionalDescription" />
       </div>
 
-      <data-view-table v-if="this.$slots.dataTable" class="DataView-Details">
+      <data-view-table v-if="this.$slots.dataTable" class="DataView-Table">
         <slot name="dataTable" />
       </data-view-table>
 
-      <div class="DataView-Description" />
+      <div class="DataView-Space" />
 
       <div class="DataView-Footer">
         <div>
@@ -166,6 +166,10 @@ export default Vue.extend({
     margin: 16px 0;
   }
 
+  &-Space {
+    margin-top: 10px;
+  }
+
   &-Description {
     margin-top: 10px;
     color: $gray-3;
@@ -178,7 +182,7 @@ export default Vue.extend({
     }
   }
 
-  &-Details {
+  &-Table {
     margin: 10px 0;
   }
 
@@ -187,7 +191,6 @@ export default Vue.extend({
 
     display: flex;
     justify-content: space-between;
-    padding: 0;
     margin-top: auto;
     color: $gray-3;
 

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -19,21 +19,24 @@
 
     &-summary {
       display: inline-block;
+      color: $gray-2;
+      white-space: nowrap;
       font-family: Hiragino Sans, sans-serif;
       font-style: normal;
       line-height: 30px;
       @include font-size(30);
 
       &-unit {
+        width: 100%;
         @include font-size(18);
       }
     }
 
     &-date {
-      white-space: wrap;
       display: inline-block;
-      line-height: initial;
+      width: 100%;
       color: $gray-3;
+      line-height: initial;
       @include font-size(12);
     }
   }

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -1,9 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:infoPanel>
-      <small :class="$style.DataViewDesc">
-        <slot name="description" />
-      </small>
+    <template v-slot:description>
+      <slot name="description" />
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4517

## 📝 関連する issue / Related Issues
- #4436
- #4484

## ⛏ 変更内容 / Details of Changes
- `DataView.vue` から不要なスタイルを削除しました
  - `DataInfo` や `OpenDataLink` のスタイルについては、それぞれのコンポーネントへ移植しました
- 未使用の Slot `footer-description` を削除しました
- 未使用の Props `loading` を削除しました
- `AgencyBarChart` と `MetroBarChart` の注釈の Slot を `infoPanel` -> `description` に変更しました
  - `infoPanel` は主にグラフの数値を表示するために使用しているので、注釈であれば `description` のほうが適切なためです
  - `DataView` のスタイルを整理した関係で、このような修正をしたほうが見た目が整うという意味合いもあります

## 📸 スクリーンショット / Screenshots
「都営地下鉄の利用者数の推移」と「都庁来庁者数の推移」グラフのみ、カードのタイトルが幅いっぱいに広がるようになりました。

| Before | After |
| --- | --- |
| ![スクリーンショット 2020-05-26 22 23 29](https://user-images.githubusercontent.com/5207601/82906213-dcb9c500-9f9f-11ea-86c6-85ca4440b499.png) | ![スクリーンショット 2020-05-26 22 23 19](https://user-images.githubusercontent.com/5207601/82906220-df1c1f00-9f9f-11ea-98e1-edf276b05af9.png)| 
| ![スクリーンショット 2020-05-26 22 27 19](https://user-images.githubusercontent.com/5207601/82906368-1a1e5280-9fa0-11ea-8f09-a031b3fb8170.png) | ![スクリーンショット 2020-05-26 22 27 27](https://user-images.githubusercontent.com/5207601/82906375-1be81600-9fa0-11ea-8356-7c789b926351.png) |

その他のカードに関しては、見た目の変更はありません。






