### PR TITLE
[refactor] グラフの注釈に関するスタイルをまとめる

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -257,14 +257,3 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
 export default Vue.extend(options)
 </script>
-
-<style module lang="scss">
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    color: $gray-3;
-    @include font-size(12);
-  }
-}
-</style>

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -38,7 +38,7 @@
         }}
       </template>
     </v-data-table>
-    <div class="note">
+    <template v-slot:additionalDescription>
       <ul>
         <li>
           {{ $t('※退院は、保健所から報告があり、確認ができているものを反映') }}
@@ -47,7 +47,7 @@
           {{ $t('※死亡退院を含む') }}
         </li>
       </ul>
-    </div>
+    </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"
@@ -119,17 +119,6 @@
   }
   .v-data-footer__select .v-select__selections .v-select__selection--comma {
     font-size: 1.2rem;
-  }
-}
-.note {
-  margin: 8px 0 0;
-  color: $gray-3;
-  @include font-size(12);
-
-  ul,
-  ol {
-    list-style-type: none;
-    padding: 0;
   }
 }
 .v-menu__content {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -117,12 +117,6 @@ export default Vue.extend({
   height: 100%;
   @include card-container();
 
-  ul,
-  ol {
-    list-style-type: none;
-    padding: 0;
-  }
-
   &-Header {
     display: flex;
     align-items: flex-start;
@@ -177,12 +171,12 @@ export default Vue.extend({
     @include font-size(12);
 
     &--Additional {
-      margin-top: 1rem;
+      margin-bottom: 10px;
     }
   }
 
   &-Table {
-    margin: 10px 0;
+    margin-bottom: 10px;
   }
 
   &-Footer {
@@ -199,6 +193,15 @@ export default Vue.extend({
     .Footer-Right {
       display: flex;
       align-items: flex-end;
+    }
+  }
+
+  &-Description,
+  &-Footer {
+    ul,
+    ol {
+      list-style-type: none;
+      padding: 0;
     }
   }
 

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -23,7 +23,7 @@
         <slot />
       </div>
 
-      <div class="DataView-Description">
+      <div class="DataView-Description DataView-Description--Additional">
         <slot name="additionalDescription" />
       </div>
 
@@ -175,6 +175,10 @@ export default Vue.extend({
     margin-top: 10px;
     color: $gray-3;
     @include font-size(12);
+
+    &--Additional {
+      margin-top: 1rem;
+    }
   }
 
   &-Table {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -117,6 +117,12 @@ export default Vue.extend({
   height: 100%;
   @include card-container();
 
+  ul,
+  ol {
+    list-style-type: none;
+    padding: 0;
+  }
+
   &-Header {
     display: flex;
     align-items: flex-start;
@@ -169,12 +175,6 @@ export default Vue.extend({
     margin-top: 10px;
     color: $gray-3;
     @include font-size(12);
-
-    ul,
-    ol {
-      list-style-type: none;
-      padding: 0;
-    }
   }
 
   &-Table {

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -40,7 +40,7 @@
       </v-data-table>
     </template>
     <template v-slot:footer>
-      <ul :class="$style.DataViewDesc">
+      <ul>
         <li>
           <external-link
             url="https://smooth-biz.metro.tokyo.lg.jp/pdf/202004date3.pdf"
@@ -271,16 +271,3 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
 export default Vue.extend(options)
 </script>
-
-<style module lang="scss">
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
-}
-</style>

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -97,7 +97,6 @@
         </template>
       </v-data-table>
     </template>
-    <slot name="additionalNotes" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -671,15 +670,6 @@ export default Vue.extend(options)
 
 <style module lang="scss">
 .Graph {
-  &Desc {
-    width: 100%;
-    margin: 0;
-    margin-bottom: 0 !important;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
   &Legend {
     text-align: center;
     list-style: none;
@@ -701,16 +691,6 @@ export default Vue.extend(options)
         @include font-size(12);
       }
     }
-  }
-}
-
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    line-height: 15px;
-    color: $gray-3;
-    @include font-size(12);
   }
 }
 </style>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -87,7 +87,11 @@
         </template>
       </v-data-table>
     </template>
-    <slot name="additionalNotes" />
+
+    <template v-slot:additionalDescription>
+      <slot name="additionalDescription" />
+    </template>
+
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -626,15 +630,6 @@ export default Vue.extend(options)
 
 <style module lang="scss">
 .Graph {
-  &Desc {
-    width: 100%;
-    margin: 0;
-    margin-bottom: 0 !important;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
   &Legend {
     text-align: center;
     list-style: none;
@@ -656,16 +651,6 @@ export default Vue.extend(options)
         @include font-size(12);
       }
     }
-  }
-}
-
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    line-height: 15px;
-    color: $gray-3;
-    @include font-size(12);
   }
 }
 </style>

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -87,11 +87,9 @@
         </template>
       </v-data-table>
     </template>
-
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
     </template>
-
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -96,7 +96,6 @@
         </template>
       </v-data-table>
     </template>
-    <slot name="additionalNotes" />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="displayInfo.lText"
@@ -697,15 +696,6 @@ export default Vue.extend(options)
 
 <style module lang="scss">
 .Graph {
-  &Desc {
-    width: 100%;
-    margin: 0;
-    margin-bottom: 0 !important;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
   &Legend {
     text-align: center;
     list-style: none;
@@ -727,16 +717,6 @@ export default Vue.extend(options)
         @include font-size(12);
       }
     }
-  }
-}
-
-.DataView {
-  &Desc {
-    margin-top: 10px;
-    margin-bottom: 0 !important;
-    line-height: 15px;
-    color: $gray-3;
-    @include font-size(12);
   }
 }
 </style>

--- a/components/cards/MonitoringStatusOverviewCard.vue
+++ b/components/cards/MonitoringStatusOverviewCard.vue
@@ -6,7 +6,7 @@
       :date="monitoringStatusData.date"
     >
       <template v-slot:additionalDescription>
-        <ul :class="$style.notes">
+        <ul>
           <li>
             {{
               $t(
@@ -40,20 +40,6 @@
     </data-view>
   </v-col>
 </template>
-
-<style lang="scss" module>
-ul.notes {
-  margin-top: 10px;
-  margin-bottom: 0;
-  padding-left: 0 !important;
-  color: $gray-3;
-  @include font-size(12);
-
-  > li {
-    list-style-type: none;
-  }
-}
-</style>
 
 <script>
 import monitoringStatusData from '@/data/monitoring_status.json'

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -12,7 +12,7 @@
       :table-labels="positiveRateTableLabels"
     >
       <template v-slot:additionalDescription>
-        <ul :class="$style.GraphDesc">
+        <ul>
           <li>
             {{
               $t(
@@ -105,16 +105,3 @@ export default {
   }
 }
 </script>
-
-<style module lang="scss">
-.Graph {
-  &Desc {
-    margin: 0;
-    margin-top: 1rem;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
-}
-</style>

--- a/components/cards/TestedCasesDetailsCard.vue
+++ b/components/cards/TestedCasesDetailsCard.vue
@@ -5,8 +5,8 @@
       :title-id="'details-of-tested-cases'"
       :date="Data.inspection_status_summary.date"
     >
-      <template v-slot:button>
-        <ul :class="$style.notes">
+      <template v-slot:description>
+        <ul>
           <li>
             {{
               $t(
@@ -30,20 +30,6 @@
     </data-view>
   </v-col>
 </template>
-
-<style lang="scss" module>
-ul.notes {
-  margin-top: 10px;
-  margin-bottom: 0;
-  padding-left: 0 !important;
-  color: $gray-3;
-  @include font-size(12);
-
-  > li {
-    list-style-type: none;
-  }
-}
-</style>
 
 <script>
 import Data from '@/data/data.json'

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -14,7 +14,7 @@
     >
       <!-- 件.tested = 検査数 -->
       <template v-slot:description>
-        <ul :class="$style.GraphDesc">
+        <ul>
           <li>
             {{
               $t(
@@ -88,16 +88,3 @@ export default {
   }
 }
 </script>
-
-<style module lang="scss">
-.Graph {
-  &Desc {
-    margin: 0;
-    margin-top: 1rem;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
-}
-</style>

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -13,7 +13,7 @@
       :additional-lines="additionalLines"
     >
       <template v-slot:additionalDescription>
-        <ul :class="$style.GraphDesc">
+        <ul>
           <li>
             {{
               $t(
@@ -91,16 +91,3 @@ export default {
   }
 }
 </script>
-
-<style module lang="scss">
-.Graph {
-  &Desc {
-    margin: 0;
-    margin-top: 1rem;
-    padding-left: 0 !important;
-    color: $gray-3;
-    list-style: none;
-    @include font-size(12);
-  }
-}
-</style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4575

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 各グラフコンポーネントから注釈のスタイル `.DataViewDesc` を削除しました
  - `DataView.vue` に上記スタイルをまとめました
- 注釈のスロットを `additionalNotes` -> `additionalDescription` に変更しました
  - レイアウトに関するスロットは `DataView.vue` にまとめたほうが管理しやすいためです

## 📸 スクリーンショット / Screenshots
カードによっては注釈の位置が数px 変わっていますが、その他の見た目に関する変更はありません。