### PR TITLE
#4839 [WIP]新型コロナウイルス感染症が心配なときにのボタンのサイズ調整

### DIFF
--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -893,9 +893,10 @@ $margin: 20;
   .anchor {
     padding-top: 2px;
     .anchorLink {
-      padding: 2px 2px 2px;
       > svg {
         margin-top: 1px;
+        max-width: 80px;
+        max-height: 80px;
       }
       &::after {
         bottom: 5px;

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -893,6 +893,7 @@ $margin: 20;
   .anchor {
     padding-top: 2px;
     .anchorLink {
+      padding: 10px 10px 20px;
       > svg {
         margin-top: 1px;
         max-width: 80px;

--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -891,8 +891,15 @@ $margin: 20;
 // 960
 @include lessThan(960) {
   .anchor {
+    padding-top: 2px;
     .anchorLink {
-      padding: 10px 10px 40px;
+      padding: 2px 2px 2px;
+      > svg {
+        margin-top: 1px;
+      }
+      &::after {
+        bottom: 5px;
+      }
     }
   }
   .boxes {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4839 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- [新型コロナウイルス感染症が心配なときに](https://stopcovid19.metro.tokyo.lg.jp/flow/) のページのボタンが大きい問題の修正案です。
  - この案では、幅が960px以下のときにmargin, paddingなどのスペースを取り除き、メインコンテンツの面積を確保しています。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![Screenshot_2020-06-25 東京都 新型コロナウイルス感染症 対策サイト(3)](https://user-images.githubusercontent.com/305368/85650138-d07c7100-b6df-11ea-9c36-97206e91e49e.png)
