### PR TITLE
auto i18n generatorで使われていない翻訳キーを削除する部分をコメントアウト

### DIFF
--- a/auto-i18n/i18n_generator.py
+++ b/auto-i18n/i18n_generator.py
@@ -241,14 +241,14 @@ with open(os.path.join(os.pardir, OUTPUT_DIR, CHECK_RESULT), mode="a", encoding=
             ja_json_keys.pop(ja_json_keys.index(key))
 
     # 以前はあったが今はない翻訳を削除する
-    for key in ja_json_keys:
-        ja_tag = ja_json.get(key)
-        ja_json.pop(key)
-        print("Remove TAG: " + str(ja_tag) + " from " + JA_JSON_PATH)
-        if not warn_count:
-            result.write(",".join(["RUN", datetime.today().strftime("%Y/%m/%d %H:%M")]) + '\n')
-        result.write(",".join(["TAG_REMOVE", str(ja_tag)]) + '\n')
-        warn_count += 1
+#     for key in ja_json_keys:
+#         ja_tag = ja_json.get(key)
+#         ja_json.pop(key)
+#         print("Remove TAG: " + str(ja_tag) + " from " + JA_JSON_PATH)
+#         if not warn_count:
+#             result.write(",".join(["RUN", datetime.today().strftime("%Y/%m/%d %H:%M")]) + '\n')
+#         result.write(",".join(["TAG_REMOVE", str(ja_tag)]) + '\n')
+#         warn_count += 1
 
     made_json = ja_json
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4747

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 使われていない翻訳キーを削除する部分をコメントアウトしました。
- 開発環境でpythonコマンドを走らせて、期待通りに動作する（ `TAG_REMOVE` が発生しない）ことを確認しました。
<img width="983" alt="スクリーンショット 2020-06-07 5 53 05" src="https://user-images.githubusercontent.com/14883063/83954326-331de200-a883-11ea-9abd-1fb9ba70be07.png">
