### PR TITLE
fix: 2軸グラフのY軸のずれを修正

### DIFF
--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -464,12 +464,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           n = Number(i)
         }
       }
-      const test = ['2020/1/1']
-      this.labels.map((label, _) => {
-        test.push(label)
-      })
       return {
-        labels: test,
+        labels: ['2020/1/1'],
         datasets: [
           {
             data: [this.displayData.datasets[0].data[n]],

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -486,12 +486,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           n = Number(i)
         }
       }
-      const test = ['2020/1/1']
-      this.labels.map((label, _) => {
-        test.push(label)
-      })
       return {
-        labels: test,
+        labels: ['2020/1/1'],
         datasets: [
           {
             data: [this.displayData.datasets[0].data[n]],


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4786

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 2軸グラフのY軸のずれを修正しました
- ref: https://github.com/tokyo-metropolitan-gov/covid19/pull/2498#issuecomment-605630746

## 📸 スクリーンショット / Screenshots
| before | after |
| --- | --- |
| ![スクリーンショット 2020-06-13 21 57 42](https://user-images.githubusercontent.com/5207601/84569392-1a508780-adc1-11ea-8096-e5b8a488415e.png) | ![スクリーンショット 2020-06-13 21 57 50](https://user-images.githubusercontent.com/5207601/84569396-1cb2e180-adc1-11ea-8d9b-fe977591eafd.png)
| ![スクリーンショット 2020-06-13 21 58 02](https://user-images.githubusercontent.com/5207601/84569405-42d88180-adc1-11ea-86ec-afaf0799e082.png) | ![スクリーンショット 2020-06-13 21 58 11](https://user-images.githubusercontent.com/5207601/84569406-479d3580-adc1-11ea-8aae-8e1c11ad75bf.png) |