### PR TITLE
グラフ一覧にタブ切替を実装

### DIFF
--- a/components/CardsTabs.vue
+++ b/components/CardsTabs.vue
@@ -37,7 +37,6 @@ export default {
   top: 1px;
   margin: 0 8px;
   border-style: solid;
-  box-shadow: inset 0 -1px 0 $gray-5;
   border-radius: 4px 4px 0 0;
   font-weight: bold !important;
   @include font-size(16, true);

--- a/components/CardsTabs.vue
+++ b/components/CardsTabs.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-tabs
+    hide-slider
+    show-arrows
+  >
+    <v-tab
+      v-for="(tab, index) in tabs"
+      :key="index"
+      :to="tab.path"
+      nuxt
+      active-class="ActiveTab"
+    >
+      <v-icon>
+        mdi-chart-timeline-variant
+      </v-icon>
+      {{ tab.label }}
+    </v-tab>
+  </v-tabs>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      tabs: [
+        { label: this.$t('モニタリング指標'), path: '/' },
+        { label: this.$t('その他 参考指標'), path: '/reference' }
+      ]
+    }
+  }
+}
+</script>
+
+<style lang="scss">
+.v-slide-group__content {
+  border-bottom: 1px solid $gray-2;
+  background: $gray-5;
+}
+.v-tab {
+  top: 1px;
+  margin-right: 8px;
+  border-style: solid;
+  box-shadow: inset 0 -1px 0 $gray-5;
+  border-radius: 4px 4px 0 0;
+  font-weight: bold !important;
+  @include font-size(16, true);
+
+  &.ActiveTab {
+    color: $gray-2 !important;
+    background: $gray-5;
+    border-color: $gray-2;
+    border-width: 1px 1px 0 1px;
+  }
+
+  &:not(.ActiveTab) {
+    color: $green-1 !important;
+    background: $white;
+    border-color: $green-1 $green-1 $gray-2 $green-1;
+    border-width: 1px;
+    &:hover {
+      color: $white !important;
+      background: $green-1;
+    }
+    .v-icon {
+      color: inherit !important;
+    }
+  }
+}
+</style>

