### PR TITLE
Chromium/Webkit系のスクロールバーのデザイン修正

### DIFF
--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -110,13 +110,59 @@ export default options
     overflow-x: scroll;
 
     &::-webkit-scrollbar {
-      height: 4px;
-      background-color: rgba(0, 0, 0, 0.01);
+      height: 10px;
+      background-color: rgba(0, 0, 0, 0.05);
     }
 
     &::-webkit-scrollbar-thumb {
-      background-color: rgba(0, 0, 0, 0.07);
+      background-color: rgba(0, 0, 0, 0.2);
     }
+
+    &::-webkit-scrollbar-thumb:hover {
+      background-color: rgba(0, 0, 0, 0.3);
+    }
+
+    &::-webkit-scrollbar-thumb:active {
+      background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    &::-webkit-scrollbar-button:single-button {
+      background-color: rgba(0, 0, 0, 0.05);
+      border-style: solid;
+      display: block;
+      height: 10px;
+      width: 10px;
+    }
+
+    /* :hover */
+    &::-webkit-scrollbar-button:single-button:hover {
+      background-color: rgba(0, 0, 0, 0.3);
+    }
+
+    /* Up */
+    &::-webkit-scrollbar-button:single-button:vertical:decrement {
+      border-width: 0 5px 5px 5px;
+      border-color: transparent transparent rgba(0, 0, 0, 0.7) transparent;
+    }
+
+    /* Down */
+    &::-webkit-scrollbar-button:single-button:vertical:increment {
+      border-width: 5px 5px 0 5px;
+      border-color: rgba(0, 0, 0, 0.7) transparent transparent transparent;
+    }
+
+    /* Left */
+    &::-webkit-scrollbar-button:single-button:horizontal:decrement {
+      border-width: 5px 5px 5px 0;
+      border-color: transparent rgba(0, 0, 0, 0.7) transparent transparent;
+    }
+
+    /* Right */
+    &::-webkit-scrollbar-button:single-button:horizontal:increment {
+      border-width: 5px 0 5px 5px;
+      border-color: transparent transparent transparent rgba(0, 0, 0, 0.7);
+    }
+
   }
 
   .sticky-legend {

--- a/components/ScrollableChart.vue
+++ b/components/ScrollableChart.vue
@@ -162,7 +162,6 @@ export default options
       border-width: 5px 0 5px 5px;
       border-color: transparent transparent transparent rgba(0, 0, 0, 0.7);
     }
-
   }
 
   .sticky-legend {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #4872 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- スクロールバーのスタイル修正
- - 高さを10pxに設定する。
- - 色を濃くする（rgba(0,0,0,0.01)→rgba(0,0,0,0.05), rgba(0,0,0,0.07)→rgba(0,0,0,0.2)）
- - スクロールバーのhover, active時に色を濃くする(hover: rgba(0,0,0,0.3), active: rgba(0,0,0,0.5))
- - スクロールバーの左右に矢印（もどき）をつける。（定義上、上下もあります）

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
Chrome
![image](https://user-images.githubusercontent.com/30145857/85648096-f3f0ed00-b6da-11ea-85c6-d1641cf0f33c.png)

Edge (Chromium)
![image](https://user-images.githubusercontent.com/30145857/85649861-23a1f400-b6df-11ea-9337-5cb094b3fe05.png)

Opera
![image](https://user-images.githubusercontent.com/30145857/85648886-b42b0500-b6dc-11ea-9cee-3f0e781c6953.png)

Firefox（変化なし）
![image](https://user-images.githubusercontent.com/30145857/85649948-564bec80-b6df-11ea-9438-2d94ee15e919.png)

