### PR TITLE
カードのタイトルとinfoPanelの幅をフレキシブルにする

### DIFF
--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -8,7 +8,9 @@
         >
           {{ title }}
         </h3>
-        <slot name="infoPanel" />
+        <div class="DataView-InfoPanel">
+          <slot name="infoPanel" />
+        </div>
       </div>
 
       <div v-if="this.$slots.attentionNote" class="DataView-AttentionNote">
@@ -138,6 +140,7 @@ export default Vue.extend({
     }
 
     @include largerThan($large) {
+      justify-content: space-between;
       flex-flow: row;
       padding: 0;
     }
@@ -162,9 +165,15 @@ export default Vue.extend({
       margin-bottom: 0;
 
       &.with-infoPanel {
-        width: 50%;
+        flex: 0 1 auto;
+        margin-right: 24px;
       }
     }
+  }
+
+  &-InfoPanel {
+    flex: 1 0 auto;
+    max-width: 50%;
   }
 
   &-Content {

--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -12,9 +12,10 @@
 <style lang="scss">
 .DataView {
   &-DataInfo {
+    margin-bottom: 10px;
+
     @include largerThan($large) {
       text-align: right;
-      width: 50%;
     }
 
     &-summary {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4840 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- タイトルとinfoPanelの幅を `width: 50%` で固定するのをやめ、 `flex-basis: auto` にしました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
before:
<img width="567" alt="スクリーンショット 2020-06-20 16 59 44" src="https://user-images.githubusercontent.com/14883063/85196885-4c5d6e80-b318-11ea-8ca5-2c9c6ba096e5.png">

after:
<img width="567" alt="スクリーンショット 2020-06-20 17 00 11" src="https://user-images.githubusercontent.com/14883063/85196894-567f6d00-b318-11ea-8d9b-b4110e9a2acb.png">

infoPanelは長いことがあるので、`max-width: 50%` を指定
<img width="567" alt="スクリーンショット 2020-06-20 17 07 20" src="https://user-images.githubusercontent.com/14883063/85196940-9d6d6280-b318-11ea-86ac-52e6565bfdd1.png">
