### PR TITLE
refactor: `vue-chart.ts` から DOM トラバースしているコードを削除

### DIFF
--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -44,7 +44,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
       <template v-slot:chart="{ chartWidth }">
         <line-chart
           :ref="'lineChart'"
@@ -59,7 +59,6 @@
       <template v-slot:sticky-chart>
         <line-chart
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -51,7 +51,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -104,7 +103,7 @@ import DataViewTable, {
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 
@@ -146,7 +145,6 @@ type Props = {
   url: string
   tableLabels: string[] | TranslateResult[]
   additionalLines: number[]
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
 }
 
@@ -207,10 +205,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     additionalLines: {
       type: Array,
       default: () => []
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -44,34 +44,31 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-slot="{ chartWidth }"
-      :label-count="displayData.labels.length"
-    >
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <line-chart
-            :ref="'lineChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <line-chart
-        class="sticky-legend"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="`${chartId}-header`"
-        :chart-data="displayDataHeader"
-        :options="displayOptionHeader"
-        :plugins="yAxesBgPlugin"
-        :display-legends="displayLegends"
-        :height="240"
-      />
+    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <line-chart
+          :ref="'lineChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
+        <line-chart
+          class="sticky-legend"
+          :style="{ display: canvas ? 'block' : 'none' }"
+          :chart-id="`${chartId}-header`"
+          :chart-data="displayDataHeader"
+          :options="displayOptionHeader"
+          :plugins="yAxesBgPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+        />
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -44,7 +44,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <line-chart
           :ref="'lineChart'"

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -6,7 +6,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -20,7 +20,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -6,32 +6,29 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-slot="{ chartWidth }"
-      :label-count="displayData.labels.length"
-    >
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <bar
-        class="sticky-legend"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="`${chartId}-header`"
-        :chart-data="displayDataHeader"
-        :options="displayOptionHeader"
-        :plugins="yAxesBgPlugin"
-        :height="240"
-      />
+    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
+        <bar
+          class="sticky-legend"
+          :style="{ display: canvas ? 'block' : 'none' }"
+          :chart-id="`${chartId}-header`"
+          :chart-data="displayDataHeader"
+          :options="displayOptionHeader"
+          :plugins="yAxesBgPlugin"
+          :height="240"
+        />
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -13,7 +13,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :height="240"
           :width="chartWidth"
         />
@@ -68,8 +67,7 @@ import {
   DisplayData,
   DataSets,
   DataSetsPoint,
-  yAxesBgPlugin,
-  scrollPlugin
+  yAxesBgPlugin
 } from '@/plugins/vue-chart'
 
 import { getGraphSeriesStyle } from '@/utils/colors'
@@ -116,7 +114,6 @@ type Props = {
   dashedRectangleRange: string
   addedValue: number
   tableLabels: string[] | TranslateResult[]
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
 }
 
@@ -177,10 +174,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     tableLabels: {
       type: Array,
       default: () => []
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -6,7 +6,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -56,7 +56,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -108,7 +107,7 @@ import DataViewTable, {
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 
 type Data = {
@@ -229,7 +228,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       displayLegends: [true, true, true, true],
       colors,
       canvas: true,
-      scrollPlugin,
       yAxesBgPlugin
     }
   },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -49,22 +49,20 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-slot="{ chartWidth }" :label-count="labels.length">
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <div>
+    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
           :style="{ display: canvas ? 'block' : 'none' }"
@@ -75,7 +73,7 @@
           :display-legends="displayLegends"
           :height="240"
         />
-      </div>
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -49,7 +49,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -49,7 +49,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -64,7 +64,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header-right`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -33,7 +33,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -33,7 +33,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -48,7 +48,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header-right`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -40,7 +40,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -92,7 +91,7 @@ import DataViewTable, {
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 
 type Data = {
@@ -201,7 +200,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       displayLegends: [true, true],
       colors,
       canvas: true,
-      scrollPlugin,
       yAxesBgPlugin
     }
   },

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -33,22 +33,20 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-slot="{ chartWidth }" :label-count="labels.length">
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <div>
+    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
           :style="{ display: canvas ? 'block' : 'none' }"
@@ -59,7 +57,7 @@
           :display-legends="displayLegends"
           :height="240"
         />
-      </div>
+      </template>
     </scrollable-chart>
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -47,7 +47,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -98,8 +97,7 @@ import ScrollableChart from '@/components/ScrollableChart.vue'
 import {
   DisplayData,
   yAxesBgPlugin,
-  yAxesBgRightPlugin,
-  scrollPlugin
+  yAxesBgRightPlugin
 } from '@/plugins/vue-chart'
 import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
 
@@ -145,7 +143,6 @@ type Props = {
   dataLabels: string[] | TranslateResult[]
   tableLabels: string[] | TranslateResult[]
   unit: string
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgRightPlugin: Chart.PluginServiceRegistrationOptions[]
 }
@@ -205,10 +202,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     unit: {
       type: String,
       default: ''
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -40,22 +40,20 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-slot="{ chartWidth }" :label-count="labels.length">
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <div>
+    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
           :style="{ display: canvas ? 'block' : 'none' }"
@@ -66,7 +64,7 @@
           :display-legends="displayLegends"
           :height="240"
         />
-      </div>
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -40,7 +40,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -55,7 +55,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header-right`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -40,7 +40,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -10,8 +10,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { PropType } from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
+import { DisplayData } from '@/plugins/vue-chart'
 
 type Data = {
   chartWidth: number
@@ -23,10 +24,11 @@ type Methods = {
   scrollRightSide: () => void
   handleResize: () => void
 }
-type Computed = {}
-type Props = {
+type Computed = {
   labelCount: number
-  dataKind: string
+}
+type Props = {
+  displayData: DisplayData
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -37,13 +39,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   Props
 > = {
   props: {
-    labelCount: {
-      type: Number,
+    displayData: {
+      type: Object as PropType<DisplayData>,
       required: true
-    },
-    dataKind: {
-      type: String,
-      default: ''
     }
   },
   data() {
@@ -53,8 +51,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     }
   },
   watch: {
-    dataKind() {
+    displayData() {
       this.scrollRightSide()
+    }
+  },
+  computed: {
+    labelCount() {
+      return this.displayData.labels?.length || 0
     }
   },
   methods: {

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -1,10 +1,6 @@
 <template>
   <div ref="chartContainer" class="LegendStickyChart">
-    <div
-      ref="scrollable"
-      class="scrollable"
-      :style="{ display: canvas ? 'block' : 'none' }"
-    >
+    <div ref="scrollable" class="scrollable">
       <div :style="{ width: `${chartWidth}px` }">
         <slot name="chart" :chart-width="chartWidth" />
       </div>
@@ -30,7 +26,6 @@ type Methods = {
 type Computed = {}
 type Props = {
   labelCount: number
-  canvas: boolean
   dataKind: string
 }
 
@@ -45,10 +40,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     labelCount: {
       type: Number,
       required: true
-    },
-    canvas: {
-      type: Boolean,
-      default: true
     },
     dataKind: {
       type: String,

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -31,6 +31,7 @@ type Computed = {}
 type Props = {
   labelCount: number
   canvas: boolean
+  dataKind: string
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -48,12 +49,21 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     canvas: {
       type: Boolean,
       default: true
+    },
+    dataKind: {
+      type: String,
+      default: ''
     }
   },
   data() {
     return {
       chartWidth: 300,
       timerId: 0
+    }
+  },
+  watch: {
+    dataKind() {
+      this.scrollRightSide()
     }
   },
   methods: {

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -1,6 +1,15 @@
 <template>
   <div ref="chartContainer" class="LegendStickyChart">
-    <slot :chart-width="chartWidth" />
+    <div
+      ref="scrollable"
+      class="scrollable"
+      :style="{ display: canvas ? 'block' : 'none' }"
+    >
+      <div :style="{ width: `${chartWidth}px` }">
+        <slot name="chart" :chart-width="chartWidth" />
+      </div>
+    </div>
+    <slot name="sticky-chart" />
   </div>
 </template>
 
@@ -15,11 +24,13 @@ type Data = {
 type Methods = {
   adjustChartWidth: () => void
   calcChartWidth: (containerWidth: number, labelCount: number) => number
+  scrollRightSide: () => void
   handleResize: () => void
 }
 type Computed = {}
 type Props = {
   labelCount: number
+  canvas: boolean
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -33,6 +44,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     labelCount: {
       type: Number,
       required: true
+    },
+    canvas: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -47,6 +62,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       if (!container) return
       const containerWidth = container.clientWidth
       this.chartWidth = this.calcChartWidth(containerWidth, this.labelCount)
+      this.scrollRightSide()
     },
     calcChartWidth(containerWidth, labelCount) {
       const dates = 60
@@ -55,6 +71,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const barWidth = chartWidth / dates
       const calcWidth = barWidth * labelCount + yaxisWidth
       return Math.max(calcWidth, containerWidth)
+    },
+    scrollRightSide() {
+      const scrollable = this.$refs.scrollable as HTMLElement
+      if (!scrollable) return
+      setTimeout(() => {
+        scrollable.scrollLeft = this.chartWidth
+      })
     },
     handleResize() {
       clearTimeout(this.timerId)

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -3,7 +3,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -17,7 +17,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -3,32 +3,29 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-slot="{ chartWidth }"
-      :label-count="displayData.labels.length"
-    >
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <bar
-        class="sticky-legend"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="`${chartId}-header`"
-        :chart-data="displayDataHeader"
-        :options="displayOptionHeader"
-        :plugins="yAxesBgPlugin"
-        :height="240"
-      />
+    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
+        <bar
+          class="sticky-legend"
+          :style="{ display: canvas ? 'block' : 'none' }"
+          :chart-id="`${chartId}-header`"
+          :chart-data="displayDataHeader"
+          :options="displayOptionHeader"
+          :plugins="yAxesBgPlugin"
+          :height="240"
+        />
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -10,7 +10,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :height="240"
           :width="chartWidth"
         />
@@ -57,7 +56,7 @@ import DataViewTable, {
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 
 import { getGraphSeriesStyle } from '@/utils/colors'
 
@@ -89,7 +88,6 @@ type Props = {
   chartData: GraphDataType[]
   date: string
   unit: string
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
   byDate: boolean
 }
@@ -135,10 +133,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     unit: {
       type: String,
       default: ''
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -3,7 +3,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="displayData.labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -17,8 +17,8 @@
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
     <scrollable-chart
+      v-show="canvas"
       :label-count="displayData.labels.length"
-      :canvas="canvas"
       :data-kind="dataKind"
     >
       <template v-slot:chart="{ chartWidth }">
@@ -34,7 +34,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -16,7 +16,11 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+    <scrollable-chart
+      :label-count="displayData.labels.length"
+      :canvas="canvas"
+      :data-kind="dataKind"
+    >
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -16,11 +16,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-show="canvas"
-      :label-count="displayData.labels.length"
-      :data-kind="dataKind"
-    >
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -27,7 +27,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :height="240"
           :width="chartWidth"
         />
@@ -78,7 +77,7 @@ import DataViewTable, {
 } from '@/components/DataViewTable.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 
 import { getGraphSeriesStyle } from '@/utils/colors'
 import { getComplementedDate } from '@/utils/formatDate'
@@ -115,7 +114,6 @@ type Props = {
   date: string
   unit: string
   url: string
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
   byDate: boolean
 }
@@ -170,10 +168,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     url: {
       type: String,
       default: ''
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -16,32 +16,29 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-slot="{ chartWidth }"
-      :label-count="displayData.labels.length"
-    >
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <bar
-        class="sticky-legend"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="`${chartId}-header`"
-        :chart-data="displayDataHeader"
-        :options="displayOptionHeader"
-        :plugins="yAxesBgPlugin"
-        :height="240"
-      />
+    <scrollable-chart :label-count="displayData.labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
+        <bar
+          class="sticky-legend"
+          :style="{ display: canvas ? 'block' : 'none' }"
+          :chart-id="`${chartId}-header`"
+          :chart-data="displayDataHeader"
+          :options="displayOptionHeader"
+          :plugins="yAxesBgPlugin"
+          :height="240"
+        />
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -35,8 +35,8 @@
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
     <scrollable-chart
+      v-show="canvas"
       :label-count="labels.length"
-      :canvas="canvas"
       :data-kind="dataKind"
     >
       <template v-slot:chart="{ chartWidth }">
@@ -53,7 +53,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -34,11 +34,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart
-      v-show="canvas"
-      :label-count="labels.length"
-      :data-kind="dataKind"
-    >
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -34,7 +34,11 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+    <scrollable-chart
+      :label-count="labels.length"
+      :canvas="canvas"
+      :data-kind="dataKind"
+    >
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -34,31 +34,31 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-slot="{ chartWidth }" :label-count="labels.length">
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <bar
-        class="sticky-legend"
-        :style="{ display: canvas ? 'block' : 'none' }"
-        :chart-id="`${chartId}-header`"
-        :chart-data="displayDataHeader"
-        :options="displayOptionHeader"
-        :plugins="yAxesBgPlugin"
-        :display-legends="displayLegends"
-        :height="240"
-      />
+    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
+        <bar
+          class="sticky-legend"
+          :style="{ display: canvas ? 'block' : 'none' }"
+          :chart-id="`${chartId}-header`"
+          :chart-data="displayDataHeader"
+          :options="displayOptionHeader"
+          :plugins="yAxesBgPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+        />
+      </template>
     </scrollable-chart>
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -45,7 +45,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -94,7 +93,7 @@ import DataViewTable, {
 } from '@/components/DataViewTable.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
-import { DisplayData, yAxesBgPlugin, scrollPlugin } from '@/plugins/vue-chart'
+import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesStyle, SurfaceStyle } from '@/utils/colors'
 import { getComplementedDate } from '@/utils/formatDate'
 
@@ -142,7 +141,6 @@ type Props = {
   dataLabels: string[] | TranslateResult[]
   tableLabels: string[] | TranslateResult[]
   unit: string
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
 }
 
@@ -210,10 +208,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     unit: {
       type: String,
       default: ''
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     yAxesBgPlugin: {
       type: Array,

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -48,7 +48,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-show="canvas" :label-count="labels.length">
+    <scrollable-chart v-show="canvas" :display-data="displayData">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -55,7 +55,6 @@
           :chart-id="chartId"
           :chart-data="displayData"
           :options="displayOption"
-          :plugins="scrollPlugin"
           :display-legends="displayLegends"
           :height="240"
           :width="chartWidth"
@@ -106,8 +105,7 @@ import ScrollableChart from '@/components/ScrollableChart.vue'
 import {
   DisplayData,
   yAxesBgPlugin,
-  yAxesBgRightPlugin,
-  scrollPlugin
+  yAxesBgRightPlugin
 } from '@/plugins/vue-chart'
 import {
   getGraphSeriesStyle,
@@ -156,7 +154,6 @@ type Props = {
   tableLabels: string[] | TranslateResult[]
   unit: string
   additionalLines: number[]
-  scrollPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgPlugin: Chart.PluginServiceRegistrationOptions[]
   yAxesBgRightPlugin: Chart.PluginServiceRegistrationOptions[]
 }
@@ -216,10 +213,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     unit: {
       type: String,
       default: ''
-    },
-    scrollPlugin: {
-      type: Array,
-      default: () => scrollPlugin
     },
     additionalLines: {
       type: Array,

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -48,7 +48,7 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+    <scrollable-chart v-show="canvas" :label-count="labels.length">
       <template v-slot:chart="{ chartWidth }">
         <bar
           :ref="'barChart'"
@@ -63,7 +63,6 @@
       <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
-          :style="{ display: canvas ? 'block' : 'none' }"
           :chart-id="`${chartId}-header-right`"
           :chart-data="displayDataHeader"
           :options="displayOptionHeader"

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -48,22 +48,20 @@
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
-    <scrollable-chart v-slot="{ chartWidth }" :label-count="labels.length">
-      <div class="scrollable" :style="{ display: canvas ? 'block' : 'none' }">
-        <div :style="{ width: `${chartWidth}px` }">
-          <bar
-            :ref="'barChart'"
-            :chart-id="chartId"
-            :chart-data="displayData"
-            :options="displayOption"
-            :plugins="scrollPlugin"
-            :display-legends="displayLegends"
-            :height="240"
-            :width="chartWidth"
-          />
-        </div>
-      </div>
-      <div>
+    <scrollable-chart :label-count="labels.length" :canvas="canvas">
+      <template v-slot:chart="{ chartWidth }">
+        <bar
+          :ref="'barChart'"
+          :chart-id="chartId"
+          :chart-data="displayData"
+          :options="displayOption"
+          :plugins="scrollPlugin"
+          :display-legends="displayLegends"
+          :height="240"
+          :width="chartWidth"
+        />
+      </template>
+      <template v-slot:sticky-chart>
         <bar
           class="sticky-legend"
           :style="{ display: canvas ? 'block' : 'none' }"
@@ -74,7 +72,7 @@
           :display-legends="displayLegends"
           :height="240"
         />
-      </div>
+      </template>
     </scrollable-chart>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -52,12 +52,8 @@ const createCustomChart = () => {
     },
     watch: {
       displayLegends: watchDisplayLegends,
-      width(newWidth) {
-        setTimeout(() => {
-          this.$data._chart.resize()
-          const canvas = this.$refs.canvas as HTMLCanvasElement
-          canvas.parentElement!.parentElement!.parentElement!.scrollLeft! = newWidth
-        })
+      width() {
+        setTimeout(() => this.$data._chart.resize())
       }
     },
     mounted() {
@@ -181,11 +177,6 @@ export const yAxesBgRightPlugin: Chart.PluginServiceRegistrationOptions[] = [
 
 export const scrollPlugin: Chart.PluginServiceRegistrationOptions[] = [
   {
-    beforeInit(chartInstance) {
-      try {
-        chartInstance.canvas!.parentElement!.parentElement!.parentElement!.scrollLeft! = chartInstance.width!
-      } catch (e) {}
-    },
     beforeLayout(chartInstance) {
       chartInstance.resize()
     }

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -175,14 +175,6 @@ export const yAxesBgRightPlugin: Chart.PluginServiceRegistrationOptions[] = [
   }
 ]
 
-export const scrollPlugin: Chart.PluginServiceRegistrationOptions[] = [
-  {
-    beforeLayout(chartInstance) {
-      chartInstance.resize()
-    }
-  }
-]
-
 export interface DataSets<T = number> extends ChartData {
   data: T[]
 }


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #4573

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/4795#discussion_r440620283

## ⛏ 変更内容 / Details of Changes
- `vue-chart.ts` から DOM トラバースしているコード（`scrollPlugin`）を削除しました
 - `ScrollableChart.vue` にスクロールロジックを移しました
 - これに伴って `ScrollableChart.vue` の `template` の構造が変わったので、各グラフの `template` を部分を修正しました
- `TimeStackedBarChart.vue` で、日別・累計切替時にグラフを右端にスクロールするようにしました
  - ref: https://github.com/tokyo-metropolitan-gov/covid19/pull/4795#issuecomment-644571694

## 📸 スクリーンショット / Screenshots
[![Image from Gyazo](https://i.gyazo.com/1781ea1fd5f1678e3c2760d4bc321268.gif)](https://gyazo.com/1781ea1fd5f1678e3c2760d4bc321268)
