### PR TITLE
VuetifyのData tablesに関するsass変数の値をカスタマイズ

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -177,3 +177,10 @@ $expansion-panel-header-padding: 10px 0;
 $expansion-panel-header-min-height: 26px;
 $expansion-panel-active-header-min-height: 26px;
 $expansion-panel-header-font-size: .875rem;
+
+// Data tables
+// https://vuetifyjs.com/en/components/data-tables/
+$data-table-regular-header-font-size: 1.2rem;
+$data-table-regular-header-height: 36px;
+$data-table-regular-row-font-size: 1.2rem;
+$data-table-regular-row-height: 36px;

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -14,7 +14,7 @@
     <template v-slot:body="{ items }">
       <tbody>
         <tr v-for="(item, i) in items" :key="i">
-          <th scope="row">{{ item[headerKey] }}</th>
+          <th scope="row" class="cardTable-header">{{ item[headerKey] }}</th>
           <td v-for="(dataKey, j) in dataKeys" :key="j" class="text-end">
             {{ item[dataKey] }}
           </td>
@@ -83,6 +83,9 @@ export default Vue.extend(options)
 </script>
 
 <style lang="scss">
+.cardTable-header {
+  white-space: nowrap;
+}
 .v-data-table .text-end {
   text-align: right;
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4942 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- テーブルのフォントサイズを大きくするためにVuetifyのsass変数の値を上書きしました。
- 日付部分が折り返して見づらくなっていたので、 `white-space: nowrap;` を指定しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![陽性患者の属性](https://user-images.githubusercontent.com/14883063/86558113-6abb9f00-bf93-11ea-8259-072f94563228.jpg)
![区市町村別](https://user-images.githubusercontent.com/14883063/86558121-7018e980-bf93-11ea-838e-b2d54d9c8bc6.jpg)
![検査実施件数](https://user-images.githubusercontent.com/14883063/86558126-73ac7080-bf93-11ea-9181-36a067ed4665.jpg)
