### PR TITLE
IE11向け日付フォーマット及びNodeList処理修正

### DIFF
--- a/components/ConfirmedCasesByMunicipalitiesTable.vue
+++ b/components/ConfirmedCasesByMunicipalitiesTable.vue
@@ -58,8 +58,9 @@ export default Vue.extend({
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el
     const tables = vTableElement.querySelectorAll('table')
-
-    tables.forEach((table: HTMLElement) => {
+    // NodeListをIE11でforEachするためのワークアラウンド
+    const nodes = Array.prototype.slice.call(tables, 0)
+    nodes.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
   }

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -191,8 +191,9 @@ export default Vue.extend({
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el
     const tables = vTableElement.querySelectorAll('table')
-
-    tables.forEach((table: HTMLElement) => {
+    // NodeListをIE11でforEachするためのワークアラウンド
+    const nodes = Array.prototype.slice.call(tables, 0)
+    nodes.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
   }

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -225,20 +225,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   }),
   computed: {
     displayInfo() {
-      const date = this.$d(
-        new Date(this.labels[this.labels.length - 1]),
-        'dateWithoutYear'
-      )
       if (this.dataKind === 'transition') {
         return {
           lText: this.sum(this.pickLastNumber(this.chartData)).toLocaleString(),
-          sText: `${this.$t('{date}の合計', { date })}`,
+          sText: `${this.$t('{date}の合計', {
+            date: this.labels[this.labels.length - 1]
+          })}`,
           unit: this.unit
         }
       }
       return {
         lText: this.sum(this.cumulativeSum(this.chartData)).toLocaleString(),
-        sText: `${this.$t('{date}の全体累計', { date })}`,
+        sText: `${this.$t('{date}の合計', {
+          date: this.labels[this.labels.length - 1]
+        })}`,
         unit: this.unit
       }
     },

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -15,7 +15,7 @@ const dateTimeFormatsCommon = {
     day: 'numeric'
   },
   dateWithoutYear: {
-    month: 'short',
+    month: 'long',
     day: 'numeric'
   }
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4657 

## 📝 関連する issue / Related Issues
- #1543
上記への修正[プルリクエスト](https://github.com/tokyo-metropolitan-gov/covid19/pull/4232)を一部巻き戻してしまっています。

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `nuxt-i18n`のdateWithoutYearのmonth指定を`long`に変更。（IE11では `month: 'short'` だと数字のみになってしまい「月」が入らないため）
- IE11向けNodeListのforEachのためにワークアラウンドを追加

![コメント 2020-06-01 155837](https://user-images.githubusercontent.com/1763230/83383856-eec4b900-a420-11ea-9a76-3d28dcfea09f.png)
![コメント 2020-06-01 155940](https://user-images.githubusercontent.com/1763230/83383861-f1271300-a420-11ea-9ecf-ac08c40a3513.png)
