### PR TITLE
緩和ステップの移行日時をブラウザ実装に依存しないように表示

### DIFF
--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -54,7 +54,26 @@ export default Vue.extend({
   },
   computed: {
     formattedDayForDisplay() {
-      return this.$d(new Date(RelaxationStep.changed), 'dateWithDayOfWeek')
+      const dateChanged = new Date(RelaxationStep.changed)
+      const hour24h = dateChanged.getHours()
+      const isPM = hour24h >= 12
+      let hour12h = isPM ? hour24h - 12 : hour24h
+
+      // 日本語では 24時間表記で
+      //  *  0 - 11時は 12時間表記でも 午前 0 - 11時
+      //  * 12 - 23時は 12時間表記では 午後 0 - 11時
+      // しかし深夜0時・正午は 他の言語では12時
+      if (!['ja', 'ja-basic'].includes(this.$i18n.locale)) {
+        // 0時を12時に置き換える
+        hour12h = hour12h === 0 ? 12 : hour12h
+      }
+
+      const date = this.$d(dateChanged, 'dateWithDayOfWeek')
+      const time = this.$t(isPM ? '午後 {hour12h}時' : '午前 {hour12h}時', {
+        hour12h
+      })
+
+      return this.$t('{date} {time}', { date, time })
     }
   }
 })

--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -54,10 +54,7 @@ export default Vue.extend({
   },
   computed: {
     formattedDayForDisplay() {
-      return this.$d(
-        new Date(RelaxationStep.changed),
-        'dateTimeRelaxationSteps'
-      )
+      return this.$d(new Date(RelaxationStep.changed), 'dateWithDayOfWeek')
     }
   }
 })

--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -32,6 +32,14 @@
             </span>
           </li>
         </ul>
+        <p class="RelaxationStep-changed-text">
+          {{
+            $t('{date} ステップ {num}に移行', {
+              date: formattedDayForDisplay,
+              num: RelaxationStep.step
+            })
+          }}
+        </p>
       </div>
     </div>
   </div>

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -18,12 +18,10 @@ const dateTimeFormatsCommon = {
     month: 'long',
     day: 'numeric'
   },
-  dateTimeRelaxationSteps: {
-    hour12: true,
+  dateWithDayOfWeek: {
     weekday: 'short',
     month: 'short',
-    day: 'numeric',
-    hour: 'numeric'
+    day: 'numeric'
   }
 }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4696 
- close #4716 

## 📝 関連する issue / Related Issues
- revert #4710 

## ⛏ 変更内容 / Details of Changes
- `dateTimeRelaxationSteps` を日付部分のみの `dateWithDayOfWeek` に変更
- 12時間制の「時」表示をどのブラウザでも同じように表示できるように変更

以下のような翻訳定義が必要になります
```json
  "午前 {hour12h}時": "{hour12h} AM",
  "午後 {hour12h}時": "{hour12h} PM",
  "{date} {time}": "{date}, {time}",

  "午前 {hour12h}時": "上午 {hour12h}时",
  "午後 {hour12h}時": "下午 {hour12h}时",
  "{date} {time}": "{date} {time}",

  "午前 {hour12h}時": "上午 {hour12h}時",
  "午後 {hour12h}時": "下午 {hour12h}時",
  "{date} {time}": "{date} {time}",

  "午前 {hour12h}時": "오전 {hour12h}시",
  "午後 {hour12h}時": "오후 {hour12h}시",
  "{date} {time}": "{date} {time}",
```