### PR TITLE
1つのカードに複数の指標値をタイトル付きで記載できるようにする。

### DIFF
--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -59,7 +59,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -123,7 +123,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   formatter: Function
@@ -161,7 +161,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       default: ''
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       default: () => []
     },

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -57,11 +57,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="displayInfo.unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
     <template v-slot:footer>
@@ -82,7 +83,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
@@ -104,11 +105,13 @@ type Methods = {
 
 type Computed = {
   displayTransitionRatio: string
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -120,6 +123,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   formatter: Function
@@ -144,7 +148,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -156,6 +160,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     titleId: {
       type: String,
       default: ''
+    },
+    summaryTitles: {
+      type: Array,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -208,15 +216,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
-      return {
-        lText: `${this.formatter(this.chartData.slice(-1)[0].transition)}`,
-        sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
-          'の数値'
-        )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: `${this.formatter(this.chartData.slice(-1)[0].transition)}`,
+          sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+            'の数値'
+          )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       const style = [getGraphSeriesColor('D')]

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -36,7 +36,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -108,7 +108,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   date: string
@@ -146,7 +146,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       default: ''
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       default: () => []
     },

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -34,11 +34,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="displayInfo.unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
     <template v-slot:footer>
@@ -59,7 +60,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import {
@@ -85,11 +86,13 @@ type Computed = {
     x: string
     y: number
   }[]
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: {
     labels: string[]
     datasets: (DataSets | DataSetsPoint)[]
@@ -105,6 +108,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   date: string
@@ -129,7 +133,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -141,6 +145,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     titleId: {
       type: String,
       default: ''
+    },
+    summaryTitles: {
+      type: Array,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -201,15 +209,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       ]
     },
     displayInfo() {
-      return {
-        lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
-        sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
-          'の数値'
-        )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: `${this.chartData.slice(-1)[0].transition.toLocaleString()}`,
+          sText: `${this.chartData.slice(-1)[0].label} ${this.$t(
+            'の数値'
+          )}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       const style = getGraphSeriesStyle(1)[0]

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -1,7 +1,10 @@
 <template>
   <v-card class="DataView">
     <div class="DataView-Inner">
-      <div class="DataView-Header">
+      <div
+        class="DataView-Header"
+        :class="!!$slots.dataSetPanel ? 'with-dataSetPanel' : ''"
+      >
         <h3
           class="DataView-Title"
           :class="
@@ -14,10 +17,10 @@
         >
           {{ title }}
         </h3>
-        <div class="DataView-InfoPanel">
+        <div v-if="!!$slots.infoPanel" class="DataView-InfoPanel">
           <slot name="infoPanel" />
         </div>
-        <div class="DataView-DataSetPanel">
+        <div v-if="!!$slots.dataSetPanel" class="DataView-DataSetPanel">
           <slot name="dataSetPanel" />
         </div>
       </div>
@@ -152,6 +155,10 @@ export default Vue.extend({
       justify-content: space-between;
       flex-flow: row;
       padding: 0;
+
+      &.with-dataSetPanel {
+        flex-flow: column;
+      }
     }
   }
 

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -98,6 +98,10 @@ export default Vue.extend({
     date: {
       type: String,
       default: ''
+    },
+    headTitle: {
+      type: String,
+      default: ''
     }
   },
   computed: {
@@ -117,12 +121,12 @@ export default Vue.extend({
     if (!this.$route.params.card) return {}
 
     return {
-      title: this.title,
+      title: this.headTitle ? this.headTitle : this.title,
       meta: [
         {
           hid: 'og:title',
           property: 'og:title',
-          content: this.title
+          content: this.headTitle ? this.headTitle : this.title
         },
         { hid: 'description', name: 'description', content: this.date },
         {

--- a/components/DataView.vue
+++ b/components/DataView.vue
@@ -4,12 +4,21 @@
       <div class="DataView-Header">
         <h3
           class="DataView-Title"
-          :class="!!$slots.infoPanel ? 'with-infoPanel' : ''"
+          :class="
+            !!$slots.infoPanel
+              ? 'with-infoPanel'
+              : !!$slots.dataSetPanel
+              ? 'with-dataSetPanel'
+              : ''
+          "
         >
           {{ title }}
         </h3>
         <div class="DataView-InfoPanel">
           <slot name="infoPanel" />
+        </div>
+        <div class="DataView-DataSetPanel">
+          <slot name="dataSetPanel" />
         </div>
       </div>
 
@@ -161,6 +170,10 @@ export default Vue.extend({
     color: $gray-2;
     @include font-size(20);
 
+    &.with-dataSetPanel {
+      margin-bottom: 0;
+    }
+
     @include largerThan($large) {
       margin-bottom: 0;
 
@@ -169,11 +182,20 @@ export default Vue.extend({
         margin-right: 24px;
       }
     }
+
+    span {
+      display: inline-block;
+    }
   }
 
   &-InfoPanel {
     flex: 1 0 auto;
     max-width: 50%;
+  }
+
+  &-DataSetPanel {
+    flex: 1 0 auto;
+    width: 100%;
   }
 
   &-Content {

--- a/components/DataViewDataSetPanel.vue
+++ b/components/DataViewDataSetPanel.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="DataView-DataSet">
+    <span class="DataView-DataSet-title">{{ title }}</span>
+    <div class="DataView-DataSet-DataInfo">
+      <span v-if="lText !== ''" class="DataView-DataSet-DataInfo-summary">
+        {{ lText }}
+        <small class="DataView-DataSet-DataInfo-summary-unit">{{ unit }}</small>
+      </span>
+      <br v-if="lText !== ''" />
+      <small class="DataView-DataSet-DataInfo-date">{{ sText }}</small>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.DataView {
+  &-DataSet {
+    display: flex;
+    width: 100%;
+    margin-bottom: 10px;
+
+    &-title {
+      font-size: 2rem;
+      flex: 1 1 auto;
+    }
+
+    &-DataInfo {
+      text-align: right;
+
+      &-summary {
+        flex: 0 1 auto;
+        display: inline-block;
+        color: $gray-2;
+        white-space: nowrap;
+        font-family: Hiragino Sans, sans-serif;
+        font-style: normal;
+        line-height: 30px;
+        @include font-size(30);
+
+        &-unit {
+          width: 100%;
+          @include font-size(18);
+        }
+      }
+
+      &-date {
+        display: inline-block;
+        width: 100%;
+        color: $gray-3;
+        line-height: initial;
+        text-align: right;
+        @include font-size(12);
+      }
+    }
+  }
+}
+</style>
+
+<script lang="ts">
+import Vue from 'vue'
+
+export default Vue.extend({
+  props: {
+    title: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    lText: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    sText: {
+      type: String,
+      required: true
+    },
+    unit: {
+      type: String,
+      required: false,
+      default: ''
+    }
+  }
+})
+</script>

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -65,7 +65,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -127,7 +127,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -166,7 +166,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       required: false,
       default: 'monitoring-number-of-confirmed-cases'
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       required: false,
       default: () => []

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <ul
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -63,11 +63,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
     <template v-slot:footer>
@@ -88,7 +89,7 @@ import DataViewTable, {
   TableItem
 } from '@/components/DataViewTable.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
@@ -107,11 +108,13 @@ type Methods = {
 
 type Computed = {
   displayTransitionRatio: string
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -124,6 +127,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -148,7 +152,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -161,6 +165,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: false,
       default: 'monitoring-number-of-confirmed-cases'
+    },
+    summaryTitles: {
+      type: Array,
+      required: false,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -222,17 +231,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
-      return {
-        lText: this.getFormatter(1)(
-          this.chartData[1][this.chartData[1].length - 1]
-        ),
-        sText: `${this.$t('{date} の数値', {
-          date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
-        })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: this.getFormatter(1)(
+            this.chartData[1][this.chartData[1].length - 1]
+          ),
+          sText: `${this.$t('{date} の数値', {
+            date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
+          })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       return {

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -65,7 +65,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -126,7 +126,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: number[][]
   date: string
@@ -163,7 +163,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       required: false,
       default: 'monitoring-number-of-reports-to-covid19-consultation-desk'
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       required: false,
       default: () => []

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <ul
       :class="$style.GraphLegend"
       :style="{ display: canvas ? 'block' : 'none' }"

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -63,11 +63,12 @@
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
     <template v-slot:footer>
@@ -87,7 +88,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
@@ -106,11 +107,13 @@ type Methods = {
 
 type Computed = {
   displayTransitionRatio: string
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -123,6 +126,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: number[][]
   date: string
@@ -145,7 +149,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -158,6 +162,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: false,
       default: 'monitoring-number-of-reports-to-covid19-consultation-desk'
+    },
+    summaryTitles: {
+      type: Array,
+      required: false,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -210,15 +219,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
-      return {
-        lText: this.chartData[1][this.chartData[1].length - 1].toLocaleString(),
-        sText: `${this.$t('{date} の数値', {
-          date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
-        })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: this.chartData[1][
+            this.chartData[1].length - 1
+          ].toLocaleString(),
+          sText: `${this.$t('{date} の数値', {
+            date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
+          })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       return {

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -72,7 +72,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -142,7 +142,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -181,7 +181,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       required: false,
       default: ''
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       required: false,
       default: () => []

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -70,11 +70,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="displayInfo.unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
   </data-view>
@@ -91,7 +92,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import {
   DisplayData,
@@ -121,11 +122,13 @@ type Methods = {
 
 type Computed = {
   displayTransitionRatio: string
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -139,6 +142,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -164,7 +168,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart
   },
   props: {
@@ -176,6 +180,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: false,
       default: ''
+    },
+    summaryTitles: {
+      type: Array,
+      required: false,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -237,17 +246,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         new Date(this.labels[this.labels.length - 1]),
         'dateWithoutYear'
       )
-      return {
-        lText: this.getFormatter(2)(
-          parseFloat(this.pickLastNumber(this.chartData)[2].toLocaleString())
-        ),
-        sText: `${this.$t('{date}の数値', {
-          date
-        })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: this.getFormatter(2)(
+            parseFloat(this.pickLastNumber(this.chartData)[2].toLocaleString())
+          ),
+          sText: `${this.$t('{date}の数値', {
+            date
+          })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       const graphSeries = getGraphSeriesStyle(2)

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -33,7 +33,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -86,7 +86,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   date: string
@@ -121,7 +121,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       default: ''
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       default: () => []
     },

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -31,11 +31,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="displayInfo.unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
   </data-view>
@@ -52,7 +53,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
@@ -67,11 +68,13 @@ type Methods = {
 }
 
 type Computed = {
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -83,6 +86,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   date: string
@@ -104,7 +108,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -116,6 +120,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     titleId: {
       type: String,
       default: ''
+    },
+    summaryTitles: {
+      type: Array,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -152,13 +160,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const dayBeforeRatio = this.formatDayBeforeRatio(
         lastDay.transition - lastDayBefore.transition
       )
-      return {
-        lText: `${lastDay.transition.toLocaleString()}`,
-        sText: `${lastDay.label} ${this.$t('の数値')}（${this.$t(
-          '前日比'
-        )}: ${dayBeforeRatio} ${this.unit}）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: `${lastDay.transition.toLocaleString()}`,
+          sText: `${lastDay.label} ${this.$t('の数値')}（${this.$t(
+            '前日比'
+          )}: ${dayBeforeRatio} ${this.unit}）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
       const style = getGraphSeriesStyle(1)[0]

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -70,11 +70,12 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:infoPanel>
-      <data-view-basic-info-panel
-        :l-text="displayInfo.lText"
-        :s-text="displayInfo.sText"
-        :unit="displayInfo.unit"
+    <template v-slot:dataSetPanel>
+      <data-view-data-set-panel
+        :title="summaryTitles[0]"
+        :l-text="displayInfo[0].lText"
+        :s-text="displayInfo[0].sText"
+        :unit="displayInfo[0].unit"
       />
     </template>
   </data-view>
@@ -91,7 +92,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
+import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import {
   DisplayData,
@@ -120,11 +121,13 @@ type Methods = {
 
 type Computed = {
   displayTransitionRatio: string
-  displayInfo: {
-    lText: string
-    sText: string
-    unit: string
-  }
+  displayInfo: [
+    {
+      lText: string
+      sText: string
+      unit: string
+    }
+  ]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -138,6 +141,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
+  summaryTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -163,7 +167,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewBasicInfoPanel,
+    DataViewDataSetPanel,
     ScrollableChart
   },
   props: {
@@ -175,6 +179,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       type: String,
       required: false,
       default: ''
+    },
+    summaryTitles: {
+      type: Array,
+      required: false,
+      default: () => []
     },
     chartId: {
       type: String,
@@ -222,10 +231,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   data: () => ({
     displayLegends: [true, true, true],
-    colors: [
-      ...getGraphSeriesStyle(2),
-      getGraphSeriesColor('E')
-    ],
+    colors: [...getGraphSeriesStyle(2), getGraphSeriesColor('E')],
     canvas: true
   }),
   computed: {
@@ -235,23 +241,22 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
     displayInfo() {
-      return {
-        lText: this.getFormatter(2)(
-          parseFloat(this.pickLastNumber(this.chartData)[2].toLocaleString())
-        ),
-        sText: `${this.$t('{date}の数値', {
-          date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
-        })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
-          this.unit
-        }）`,
-        unit: this.unit
-      }
+      return [
+        {
+          lText: this.getFormatter(2)(
+            parseFloat(this.pickLastNumber(this.chartData)[2].toLocaleString())
+          ),
+          sText: `${this.$t('{date}の数値', {
+            date: dayjs(this.labels[this.labels.length - 1]).format('M/D')
+          })}（${this.$t('前日比')}: ${this.displayTransitionRatio} ${
+            this.unit
+          }）`,
+          unit: this.unit
+        }
+      ]
     },
     displayData() {
-      const graphSeries = [
-        ...getGraphSeriesStyle(2),
-        getGraphSeriesColor('E')
-      ]
+      const graphSeries = [...getGraphSeriesStyle(2), getGraphSeriesColor('E')]
       return {
         labels: this.labels,
         datasets: [

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -72,7 +72,7 @@
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel
-        :title="summaryTitles[0]"
+        :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -141,7 +141,7 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  summaryTitles: string[]
+  infoTitles: string[]
   chartId: string
   chartData: number[][]
   getFormatter: Function
@@ -180,7 +180,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       required: false,
       default: ''
     },
-    summaryTitles: {
+    infoTitles: {
       type: Array,
       required: false,
       default: () => []

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -1,5 +1,10 @@
 <template>
-  <data-view :title="title" :title-id="titleId" :date="date">
+  <data-view
+    :title="title"
+    :title-id="titleId"
+    :date="date"
+    :head-title="title + infoTitles.join(',')"
+  >
     <template v-slot:description>
       <slot name="description" />
     </template>

--- a/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
+++ b/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <confirmed-cases-increase-ratio-by-week-chart
-      :title="$t('旧モニタリング指標(3)週単位の陽性者増加比')"
+      :title="$t('旧モニタリング指標(3)')"
       :title-id="'increase-ratio-of-confirmed-cases-by-daily'"
+      :summary-titles="[$t('週単位の陽性者増加比')]"
       :chart-id="'time-line-chart-patients-increase-ratio'"
       :chart-data="graphData"
       :formatter="formatter"
@@ -58,9 +59,7 @@ export default {
     const graphData = formatGraph(formatData)
     const tableLabels = [this.$t('週単位の陽性者増加比')]
 
-    const items = [
-      this.$t('週単位の陽性者増加比')
-    ]
+    const items = [this.$t('週単位の陽性者増加比')]
 
     // モニタリング指標(3)週単位の陽性者増加比は小数点第2位まで表示する。
     const formatter = getNumberToFixedFunction(2)

--- a/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
+++ b/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
@@ -3,7 +3,7 @@
     <confirmed-cases-increase-ratio-by-week-chart
       :title="$t('旧モニタリング指標(3)')"
       :title-id="'increase-ratio-of-confirmed-cases-by-daily'"
-      :summary-titles="[$t('週単位の陽性者増加比')]"
+      :info-titles="[$t('週単位の陽性者増加比')]"
       :chart-id="'time-line-chart-patients-increase-ratio'"
       :chart-data="graphData"
       :formatter="formatter"

--- a/components/cards/HospitalizedNumberCard.vue
+++ b/components/cards/HospitalizedNumberCard.vue
@@ -3,7 +3,7 @@
     <dashed-rectangle-time-bar-chart
       :title="$t('旧モニタリング指標(5)')"
       :title-id="'number-of-hospitalized'"
-      :summary-titles="[$t('入院患者数')]"
+      :info-titles="[$t('入院患者数')]"
       :chart-id="'dashed-rectangle-time-bar-chart-hospitalized'"
       :chart-data="patientsGraph"
       :date="positiveStatus.date"

--- a/components/cards/HospitalizedNumberCard.vue
+++ b/components/cards/HospitalizedNumberCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <dashed-rectangle-time-bar-chart
-      :title="$t('旧モニタリング指標(5)入院患者数')"
+      :title="$t('旧モニタリング指標(5)')"
       :title-id="'number-of-hospitalized'"
+      :summary-titles="[$t('入院患者数')]"
       :chart-id="'dashed-rectangle-time-bar-chart-hospitalized'"
       :chart-data="patientsGraph"
       :date="positiveStatus.date"

--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -3,7 +3,7 @@
     <monitoring-confirmed-cases-chart
       :title="$t('旧モニタリング指標(1)')"
       title-id="monitoring-number-of-confirmed-cases"
-      :summary-titles="[$t('新規陽性者数')]"
+      :info-titles="[$t('新規陽性者数')]"
       chart-id="monitoring-confirmed-cases-chart"
       :chart-data="chartData"
       :get-formatter="getFormatter"

--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <monitoring-confirmed-cases-chart
-      :title="$t('旧モニタリング指標(1)新規陽性者数')"
+      :title="$t('旧モニタリング指標(1)')"
       title-id="monitoring-number-of-confirmed-cases"
+      :summary-titles="[$t('新規陽性者数')]"
       chart-id="monitoring-confirmed-cases-chart"
       :chart-data="chartData"
       :get-formatter="getFormatter"
@@ -62,10 +63,7 @@ export default {
       [[], [], []]
     )
     const chartData = [patientsCount, sevenDayMoveAverages]
-    const dataLabels = [
-      this.$t('陽性者数'),
-      this.$t('７日間移動平均')
-    ]
+    const dataLabels = [this.$t('陽性者数'), this.$t('７日間移動平均')]
     const tableLabels = [this.$t('陽性者数'), this.$t('７日間移動平均')]
     const date = Data.date
 

--- a/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
+++ b/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <monitoring-consultation-desk-report-chart
-      :title="$t('旧モニタリング指標(7)受診相談窓口における相談件数')"
+      :title="$t('旧モニタリング指標(7)')"
       title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
+      :summary-titles="[$t('受診相談窓口における相談件数')]"
       chart-id="monitoring-consultation-desk-report-chart"
       :chart-data="chartData"
       :date="date"

--- a/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
+++ b/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
@@ -3,7 +3,7 @@
     <monitoring-consultation-desk-report-chart
       :title="$t('旧モニタリング指標(7)')"
       title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
-      :summary-titles="[$t('受診相談窓口における相談件数')]"
+      :info-titles="[$t('受診相談窓口における相談件数')]"
       chart-id="monitoring-consultation-desk-report-chart"
       :chart-data="chartData"
       :date="date"

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <positive-rate-mixed-chart
-      :title="$t('旧モニタリング指標(6)PCR検査の陽性率')"
+      :title="$t('旧モニタリング指標(6)')"
       :title-id="'positive-rate'"
+      :summary-titles="[$t('PCR検査の陽性率')]"
       :chart-id="'positive-rate-chart'"
       :chart-data="positiveRateGraph"
       :get-formatter="getFormatter"

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -3,7 +3,7 @@
     <positive-rate-mixed-chart
       :title="$t('旧モニタリング指標(6)')"
       :title-id="'positive-rate'"
-      :summary-titles="[$t('PCR検査の陽性率')]"
+      :info-titles="[$t('PCR検査の陽性率')]"
       :chart-id="'positive-rate-chart'"
       :chart-data="positiveRateGraph"
       :get-formatter="getFormatter"

--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -3,7 +3,7 @@
     <severe-case-bar-chart
       :title="$t('旧モニタリング指標(4)')"
       title-id="positive-status-severe-case"
-      :summary-titles="[$t('重症患者数')]"
+      :info-titles="[$t('重症患者数')]"
       chart-id="time-bar-chart-positive-status-severe-case"
       :chart-data="graphData"
       :date="Data.date"

--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <severe-case-bar-chart
-      :title="$t('旧モニタリング指標(4)重症患者数')"
+      :title="$t('旧モニタリング指標(4)')"
       title-id="positive-status-severe-case"
+      :summary-titles="[$t('重症患者数')]"
       chart-id="time-bar-chart-positive-status-severe-case"
       :chart-data="graphData"
       :date="Data.date"

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -3,7 +3,7 @@
     <untracked-rate-mixed-chart
       :title="$t('旧モニタリング指標(2)')"
       :title-id="'untracked-rate'"
-      :summary-titles="[$t('新規陽性者数における接触歴等不明率')]"
+      :info-titles="[$t('新規陽性者数における接触歴等不明率')]"
       :chart-id="'untracked-rate-chart'"
       :chart-data="graphData"
       :get-formatter="getFormatter"

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -1,8 +1,9 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <untracked-rate-mixed-chart
-      :title="$t('旧モニタリング指標(2)新規陽性者における接触歴等不明率')"
+      :title="$t('旧モニタリング指標(2)')"
       :title-id="'untracked-rate'"
+      :summary-titles="[$t('新規陽性者数における接触歴等不明率')]"
       :chart-id="'untracked-rate-chart'"
       :chart-data="graphData"
       :get-formatter="getFormatter"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #4428

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 1つのカードに複数の指標値をタイトル付きで記載できるようにする。
  - DataViewBasicInfoPanelをDataViewDataSetPanelにして指標値単位でタイトルを持てるようにする。
  - DataViewにDataViewDataSetPanelを追加。デザイン調整。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
