### PR TITLE
[モニタリング指標] 総括表 go_threshold が非nullの場合に結合セルでデータを表示

### DIFF
--- a/components/MonitoringStatusOverviewTable.vue
+++ b/components/MonitoringStatusOverviewTable.vue
@@ -43,6 +43,16 @@
             {{ $t(item.itemValue.stopThreshold) }}
           </td>
         </template>
+        <template
+          v-else-if="
+            item.itemValue.goThreshold !== null &&
+              item.itemValue.stopThreshold === null
+          "
+        >
+          <td :class="$style.threshold" colspan="2">
+            {{ $t(item.itemValue.goThreshold) }}
+          </td>
+        </template>
         <template v-else>
           <td colspan="2">
             &ndash;

--- a/components/MonitoringStatusOverviewTable.vue
+++ b/components/MonitoringStatusOverviewTable.vue
@@ -36,10 +36,10 @@
               item.itemValue.stopThreshold !== null
           "
         >
-          <td :class="$style.threshold">
+          <td>
             {{ $t(item.itemValue.goThreshold) }}
           </td>
-          <td :class="$style.threshold">
+          <td>
             {{ $t(item.itemValue.stopThreshold) }}
           </td>
         </template>
@@ -49,7 +49,7 @@
               item.itemValue.stopThreshold === null
           "
         >
-          <td :class="$style.threshold" colspan="2">
+          <td colspan="2">
             {{ $t(item.itemValue.goThreshold) }}
           </td>
         </template>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4579 


## ⛏ 変更内容 / Details of Changes
- `item.itemValue.goThreshold` が非null 且つ `item.itemValue.stopThreshold` がnullの場合は、セルを結合させて `item.itemValue.goThreshold` のデータを表示
    - `$t()` 関連は #4458 などで対応予定

## 📸 スクリーンショット / Screenshots
- ローカル環境で `data/monitoring_status.json` を編集して撮影したスクリーンショット
    ![image](https://user-images.githubusercontent.com/34566290/83105767-36cc9e80-a0f6-11ea-98a1-d59cf2bee808.png)

