### PR TITLE
モニタリング指標のタイトルが長いときに２行表示する。

### DIFF
--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -10,7 +10,7 @@
           <slot name="titleNode" />
         </h3>
         <h3
-          v-else="$slots.titleNode"
+          v-else
           class="DataView-Title"
           :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -3,15 +3,15 @@
     <div class="DataView-Inner">
       <div class="DataView-Header">
         <h3
-          class="DataView-Title"
           v-if="$slots.titleNode"
+          class="DataView-Title"
           :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >
           <slot name="titleNode" />
         </h3>
         <h3
-          class="DataView-Title"
           v-else="$slots.titleNode"
+          class="DataView-Title"
           :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >
           {{ title }}

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -4,15 +4,15 @@
       <div class="DataView-Header">
         <h3
           class="DataView-Title"
-          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
           v-if="$slots.titleNode"
+          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >
           <slot name="titleNode" />
         </h3>
         <h3
           class="DataView-Title"
-          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
           v-else="$slots.titleNode"
+          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
         >
           {{ title }}
         </h3>

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -5,6 +5,14 @@
         <h3
           class="DataView-Title"
           :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
+          v-if="$slots.titleNode"
+        >
+          <slot name="titleNode" />
+        </h3>
+        <h3
+          class="DataView-Title"
+          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
+          v-else="$slots.titleNode"
         >
           {{ title }}
         </h3>