--- a/components/CardsTabs.vue
+++ b/components/CardsTabs.vue
@@ -35,7 +35,7 @@ export default {
 }
 .v-tab {
   top: 1px;
-  margin-right: 8px;
+  margin: 0 8px;
   border-style: solid;
   box-shadow: inset 0 -1px 0 $gray-5;
   border-radius: 4px 4px 0 0;

--- a/components/CardsTabs.vue
+++ b/components/CardsTabs.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-tabs
-    hide-slider
-    show-arrows
-  >
+  <v-tabs hide-slider show-arrows>
     <v-tab
       v-for="(tab, index) in tabs"
       :key="index"

--- a/components/SiteTopUpper.vue
+++ b/components/SiteTopUpper.vue
@@ -1,0 +1,98 @@
+<template>
+  <div>
+    <div class="Header mb-3">
+      <page-header :icon="headerItem.icon">{{ headerItem.title }}</page-header>
+      <div class="UpdatedAt">
+        <span>{{ $t('最終更新') }}</span>
+        <time :datetime="updatedAt">{{ formattedDateForDisplay }}</time>
+      </div>
+      <div
+        v-show="!['ja', 'ja-basic'].includes($i18n.locale)"
+        class="Annotation"
+      >
+        <span>{{ $t('注釈') }}</span>
+      </div>
+    </div>
+    <whats-new class="mb-4" :items="newsItems" :is-emergency="false" />
+    <static-info
+      class="mb-4"
+      :url="localePath('/flow')"
+      :text="$t('自分や家族の症状に不安や心配があればまずは電話相談をどうぞ')"
+      :btn-text="$t('相談の手順を見る')"
+    />
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { MetaInfo } from 'vue-meta'
+import PageHeader from '@/components/PageHeader.vue'
+import WhatsNew from '@/components/WhatsNew.vue'
+import StaticInfo from '@/components/StaticInfo.vue'
+import Data from '@/data/data.json'
+import News from '@/data/news.json'
+import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
+
+export default Vue.extend({
+  components: {
+    PageHeader,
+    WhatsNew,
+    StaticInfo
+  },
+  data() {
+    const data = {
+      Data,
+      headerItem: {
+        icon: 'mdi-chart-timeline-variant',
+        title: this.$t('都内の最新感染動向')
+      },
+      newsItems: News.newsItems
+    }
+    return data
+  },
+  computed: {
+    updatedAt() {
+      return convertDatetimeToISO8601Format(this.$data.Data.lastUpdate)
+    },
+    formattedDateForDisplay() {
+      return this.$d(new Date(Data.lastUpdate), 'dateTime')
+    }
+  },
+  head(): MetaInfo {
+    return {
+      title: this.$t('都内の最新感染動向') as string
+    }
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.MainPage {
+  .Header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+
+    @include lessThan($small) {
+      flex-direction: column;
+      align-items: baseline;
+    }
+  }
+
+  .UpdatedAt {
+    @include font-size(14);
+
+    color: $gray-3;
+    margin-bottom: 0.2rem;
+  }
+
+  .Annotation {
+    @include font-size(12);
+
+    color: $gray-3;
+    @include largerThan($small) {
+      margin: 0 0 0 auto;
+    }
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,25 +1,7 @@
 <template>
   <div class="MainPage">
-    <div class="Header mb-3">
-      <page-header :icon="headerItem.icon">{{ headerItem.title }}</page-header>
-      <div class="UpdatedAt">
-        <span>{{ $t('最終更新') }}</span>
-        <time :datetime="updatedAt">{{ formattedDateForDisplay }}</time>
-      </div>
-      <div
-        v-show="!['ja', 'ja-basic'].includes($i18n.locale)"
-        class="Annotation"
-      >
-        <span>{{ $t('注釈') }}</span>
-      </div>
-    </div>
-    <whats-new class="mb-4" :items="newsItems" :is-emergency="false" />
-    <static-info
-      class="mb-4"
-      :url="localePath('/flow')"
-      :text="$t('自分や家族の症状に不安や心配があればまずは電話相談をどうぞ')"
-      :btn-text="$t('相談の手順を見る')"
-    />
+    <site-top-upper />
+    <cards-tabs />
     <card-row class="DataBlock">
       <!-- 検査陽性者の状況 -->
       <confirmed-cases-details-card />
@@ -41,143 +23,47 @@
       <positive-rate-card />
       <!-- モニタリング指標(7)受診相談窓口における相談件数 -->
       <monitoring-consultation-desk-reports-number-card />
-      <!-- 陽性患者の属性 -->
-      <confirmed-cases-attributes-card />
-      <!-- 区市町村別患者数 -->
-      <confirmed-cases-by-municipalities-card />
-      <!-- 検査実施状況 -->
-      <tested-cases-details-card />
-      <!-- 検査実施件数 -->
-      <tested-number-card />
-      <!-- 検査実施人数（健康安全研究センターによる実施分） -->
-      <inspection-persons-number-card />
-      <!-- PCR検査陽性者の発生動向（確定日別による陽性者数の推移） -->
-      <positive-number-by-diagnosed-date-card />
-      <!-- 新型コロナコールセンター相談件数 -->
-      <telephone-advisory-reports-number-card />
-      <!-- 新型コロナ受診相談窓口相談件数 -->
-      <consultation-desk-reports-number-card />
-      <!-- 都営地下鉄の利用者数の推移 -->
-      <metro-card />
-      <!-- 都庁来庁者数の推移 -->
-      <agency-card />
     </card-row>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
-import { MetaInfo } from 'vue-meta'
-import PageHeader from '@/components/PageHeader.vue'
-import WhatsNew from '@/components/WhatsNew.vue'
-import StaticInfo from '@/components/StaticInfo.vue'
+import SiteTopUpper from "@/components/SiteTopUpper.vue";
+import CardsTabs from "@/components/CardsTabs.vue";
 import CardRow from '@/components/cards/CardRow.vue'
-import Data from '@/data/data.json'
-import News from '@/data/news.json'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
-import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
-import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'
-import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
-import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
-import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
-import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
-import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
 import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringConfirmedCasesNumberCard.vue'
 import PositiveRateCard from '~/components/cards/PositiveRateCard.vue'
-import MetroCard from '@/components/cards/MetroCard.vue'
-import AgencyCard from '@/components/cards/AgencyCard.vue'
 import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
-import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
 import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
 import ConfirmedCasesIncreaseRatioByWeekCard from '@/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue'
 import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
 import MonitoringStatusOverviewCard from '@/components/cards/MonitoringStatusOverviewCard.vue'
-import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
 
 export default Vue.extend({
   components: {
+    SiteTopUpper,
+    CardsTabs,
+    CardRow,
     MonitoringConfirmedCasesNumberCard,
     UntrackedRateCard,
     SevereCaseCard,
     MonitoringConsultationDeskReportsNumberCard,
     PositiveRateCard,
-    PageHeader,
-    WhatsNew,
-    StaticInfo,
-    CardRow,
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
-    ConfirmedCasesAttributesCard,
-    ConfirmedCasesByMunicipalitiesCard,
-    TestedCasesDetailsCard,
-    InspectionPersonsNumberCard,
-    TestedNumberCard,
-    TelephoneAdvisoryReportsNumberCard,
-    ConsultationDeskReportsNumberCard,
-    MetroCard,
-    AgencyCard,
-    PositiveNumberByDiagnosedDateCard,
     ConfirmedCasesIncreaseRatioByWeekCard,
     HospitalizedNumberCard,
     MonitoringStatusOverviewCard
-  },
-  data() {
-    const data = {
-      Data,
-      headerItem: {
-        icon: 'mdi-chart-timeline-variant',
-        title: this.$t('都内の最新感染動向')
-      },
-      newsItems: News.newsItems
-    }
-    return data
-  },
-  computed: {
-    updatedAt() {
-      return convertDatetimeToISO8601Format(this.$data.Data.lastUpdate)
-    },
-    formattedDateForDisplay() {
-      return this.$d(new Date(Data.lastUpdate), 'dateTime')
-    }
-  },
-  head(): MetaInfo {
-    return {
-      title: this.$t('都内の最新感染動向') as string
-    }
   }
 })
 </script>
 
 <style lang="scss" scoped>
 .MainPage {
-  .Header {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: flex-end;
-
-    @include lessThan($small) {
-      flex-direction: column;
-      align-items: baseline;
-    }
-  }
-
-  .UpdatedAt {
-    @include font-size(14);
-
-    color: $gray-3;
-    margin-bottom: 0.2rem;
-  }
-
-  .Annotation {
-    @include font-size(12);
-
-    color: $gray-3;
-    @include largerThan($small) {
-      margin: 0 0 0 auto;
-    }
-  }
   .DataBlock {
     margin: 20px -8px;
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -29,8 +29,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import SiteTopUpper from "@/components/SiteTopUpper.vue";
-import CardsTabs from "@/components/CardsTabs.vue";
+import SiteTopUpper from '@/components/SiteTopUpper.vue'
+import CardsTabs from '@/components/CardsTabs.vue'
 import CardRow from '@/components/cards/CardRow.vue'
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'

--- a/pages/reference.vue
+++ b/pages/reference.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="MainPage">
+    <site-top-upper />
+    <cards-tabs />
+    <card-row class="DataBlock">
+      <!-- 陽性患者の属性 -->
+      <confirmed-cases-attributes-card />
+      <!-- 区市町村別患者数 -->
+      <confirmed-cases-by-municipalities-card />
+      <!-- PCR検査陽性者の発生動向（確定日別による陽性者数の推移） -->
+      <positive-number-by-diagnosed-date-card />
+      <!-- 検査実施件数 -->
+      <tested-number-card />
+      <!-- 新型コロナコールセンター相談件数 -->
+      <telephone-advisory-reports-number-card />
+    </card-row>
+    <card-row class="DataBlock">
+      <!-- 都営地下鉄の利用者数の推移 -->
+      <metro-card />
+      <!-- 都庁来庁者数の推移 -->
+      <agency-card />
+      <!-- 検査実施状況 -->
+      <tested-cases-details-card />
+      <!-- 検査実施人数（健康安全研究センターによる実施分） -->
+      <inspection-persons-number-card />
+      <!-- 新型コロナ受診相談窓口相談件数 -->
+      <consultation-desk-reports-number-card />
+    </card-row>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import SiteTopUpper from '@/components/SiteTopUpper.vue';
+import CardsTabs from '@/components/CardsTabs.vue';
+import CardRow from '@/components/cards/CardRow.vue'
+import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
+import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'
+import TestedCasesDetailsCard from '@/components/cards/TestedCasesDetailsCard.vue'
+import InspectionPersonsNumberCard from '@/components/cards/InspectionPersonsNumberCard.vue'
+import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
+import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
+import ConsultationDeskReportsNumberCard from '@/components/cards/ConsultationDeskReportsNumberCard.vue'
+import MetroCard from '@/components/cards/MetroCard.vue'
+import AgencyCard from '@/components/cards/AgencyCard.vue'
+import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
+
+export default Vue.extend({
+  components: {
+    SiteTopUpper,
+    CardsTabs,
+    CardRow,
+    ConfirmedCasesAttributesCard,
+    ConfirmedCasesByMunicipalitiesCard,
+    TestedCasesDetailsCard,
+    InspectionPersonsNumberCard,
+    TestedNumberCard,
+    TelephoneAdvisoryReportsNumberCard,
+    ConsultationDeskReportsNumberCard,
+    MetroCard,
+    AgencyCard,
+    PositiveNumberByDiagnosedDateCard
+  }
+})
+</script>
+
+<style lang="scss" scoped>
+.MainPage {
+  .DataBlock {
+    margin: 20px -8px;
+
+    .DataCard {
+      @include largerThan($medium) {
+        padding: 10px;
+      }
+
+      @include lessThan($small) {
+        padding: 4px 8px;
+      }
+    }
+  }
+}
+</style>

--- a/pages/reference.vue
+++ b/pages/reference.vue
@@ -31,8 +31,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import SiteTopUpper from '@/components/SiteTopUpper.vue';
-import CardsTabs from '@/components/CardsTabs.vue';
+import SiteTopUpper from '@/components/SiteTopUpper.vue'
+import CardsTabs from '@/components/CardsTabs.vue'
 import CardRow from '@/components/cards/CardRow.vue'
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4637 

## 📝 関連する issue / Related Issues
- #4648 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- グラフ一覧にタブ切替を実装
- それぞれルーティングするために `index.vue` を修正、 `reference.vue` を作成
- タブのコンポーネント `CardsTabs.vue` を作成
- サイトトップの上部コンテンツをまとめたコンポーネント `SiteTopUpper.vue` を作成
- グラフの並べ替え

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
「モニタリング指標」選択時
![スクリーンショット 2020-06-02 2 48 58](https://user-images.githubusercontent.com/14883063/83437998-a8e90e80-a47b-11ea-93bf-dd2851b76698.png)

「その他 参考指標」選択時
![スクリーンショット 2020-06-02 2 49 06](https://user-images.githubusercontent.com/14883063/83438023-b30b0d00-a47b-11ea-85d5-611062bff414.png)
