### PR TITLE
[refactor] PositiveRateCard.vue および UntrackedRateCard.vue の定数統合

### DIFF
--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -7,7 +7,11 @@
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"
     >
-      <li v-for="(item, i) in items" :key="i" @click="onClickLegend(i)">
+      <li
+        v-for="(dataLabel, i) in dataLabels"
+        :key="i"
+        @click="onClickLegend(i)"
+      >
         <button>
           <div
             v-if="i >= 2"
@@ -27,7 +31,7 @@
             :style="{
               textDecoration: displayLegends[i] ? 'none' : 'line-through'
             }"
-            >{{ item }}</span
+            >{{ dataLabel }}</span
           >
         </button>
       </li>
@@ -166,7 +170,6 @@ type Props = {
   chartId: string
   chartData: number[][]
   date: string
-  items: string[]
   labels: string[]
   dataLabels: string[] | TranslateResult[]
   tableLabels: string[] | TranslateResult[]
@@ -210,10 +213,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: true,
       default: ''
-    },
-    items: {
-      type: Array,
-      default: () => []
     },
     labels: {
       type: Array,
@@ -276,7 +275,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'bar',
             yAxisID: 'y-axis-1',
-            label: this.items[0],
+            label: this.dataLabels[0],
             data: this.chartData[0],
             backgroundColor: graphSeries[0].fillColor,
             borderColor: graphSeries[0].strokeColor,
@@ -286,7 +285,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'bar',
             yAxisID: 'y-axis-1',
-            label: this.items[1],
+            label: this.dataLabels[1],
             data: this.chartData[1],
             backgroundColor: graphSeries[1].fillColor,
             borderColor: graphSeries[1].strokeColor,
@@ -296,7 +295,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'line',
             yAxisID: 'y-axis-2',
-            label: this.items[2],
+            label: this.dataLabels[2],
             data: this.chartData[2],
             pointBackgroundColor: 'rgba(0,0,0,0)',
             pointBorderColor: 'rgba(0,0,0,0)',

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -7,7 +7,11 @@
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"
     >
-      <li v-for="(item, i) in items" :key="i" @click="onClickLegend(i)">
+      <li
+        v-for="(dataLabel, i) in dataLabels"
+        :key="i"
+        @click="onClickLegend(i)"
+      >
         <button>
           <div
             v-if="i === 3"
@@ -27,7 +31,7 @@
             :style="{
               textDecoration: displayLegends[i] ? 'none' : 'line-through'
             }"
-            >{{ item }}</span
+            >{{ dataLabel }}</span
           >
         </button>
       </li>
@@ -167,7 +171,6 @@ type Props = {
   chartId: string
   chartData: number[][]
   date: string
-  items: string[]
   labels: string[]
   dataLabels: string[] | TranslateResult[]
   tableLabels: string[] | TranslateResult[]
@@ -212,10 +215,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: true,
       default: ''
-    },
-    items: {
-      type: Array,
-      default: () => []
     },
     labels: {
       type: Array,
@@ -290,7 +289,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'bar',
             yAxisID: 'y-axis-1',
-            label: this.items[0],
+            label: this.dataLabels[0],
             data: this.chartData[0],
             backgroundColor: graphSeries[0].fillColor,
             borderColor: graphSeries[0].strokeColor,
@@ -300,7 +299,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'bar',
             yAxisID: 'y-axis-1',
-            label: this.items[1],
+            label: this.dataLabels[1],
             data: this.chartData[1],
             backgroundColor: graphSeries[1].fillColor,
             borderColor: graphSeries[1].strokeColor,
@@ -310,7 +309,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'line',
             yAxisID: 'y-axis-2',
-            label: this.items[2],
+            label: this.dataLabels[2],
             data: this.chartData[2],
             pointBackgroundColor: 'rgba(0,0,0,0)',
             pointBorderColor: 'rgba(0,0,0,0)',
@@ -323,7 +322,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           {
             type: 'line',
             yAxisID: 'y-axis-2',
-            label: this.items[3],
+            label: this.dataLabels[3],
             data: this.makeLineData(this.additionalLines[0]),
             pointBackgroundColor: 'rgba(0,0,0,0)',
             pointBorderColor: 'rgba(0,0,0,0)',

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -6,7 +6,6 @@
       :chart-id="'positive-rate-chart'"
       :chart-data="positiveRateGraph"
       :date="PositiveRate.date"
-      :items="positiveRateItems"
       :labels="positiveRateLabels"
       unit="%"
       :data-labels="positiveRateDataLabels"
@@ -84,11 +83,6 @@ export default {
     }
 
     const positiveRateGraph = [positiveCount, negativeCount, positiveRates]
-    const positiveRateItems = [
-      this.$t('陽性者数'),
-      this.$t('陰性者数'),
-      this.$t('陽性率')
-    ]
     const positiveRateDataLabels = [
       this.$t('陽性者数'),
       this.$t('陰性者数'),
@@ -104,7 +98,6 @@ export default {
     return {
       PositiveRate,
       positiveRateGraph,
-      positiveRateItems,
       positiveRateLabels,
       positiveRateDataLabels,
       positiveRateTableLabels

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -6,7 +6,6 @@
       :chart-id="'untracked-rate-chart'"
       :chart-data="graphData"
       :date="updated"
-      :items="items"
       :labels="dateList"
       unit="%"
       :data-labels="dataLabels"
@@ -68,12 +67,6 @@ export default {
     const updated = Data.date
     const graphData = [reportedCount, missingCount, untrackedRate]
 
-    const items = [
-      this.$t('接触歴等判明者数'),
-      this.$t('接触歴等不明者数'),
-      this.$t('接触歴等不明率（7日間移動平均）'),
-      this.$t('緩和・再要請の目安')
-    ]
     const dataLabels = [
       this.$t('接触歴等判明者数'),
       this.$t('接触歴等不明者数'),
@@ -91,7 +84,6 @@ export default {
       updated,
       graphData,
       dateList,
-      items,
       dataLabels,
       tableLabels,
       additionalLines


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4459 

## ⛏ 変更内容 / Details of Changes
- `PositiveRateCard.vue` の重複した定数 `items` を `dataLabels` に統合
- `UntrackedRateCard.vue` の重複した定数 `items` を `dataLabels` に統合
- 定数統合に伴う関連ファイルの修正

## 📸 スクリーンショット / Screenshots
リファクタリングのため画面変更はありません。
凡例・ツールチップ・テーブルヘッダに影響がないことを確認済みです。

| PositiveRateCard.vue | UntrackedRateCard.vue |
|---|---|
| <img src="https://user-images.githubusercontent.com/24243541/83038525-0514f280-a078-11ea-8214-29e1eb7c686b.png"> | <img src="https://user-images.githubusercontent.com/24243541/83037512-d6e2e300-a076-11ea-9ece-a317b2d294e5.png"> |