### PR TITLE
getComplementedDate で本日の日付を今年のものと判定するようにする

### DIFF
--- a/utils/formatDate.ts
+++ b/utils/formatDate.ts
@@ -62,7 +62,7 @@ export const getComplementedDate = (dateString: string): string => {
   const currentDate = today.getDate()
   let targetYear = today.getFullYear()
 
-  if (currentMonth <= month && currentDate <= date) {
+  if (currentMonth < month || (currentMonth === month && currentDate < date)) {
     targetYear -= 1
   }
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4693

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- getComplementedDate のtargetYearを-1する条件を`currentMonth <= month && currentDate <= date`から`currentMonth < month || (currentMonth === month && currentDate < date)`に変更する。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