@@ -168,6 +176,10 @@ export default Vue.extend({
         flex: 0 1 auto;
         margin-right: 24px;
       }
+    }
+
+    span {
+      display: inline-block;
     }
   }
 

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <ul
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <ul
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <ul
       :class="$style.GraphLegend"

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,8 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span>
-      <span>{{title}}</span>
+      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,5 +1,9 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
+    <template v-slot:titleNode>
+      <span>{{$t("モニタリング指標")}}</span>
+      <span>{{title}}</span>
+    </template>
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,7 +1,8 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
+      <span>{{ $t('モニタリング指標') }}</span>
+      <span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />
@@ -225,10 +226,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   data: () => ({
     displayLegends: [true, true, true],
-    colors: [
-      ...getGraphSeriesStyle(2),
-      getGraphSeriesColor('E')
-    ],
+    colors: [...getGraphSeriesStyle(2), getGraphSeriesColor('E')],
     canvas: true
   }),
   computed: {
@@ -251,10 +249,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayData() {
-      const graphSeries = [
-        ...getGraphSeriesStyle(2),
-        getGraphSeriesColor('E')
-      ]
+      const graphSeries = [...getGraphSeriesStyle(2), getGraphSeriesColor('E')]
       return {
         labels: this.labels,
         datasets: [

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,5 +1,9 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="$t('モニタリング指標') + title"
+    :title-id="titleId"
+    :date="date"
+  >
     <template v-slot:titleNode>
       <span>{{ $t('モニタリング指標') }}</span>
       <span>{{ title }}</span>

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t("モニタリング指標")}}</span><span>{{title}}</span>
+      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,7 +1,7 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
     <template v-slot:titleNode>
-      <span>{{$t('モニタリング指標')}}</span><span>{{title}}</span>
+      <span>{{ $t('モニタリング指標') }}</span><span>{{ title }}</span>
     </template>
     <template v-slot:description>
       <slot name="description" />

--- a/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
+++ b/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <confirmed-cases-increase-ratio-by-week-chart
-      :title="$t('モニタリング指標(3)週単位の陽性者増加比')"
+      :title="$t('(3)週単位の陽性者増加比')"
       :title-id="'increase-ratio-of-confirmed-cases-by-daily'"
       :chart-id="'time-line-chart-patients-increase-ratio'"
       :chart-data="graphData"

--- a/components/cards/HospitalizedNumberCard.vue
+++ b/components/cards/HospitalizedNumberCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <dashed-rectangle-time-bar-chart
-      :title="$t('モニタリング指標(5)入院患者数')"
+      :title="$t('(5)入院患者数')"
       :title-id="'number-of-hospitalized'"
       :chart-id="'dashed-rectangle-time-bar-chart-hospitalized'"
       :chart-data="patientsGraph"

--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <monitoring-confirmed-cases-chart
-      :title="$t('モニタリング指標(1)新規陽性者数')"
+      :title="$t('(1)新規陽性者数')"
       title-id="monitoring-number-of-confirmed-cases"
       chart-id="monitoring-confirmed-cases-chart"
       :chart-data="chartData"

--- a/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
+++ b/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <monitoring-consultation-desk-report-chart
-      :title="$t('モニタリング指標(7)受診相談窓口における相談件数')"
+      :title="$t('(7)受診相談窓口における相談件数')"
       title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
       chart-id="monitoring-consultation-desk-report-chart"
       :chart-data="chartData"

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <positive-rate-mixed-chart
-      :title="$t('モニタリング指標(6)PCR検査の陽性率')"
+      :title="$t('(6)PCR検査の陽性率')"
       :title-id="'positive-rate'"
       :chart-id="'positive-rate-chart'"
       :chart-data="positiveRateGraph"

--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <severe-case-bar-chart
-      :title="$t('モニタリング指標(4)重症患者数')"
+      :title="$t('(4)重症患者数')"
       title-id="positive-status-severe-case"
       chart-id="time-bar-chart-positive-status-severe-case"
       :chart-data="graphData"

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <untracked-rate-mixed-chart
-      :title="$t('モニタリング指標(2)新規陽性者における接触歴等不明率')"
+      :title="$t('(2)新規陽性者における接触歴等不明率')"
       :title-id="'untracked-rate'"
       :chart-id="'untracked-rate-chart'"
       :chart-data="graphData"

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <untracked-rate-mixed-chart
-      :title="$t('(2)新規陽性者における接触歴等不明率')"
+      :title="$t('(2)新規陽性者数における接触歴等不明率')"
       :title-id="'untracked-rate'"
       :chart-id="'untracked-rate-chart'"
       :chart-data="graphData"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4428

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- DataView.vueに`titleNode`というスロットを追加して、スロットがある時は文字列の`title`ではなくそちらを表示する。
- モニタリング指標のChartコンポーネントに`titleNode`スロットを作成。
-  `title`プロパティはChartコンポーネントで`モニタリング指標`も文字を追加。
- Cardコンポーネントでは`title`から`モニタリング指標`の文字を削除するだけにしました。
- `titleNode`スロットがなければ今までと同じ。
- 改行はDataView-Title内の`span`を`inline-block`にして長い時の改行位置としました。
- DataView.vueの`title`を`v-html`にしてHTMLを挿入できるようにするのは[潜在的な危険](https://jp.vuejs.org/v2/guide/security.html#HTML-%E3%81%AE%E6%8C%BF%E5%85%A5)になるとのこと。
- 翻訳もできる。(一箇所聞いていないものがあったので翻訳できる文言に合わせました。)
- `<title>` `og:title`には`モニタリング指標`から始まる文字列で指定される。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

### フルスクリーン
<img width="581" alt="スクリーンショット 2020-07-02 0 07 45" src="https://user-images.githubusercontent.com/2096703/86260318-1497d600-bbf8-11ea-9403-c2ae012c9495.png">
<img width="1167" alt="スクリーンショット 2020-07-02 0 08 15" src="https://user-images.githubusercontent.com/2096703/86260361-237e8880-bbf8-11ea-8c4e-ade7ea883932.png">
<img width="1166" alt="スクリーンショット 2020-07-02 0 08 39" src="https://user-images.githubusercontent.com/2096703/86260405-31cca480-bbf8-11ea-9da3-26d10d1cad81.png">
<img width="1163" alt="スクリーンショット 2020-07-02 0 09 01" src="https://user-images.githubusercontent.com/2096703/86260442-3e50fd00-bbf8-11ea-9e11-509bbbcc90cc.png">


### 幅が狭いと改行される
<img width="369" alt="スクリーンショット 2020-07-02 0 11 59" src="https://user-images.githubusercontent.com/2096703/86260767-aa336580-bbf8-11ea-9567-4e0d30dd660b.png">


### embed=trueで表示幅が大きい時は改行されない
<img width="691" alt="スクリーンショット 2020-07-02 0 09 59" src="https://user-images.githubusercontent.com/2096703/86260542-62acd980-bbf8-11ea-80ea-5cdc3fbe4f8b.png">


### 翻訳もされる
<img width="437" alt="スクリーンショット 2020-07-02 0 14 31" src="https://user-images.githubusercontent.com/2096703/86261029-04ccc180-bbf9-11ea-957a-343b1609febc.png">

### `<title>`と`og:title`
<img width="532" alt="スクリーンショット 2020-07-02 8 49 31" src="https://user-images.githubusercontent.com/2096703/86301474-f6a29380-bc40-11ea-838f-14e092723b55.png">
<img width="646" alt="スクリーンショット 2020-07-02 8 49 59" src="https://user-images.githubusercontent.com/2096703/86301510-08843680-bc41-11ea-9629-fcc5bc1281ac.png">
