### PR TITLE
[refactor] グラフデータを表示するテーブルコンポーネントを追加

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -15,29 +15,7 @@
       :height="240"
     />
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item[0] }}</td>
-              <td class="text-end">{{ item[1] }}</td>
-              <td class="text-end">{{ item[2] }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
   </data-view>
 </template>
@@ -49,6 +27,10 @@ import { ChartOptions } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import agencyData from '@/data/agency.json'
 import DataView from '@/components/DataView.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import { DisplayData, DataSets } from '@/plugins/vue-chart'
 
@@ -72,13 +54,8 @@ type Methods = {}
 type Computed = {
   displayData: AgencyDisplayData
   displayOption: ChartOptions
-  tableHeaders: {
-    text: VueI18n.TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 type Props = {
   title: string
@@ -97,7 +74,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView },
+  components: { DataView, DataViewTable },
   props: {
     title: {
       type: String,

--- a/components/ConfirmedCasesByMunicipalitiesTable.vue
+++ b/components/ConfirmedCasesByMunicipalitiesTable.vue
@@ -13,7 +13,7 @@
       :fixed-header="true"
       :mobile-breakpoint="0"
       :disable-sort="true"
-      class="cardTableMunicipalities"
+      class="cardTable"
     />
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -24,47 +24,6 @@
     </template>
   </data-view>
 </template>
-
-<style lang="scss">
-.cardTableMunicipalities {
-  &.v-data-table {
-    box-shadow: 0 -20px 12px -12px #0003 inset;
-    th {
-      padding: 8px 10px;
-      height: auto;
-      border-bottom: 1px solid $gray-4;
-      color: $gray-2;
-      @include font-size(12);
-    }
-
-    tbody {
-      tr {
-        color: $gray-1;
-
-        th {
-          font-weight: normal;
-        }
-
-        td {
-          padding: 8px 10px;
-          height: auto;
-          @include font-size(12);
-        }
-
-        &:nth-child(odd) {
-          th,
-          td {
-            background: rgba($gray-4, 0.3);
-          }
-        }
-      }
-    }
-    &:focus {
-      outline: dotted $gray-3 1px;
-    }
-  }
-}
-</style>
 
 <script lang="ts">
 import Vue from 'vue'

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -75,27 +75,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item.transition }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -118,6 +98,10 @@ import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
@@ -149,14 +133,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    text: string
-    transition: string
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 type Props = {
   title: string
@@ -183,7 +161,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -35,27 +35,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item.transition }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -78,7 +58,10 @@ import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
-import DataSelector from '@/components/DataSelector.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import {
@@ -119,14 +102,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    text: string
-    transition: string
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -154,7 +131,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -27,9 +27,12 @@
         <slot name="additionalDescription" />
       </div>
 
-      <data-view-table v-if="this.$slots.dataTable" class="DataView-Table">
+      <data-view-expantion-panel
+        v-if="this.$slots.dataTable"
+        class="DataView-ExpantionPanel"
+      >
         <slot name="dataTable" />
-      </data-view-table>
+      </data-view-expantion-panel>
 
       <div class="DataView-Space" />
 
@@ -60,11 +63,11 @@
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
-import DataViewTable from '@/components/DataViewTable.vue'
+import DataViewExpantionPanel from '@/components/DataViewExpantionPanel.vue'
 import DataViewShare from '@/components/DataViewShare.vue'
 
 export default Vue.extend({
-  components: { DataViewTable, DataViewShare },
+  components: { DataViewExpantionPanel, DataViewShare },
   props: {
     title: {
       type: String,
@@ -175,7 +178,7 @@ export default Vue.extend({
     }
   }
 
-  &-Table {
+  &-ExpantionPanel {
     margin-bottom: 10px;
   }
 

--- a/components/DataViewExpantionPanel.vue
+++ b/components/DataViewExpantionPanel.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <v-expansion-panels v-if="showDetails" flat>
+      <v-expansion-panel>
+        <v-expansion-panel-header
+          :hide-actions="true"
+          :style="{ transition: 'none' }"
+          @click="toggleDetails"
+        >
+          <template slot:actions>
+            <div class="v-expansion-panel-header__icon">
+              <v-icon left>mdi-chevron-right</v-icon>
+            </div>
+          </template>
+          <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <slot />
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+    <template v-else>
+      <slot />
+    </template>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
+
+export default Vue.extend({
+  data() {
+    return {
+      showDetails: false
+    }
+  },
+  mounted() {
+    this.showDetails = true
+  },
+  methods: {
+    toggleDetails() {
+      EventBus.$emit(TOGGLE_EVENT, { dataView: this.$parent })
+    }
+  }
+})
+</script>
+
+<style lang="scss">
+.v-expansion-panel-header__icon {
+  margin-left: -5px !important;
+
+  & .v-icon--left {
+    margin-right: 5px;
+  }
+
+  .v-expansion-panel--active & .v-icon {
+    transform: rotate(90deg) !important;
+  }
+}
+
+.expansion-panel-text {
+  color: $gray-1;
+  @include font-size(14);
+}
+</style>

--- a/components/DataViewExpantionPanel.vue
+++ b/components/DataViewExpantionPanel.vue
@@ -7,11 +7,9 @@
           :style="{ transition: 'none' }"
           @click="toggleDetails"
         >
-          <template slot:actions>
-            <div class="v-expansion-panel-header__icon">
-              <v-icon left>mdi-chevron-right</v-icon>
-            </div>
-          </template>
+          <div class="v-expansion-panel-header__icon">
+            <v-icon left>mdi-chevron-right</v-icon>
+          </div>
           <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
         </v-expansion-panel-header>
         <v-expansion-panel-content>

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -1,69 +1,85 @@
 <template>
-  <div>
-    <v-expansion-panels v-if="showDetails" flat>
-      <v-expansion-panel>
-        <v-expansion-panel-header
-          :hide-actions="true"
-          :style="{ transition: 'none' }"
-          @click="toggleDetails"
-        >
-          <template slot:actions>
-            <div class="v-expansion-panel-header__icon">
-              <v-icon left>mdi-chevron-right</v-icon>
-            </div>
-          </template>
-          <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
-        </v-expansion-panel-header>
-        <v-expansion-panel-content>
-          <slot />
-        </v-expansion-panel-content>
-      </v-expansion-panel>
-    </v-expansion-panels>
-    <template v-else>
-      <slot />
+  <v-data-table
+    :headers="headers"
+    :items="items"
+    :items-per-page="-1"
+    :hide-default-footer="true"
+    :height="240"
+    :fixed-header="true"
+    :disable-sort="true"
+    :mobile-breakpoint="0"
+    class="cardTable"
+    item-key="name"
+  >
+    <template v-slot:body="{ items }">
+      <tbody>
+        <tr v-for="(item, i) in items" :key="i">
+          <th scope="row">{{ item[headerKey] }}</th>
+          <td v-for="(dataKey, j) in dataKeys" :key="j" class="text-end">
+            {{ item[dataKey] }}
+          </td>
+        </tr>
+      </tbody>
     </template>
-  </div>
+  </v-data-table>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
+import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import { TranslateResult } from 'vue-i18n'
 
-export default Vue.extend({
-  data() {
-    return {
-      showDetails: false
+export type TableHeader = {
+  text: TranslateResult
+  value: string
+  align?: string
+}
+export type TableItem = {
+  [key: number]: number
+}
+type Data = {}
+type Methods = {}
+type Computed = {
+  dataKeys: string[]
+}
+type Props = {
+  headers: TableHeader[]
+  items: TableItem[]
+  headerKey: string
+}
+
+const options: ThisTypedComponentOptionsWithRecordProps<
+  Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = {
+  props: {
+    headers: {
+      type: Array,
+      default: () => []
+    },
+    items: {
+      type: Array,
+      default: () => []
+    },
+    headerKey: {
+      type: String,
+      default: 'text'
     }
   },
-  mounted() {
-    this.showDetails = true
-  },
-  methods: {
-    toggleDetails() {
-      EventBus.$emit(TOGGLE_EVENT, { dataView: this.$parent })
+  computed: {
+    dataKeys() {
+      return this.headers.map(h => h.value).filter(h => h !== this.headerKey)
     }
   }
-})
+}
+
+export default Vue.extend(options)
 </script>
 
 <style lang="scss">
-.v-expansion-panel-header__icon {
-  margin-left: -5px !important;
-
-  & .v-icon--left {
-    margin-right: 5px;
-  }
-
-  .v-expansion-panel--active & .v-icon {
-    transform: rotate(90deg) !important;
-  }
-}
-
-.expansion-panel-text {
-  color: $gray-1;
-  @include font-size(14);
-}
-
 .v-data-table .text-end {
   text-align: right;
 }

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -35,6 +35,9 @@ export type TableHeader = {
   align?: string
 }
 export type TableItem = {
+  text: string
+  transition?: string
+  cumulative?: string
   [key: number]: number
 }
 type Data = {}

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -15,29 +15,7 @@
       :height="240"
     />
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item[0] }}</td>
-              <td class="text-end">{{ item[1] }}</td>
-              <td class="text-end">{{ item[2] }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:footer>
       <ul>
@@ -64,10 +42,13 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { TranslateResult } from 'vue-i18n'
 import { ChartOptions, ChartData, Chart } from 'chart.js'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import ExternalLink from '@/components/ExternalLink.vue'
 import { DisplayData } from '@/plugins/vue-chart'
@@ -82,13 +63,8 @@ type Data = {
 type Methods = {}
 type Computed = {
   displayData: DisplayData
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
   displayOption: Chart.ChartOptions
 }
 type Props = {
@@ -113,7 +89,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, ExternalLink },
+  components: { DataView, DataViewTable, ExternalLink },
   props: {
     title: {
       type: String,

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -70,22 +70,11 @@
         />
       </div>
     </div>
-    <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      />
-    </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
+    </template>
+    <template v-slot:dataTable>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -107,6 +96,10 @@ import { TranslateResult } from 'vue-i18n'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
@@ -137,13 +130,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -170,7 +158,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -54,18 +54,7 @@
       </div>
     </div>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      />
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
@@ -90,8 +79,12 @@ import { TranslateResult } from 'vue-i18n'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
-import OpenDataLink from '@/components/OpenDataLink.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 
@@ -120,13 +113,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -151,7 +139,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -72,30 +72,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item['0'] }}</td>
-              <td class="text-end">{{ item['1'] }}</td>
-              <td class="text-end">{{ item['2'] }}</td>
-              <td class="text-end">{{ item['3'] }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -114,7 +91,10 @@ import { TranslateResult } from 'vue-i18n'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
-import DataSelector from '@/components/DataSelector.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import {
   DisplayData,
@@ -154,13 +134,8 @@ type Computed = {
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
   scaledTicksYAxisMaxRight: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -188,7 +163,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel
+  },
   props: {
     title: {
       type: String,

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -32,18 +32,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      />
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -57,13 +46,15 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { TranslateResult } from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
-import DataSelector from '@/components/DataSelector.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
@@ -89,14 +80,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    text: string
-    transition: string
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 type Props = {
   title: string
@@ -120,7 +105,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -42,28 +42,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item.transition }}</td>
-              <td class="text-end">{{ item.cumulative }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -80,7 +59,6 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { TranslateResult } from 'vue-i18n'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
@@ -88,6 +66,10 @@ import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
 
@@ -115,15 +97,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    text: string
-    transition: string
-    cumulative: string
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 type Props = {
   title: string
@@ -152,7 +127,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         ? 'cumulative'
         : 'transition'
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel, OpenDataLink },
+  components: {
+    DataView,
+    DataSelector,
+    DataViewBasicInfoPanel,
+    DataViewTable,
+    OpenDataLink
+  },
   props: {
     title: {
       type: String,

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -62,30 +62,7 @@
       />
     </div>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item['0'] }}</td>
-              <td class="text-end">{{ item['1'] }}</td>
-              <td class="text-end">{{ item['2'] }}</td>
-              <td class="text-end">{{ item['3'] }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
@@ -108,6 +85,10 @@ import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
@@ -142,13 +123,8 @@ type Computed = {
   displayDataHeader: DisplayData
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -180,7 +156,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         ? 'cumulative'
         : 'transition'
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel },
+  components: {
+    DataView,
+    DataSelector,
+    DataViewTable,
+    DataViewBasicInfoPanel
+  },
   props: {
     title: {
       type: String,

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -73,29 +73,7 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <v-data-table
-        :headers="tableHeaders"
-        :items="tableData"
-        :items-per-page="-1"
-        :hide-default-footer="true"
-        :height="240"
-        :fixed-header="true"
-        :disable-sort="true"
-        :mobile-breakpoint="0"
-        class="cardTable"
-        item-key="name"
-      >
-        <template v-slot:body="{ items }">
-          <tbody>
-            <tr v-for="item in items" :key="item.text">
-              <th scope="row">{{ item.text }}</th>
-              <td class="text-end">{{ item['0'] }}</td>
-              <td class="text-end">{{ item['1'] }}</td>
-              <td class="text-end">{{ item['2'] }}</td>
-            </tr>
-          </tbody>
-        </template>
-      </v-data-table>
+      <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
@@ -114,7 +92,10 @@ import { TranslateResult } from 'vue-i18n'
 import { Chart } from 'chart.js'
 import dayjs from 'dayjs'
 import DataView from '@/components/DataView.vue'
-import DataSelector from '@/components/DataSelector.vue'
+import DataViewTable, {
+  TableHeader,
+  TableItem
+} from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import {
   DisplayData,
@@ -156,13 +137,8 @@ type Computed = {
   displayOptionHeader: Chart.ChartOptions
   scaledTicksYAxisMax: number
   scaledTicksYAxisMaxRight: number
-  tableHeaders: {
-    text: TranslateResult
-    value: string
-  }[]
-  tableData: {
-    [key: number]: number
-  }[]
+  tableHeaders: TableHeader[]
+  tableData: TableItem[]
 }
 
 type Props = {
@@ -191,7 +167,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   created() {
     this.canvas = process.browser
   },
-  components: { DataView, DataSelector, DataViewBasicInfoPanel },
+  components: {
+    DataView,
+    DataViewTable,
+    DataViewBasicInfoPanel
+  },
   props: {
     title: {
       type: String,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4623

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 各グラフのデータを表示するためのコンポーネント `DataViewTable.vue` を追加しました
  - 元の `DataViewTable.vue` コンポーネントは、コンポーネントの役割に合わせて`DataViewExpantionPanel.vue` へリネームしました
- 各グラフで `v-data-table` で実装している箇所を `DataViewTable.vue` で置き換えました
  - `陽性患者の属性` と `陽性患者数（区市町村別）` については、データの表示形式が異なるので今回は共通化の対象から外しました
  - `陽性患者数（区市町村別）` のみ重複していたテーブルのスタイルを削除しました

## 📸 スクリーンショット / Screenshots
リファクタリングなので、見た目の変更はありません。
すべてのデータテーブルで、`th` 要素に `scope="row"` 属性がつくようになりました。
（最新コミットで Netlify の Deploy Preview が出てこないので、ローカルで確認しました）

![スクリーンショット 2020-05-30 20 51 07](https://user-images.githubusercontent.com/5207601/83327519-7a223b00-a2b7-11ea-86c1-de0308ce4a4d.png)