### PR TITLE
折れ線グラフの凡例を線状にする

### DIFF
--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -7,7 +7,15 @@
       <li v-for="(item, i) in dataLabels" :key="i" @click="onClickLegend(i)">
         <button>
           <div
-            v-if="i === 2"
+            v-if="i === 1"
+            :style="{
+              background: colors[i].fillColor,
+              border: 0,
+              height: '3px'
+            }"
+          />
+          <div
+            v-else-if="i === 2"
             :style="{
               background: `repeating-linear-gradient(90deg, ${colors[i].fillColor}, ${colors[i].fillColor} 2px, #fff 2px, #fff 4px)`,
               border: 0,

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -7,6 +7,15 @@
       <li v-for="(item, i) in dataLabels" :key="i" @click="onClickLegend(i)">
         <button>
           <div
+            v-if="i === 1"
+            :style="{
+              backgroundColor: colors[i].fillColor,
+              border: 0,
+              height: '3px'
+            }"
+          />
+          <div
+            v-else
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -14,10 +14,11 @@
       >
         <button>
           <div
-            v-if="i >= 2"
+            v-if="i === 2"
             :style="{
               backgroundColor: '#CC7004',
-              borderColor: '#CC7004'
+              border: 0,
+              height: '3px'
             }"
           />
           <div

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -14,7 +14,15 @@
       >
         <button>
           <div
-            v-if="i === 3"
+            v-if="i === 2"
+            :style="{
+              backgroundColor: colors[i].fillColor,
+              border: 0,
+              height: '3px'
+            }"
+          />
+          <div
+            v-else-if="i === 3"
             :style="{
               background: `repeating-linear-gradient(90deg, ${colors[i].fillColor}, ${colors[i].fillColor} 2px, #fff 2px, #fff 4px)`,
               border: 0,


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4635 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 折れ線グラフの凡例のスタイルが `border: 0` `height: '3px'` となるように `v-if` 文を追加しました。
- 対応した折れ線グラフは以下の４つ。
・モニタリング指標(1)新規陽性者数：7日間移動平均
・モニタリング指標(2)新規陽性者における接触歴等不明率：接触歴等不明率（7日間移動平均）
・モニタリング指標(6)PCR検査の陽性率：陽性率
・モニタリング指標(7)受診相談窓口における相談件数：7日間移動平均

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2020-05-30 11 22 50](https://user-images.githubusercontent.com/14883063/83317678-520beb00-a269-11ea-84c5-eb1a4d20ad7f.png)
![スクリーンショット 2020-05-30 11 32 11](https://user-images.githubusercontent.com/14883063/83317681-589a6280-a269-11ea-9847-89c10f9e4861.png)
![スクリーンショット 2020-05-30 11 32 29](https://user-images.githubusercontent.com/14883063/83317685-5f28da00-a269-11ea-96a2-970001eb6417.png)
![スクリーンショット 2020-05-30 11 32 41](https://user-images.githubusercontent.com/14883063/83317693-651ebb00-a269-11ea-9545-9229384a12c6.png)
