### PR TITLE
fix: ブラウザリサイズ時の `TypeError` エラーを修正

### DIFF
--- a/components/cards/CardRow.vue
+++ b/components/cards/CardRow.vue
@@ -11,8 +11,11 @@ import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
 
 const cardClassName = '.DataCard'
 
+type Payload = {
+  dataView?: Vue
+}
 type Data = {
-  payload: Payload | {}
+  payload: Payload
 }
 type Methods = {
   handleCardHeight: () => void
@@ -22,9 +25,6 @@ type Computed = {
   cardElements: (HTMLElement | null)[]
 }
 type Props = {}
-type Payload = {
-  dataView: Vue
-}
 
 const options: ThisTypedComponentOptionsWithRecordProps<
   Vue,
@@ -40,6 +40,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   methods: {
     handleCardHeight() {
+      if (!this.payload.dataView) return
+
       const [self, side] = this.cardElements
       if (self) {
         self.style.height = ''

--- a/components/cards/CardRow.vue
+++ b/components/cards/CardRow.vue
@@ -68,16 +68,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   computed: {
     cardElements() {
-      const parent = this.$el.children
-      const payload = this.payload as Payload
-      const child = payload.dataView.$el.parentElement
+      if (!this.payload.dataView) return [null, null]
 
-      const index = Array.prototype.indexOf.call(parent, child) + 1
+      const cards = this.$el.children
+      const self = this.payload.dataView.$el.parentElement
+      const index = Array.prototype.indexOf.call(cards, self) + 1
       const sideIndex = index % 2 === 0 ? index - 1 : index + 1
-
-      const self = document.querySelector(
-        `${cardClassName}:nth-child(${index}`
-      ) as HTMLElement
       const side = document.querySelector(
         `${cardClassName}:nth-child(${sideIndex}`
       ) as HTMLElement


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4646
- close #4653

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 「テーブルを表示」をクリックしないと `payload.dataView` が `undefined` なため、存在チェックする処理を追加しました
- 不要なコードがあったのでリファクタリングしました

## 📸 スクリーンショット / Screenshots
### Before
[![Image from Gyazo](https://i.gyazo.com/534bb40d32c3e272c9fe8f727961e3f4.gif)](https://gyazo.com/534bb40d32c3e272c9fe8f727961e3f4)

### After
[![Image from Gyazo](https://i.gyazo.com/ed1c1c5369ce4a54401a4aa7fc563afe.gif)](https://gyazo.com/ed1c1c5369ce4a54401a4aa7fc563afe)