### PR TITLE
注釈のulのスタイルをlist-style-type: discに修正

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -182,33 +182,27 @@ export default Vue.extend({
 
     ul,
     ol {
-      list-style-type: none;
-      padding: 0;
+      list-style: disc inside;
+      padding-left: 1em;
+
+      li {
+        margin-left: 1.5em;
+        text-indent: -1.5em;
+      }
+    }
+
+    .ListStyleNone {
+      list-style: none;
+      padding-left: 0;
+
+      li {
+        margin-left: 0;
+        text-indent: 0;
+      }
     }
 
     &--Additional {
       margin-bottom: 10px;
-
-      ul,
-      ol {
-        list-style: disc inside;
-        padding-left: 1em;
-
-        li {
-          margin-left: 1.5em;
-          text-indent: -1.5em;
-        }
-      }
-
-      .ListStyleNone {
-        list-style: none;
-        padding-left: 0;
-
-        li {
-          margin-left: 0;
-          text-indent: 0;
-        }
-      }
     }
   }
 

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -8,7 +8,7 @@
       :info="info"
     >
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{ $t('（注）前日までに発生した患者数の累計値') }}
           </li>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -6,7 +6,7 @@
       :date="updatedAt"
     >
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{
               $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -11,7 +11,7 @@
       :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
     >
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{ $t('（注）保健所から発生届が提出された日を基準とする') }}
           </li>

--- a/components/cards/InspectionPersonsNumberCard.vue
+++ b/components/cards/InspectionPersonsNumberCard.vue
@@ -18,7 +18,7 @@
         </p>
       </template>
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{ $t('（注）検査結果の判明日を基準とする') }}
           </li>

--- a/components/cards/TestedCasesDetailsCard.vue
+++ b/components/cards/TestedCasesDetailsCard.vue
@@ -15,7 +15,7 @@
         </p>
       </template>
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{
               $t(

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -14,7 +14,7 @@
     >
       <!-- 件.tested = 検査数 -->
       <template v-slot:description>
-        <ul>
+        <ul class="ListStyleNone">
           <li>
             {{
               $t(


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4768 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `v-slot:description` のデフォルトのスタイルを `list-style: disc inside;` にしました。
- 未修正の注釈にクラスをつけて従来のスタイルを適用しました（いずれ削除することを想定）。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2020-06-08 20 24 31](https://user-images.githubusercontent.com/14883063/84025197-163df780-a9c6-11ea-9a7c-ed6d820e6c86.png)
