### PR TITLE
ステップ＆アラートのスタイルを調整

### DIFF
--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -198,7 +198,7 @@ $tinySmall: 420;
     .RelaxationStep-steps {
       font-size: 0.8rem;
       margin-left: 1rem;
-      padding: 0.25rem 0.25rem 0.25rem 1rem;
+      padding: 0.26rem 0.26rem 0.26rem 1rem;
       &::after,
       &::before {
         border-width: 1rem 0 1rem 0.8rem;
@@ -244,11 +244,17 @@ $tinySmall: 420;
           flex-basis: auto;
         }
       }
+
+      @include lessThan($tinySmall) {
+        &-steps {
+          margin: 0 -8px;
+        }
+      }
     }
 
     .RelaxationStep-steps-list {
       display: flex;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
       justify-content: center;
       list-style: none;
       padding: 0;
@@ -256,8 +262,8 @@ $tinySmall: 420;
       white-space: nowrap;
       width: 100%;
 
-      @include largerThan($tinySmall) {
-        flex-wrap: nowrap;
+      @include lessThan($tiny) {
+        margin-left: -6px;
       }
 
       .RelaxationStep-steps-item {

--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -47,8 +47,8 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import LinkToInformationAboutRoadmap from '~/components/LinkToInformationAboutRoadmap.vue'
-import RelaxationStep from '~/data/tokyo_alert.json'
+import LinkToInformationAboutRoadmap from '@/components/LinkToInformationAboutRoadmap.vue'
+import RelaxationStep from '@/data/tokyo_alert.json'
 
 export default Vue.extend({
   components: {
@@ -88,7 +88,10 @@ export default Vue.extend({
 </script>
 
 <style lang="scss">
-@function px2vw($px, $vw: 900) {
+$mediumLarge: 900;
+$tinySmall: 420;
+
+@function px2vw($px, $vw: $mediumLarge) {
   @return $px / $vw * 100vw;
 }
 
@@ -121,6 +124,7 @@ export default Vue.extend({
       flex-wrap: wrap;
       align-items: center;
       justify-content: flex-end;
+      padding-left: 12px;
 
       @include lessThan($medium) {
         justify-content: flex-start;
@@ -148,7 +152,7 @@ export default Vue.extend({
       position: absolute;
       content: '';
       top: 0;
-      right: 1px;
+      right: 0.1rem;
       transform: translateX(100%);
       border-width: px2vw(15.5) 0 px2vw(15.5) px2vw(15.5);
       border-style: solid;
@@ -165,7 +169,7 @@ export default Vue.extend({
       position: absolute;
       content: '';
       top: 0;
-      left: px2vw(15.5);
+      left: px2vw(15);
       transform: translateX(-100%);
       border-width: px2vw(15.5) 0 px2vw(15.5) px2vw(15.5);
       border-style: solid;
@@ -182,24 +186,31 @@ export default Vue.extend({
       &::after,
       &::before {
         border-width: 1.3rem 0 1.3rem 1.3rem;
-        border-style: solid;
-        border-color: transparent;
-      }
-      &-on::after {
-        border-left-color: $green-1;
-      }
-      &-off::after {
-        border-left-color: $gray-4;
       }
       &-on::before,
       &-off::before {
-        left: 1.3rem;
-        border-left-color: $white;
+        left: 1.2rem;
       }
     }
   }
 
-  @include largerThan(900) {
+  @include lessThan($tinySmall) {
+    .RelaxationStep-steps {
+      font-size: 0.8rem;
+      margin-left: 1rem;
+      padding: 0.25rem 0.25rem 0.25rem 1rem;
+      &::after,
+      &::before {
+        border-width: 1rem 0 1rem 0.8rem;
+      }
+      &-on::before,
+      &-off::before {
+        left: 0.8rem;
+      }
+    }
+  }
+
+  @include largerThan($mediumLarge) {
     .RelaxationStep-steps {
       font-size: 1.4rem;
       margin-left: 1.6rem;
@@ -207,19 +218,10 @@ export default Vue.extend({
       &::after,
       &::before {
         border-width: 1.55rem 0 1.55rem 1.55rem;
-        border-style: solid;
-        border-color: transparent;
-      }
-      &-on::after {
-        border-left-color: $green-1;
-      }
-      &-off::after {
-        border-left-color: $gray-4;
       }
       &-on::before,
       &-off::before {
-        left: 1.55rem;
-        border-left-color: $white;
+        left: 1.45rem;
       }
     }
   }
@@ -254,7 +256,7 @@ export default Vue.extend({
       white-space: nowrap;
       width: 100%;
 
-      @include largerThan(420) {
+      @include largerThan($tinySmall) {
         flex-wrap: nowrap;
       }
 

--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -148,15 +148,18 @@ $tinySmall: 420;
       color: $gray-2;
       background-color: $gray-4;
     }
-    &::after {
+    &::after,
+    &::before {
       position: absolute;
       content: '';
-      top: 0;
-      right: 0.1rem;
-      transform: translateX(100%);
-      border-width: px2vw(15.5) 0 px2vw(15.5) px2vw(15.5);
       border-style: solid;
       border-color: transparent;
+      border-width: px2vw(15.5) 0 px2vw(15.5) px2vw(15.5);
+      top: 50%;
+    }
+    &::after {
+      right: 0.1rem;
+      transform: translate(100%, -50%);
     }
     &-on::after {
       border-left-color: $green-1;
@@ -164,16 +167,9 @@ $tinySmall: 420;
     &-off::after {
       border-left-color: $gray-4;
     }
-    &-on::before,
-    &-off::before {
-      position: absolute;
-      content: '';
-      top: 0;
+    &::before {
       left: px2vw(15);
-      transform: translateX(-100%);
-      border-width: px2vw(15.5) 0 px2vw(15.5) px2vw(15.5);
-      border-style: solid;
-      border-color: transparent;
+      transform: translate(-100%, -50%);
       border-left-color: $white;
     }
   }
@@ -198,7 +194,7 @@ $tinySmall: 420;
     .RelaxationStep-steps {
       font-size: 0.8rem;
       margin-left: 1rem;
-      padding: 0.26rem 0.26rem 0.26rem 1rem;
+      padding: 0.32rem 0.32rem 0.32rem 1rem;
       &::after,
       &::before {
         border-width: 1rem 0 1rem 0.8rem;
@@ -283,8 +279,7 @@ $tinySmall: 420;
           border-radius: 5px 0 0 5px;
           margin-left: 0;
           &::before {
-            margin-top: -9999px;
-            margin-left: -9999px;
+            display: none;
           }
         }
       }

--- a/components/RelaxationStepCard.vue
+++ b/components/RelaxationStepCard.vue
@@ -267,6 +267,10 @@ $tinySmall: 420;
         @include largerThan($large) {
           flex: 1 1 auto;
         }
+
+        @include lessThan($tinySmall) {
+          flex: 0 1 25%;
+        }
       }
       .RelaxationStep-steps-item:first-child {
         .RelaxationStep-steps {

--- a/components/TokyoAlertCard.vue
+++ b/components/TokyoAlertCard.vue
@@ -64,6 +64,7 @@ export default Vue.extend({
       flex-wrap: wrap;
       align-items: center;
       justify-content: flex-end;
+      padding-left: 12px;
 
       @include lessThan($medium) {
         justify-content: flex-start;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4725 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- モバイルサイズでステップの矢印がカラム落ちしないようにしました。
- 不要な縦線が表示されないようにしました。
- cssを整理しました。
- 東京アラートのリンク部分にpaddingを設定しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
380px幅の場合
![380px幅](https://user-images.githubusercontent.com/14883063/83832366-79a8fa80-a724-11ea-88c3-c6159745f36e.jpg)

不要な縦線を表示させない
![不要な縦線削除](https://user-images.githubusercontent.com/14883063/83832377-7f064500-a724-11ea-9c09-50c8d0e54049.jpg)
