### PR TITLE
旧モニタリング指標(3) 削除予告追加・配置変更

### DIFF
--- a/components/CardsMonitoring.vue
+++ b/components/CardsMonitoring.vue
@@ -25,8 +25,6 @@
       <monitoring-confirmed-cases-number-card />
       <!-- モニタリング指標(2)新規陽性者における接触歴等不明率 -->
       <untracked-rate-card />
-      <!-- モニタリング指標(3)週単位の陽性者増加比 -->
-      <confirmed-cases-increase-ratio-by-week-card />
       <!-- モニタリング指標(4)重症患者数 -->
       <severe-case-card />
       <!-- モニタリング指標(5)入院患者数 -->
@@ -49,7 +47,6 @@ import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringCon
 import PositiveRateCard from '~/components/cards/PositiveRateCard.vue'
 import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
 import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
-import ConfirmedCasesIncreaseRatioByWeekCard from '@/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue'
 import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
 import MonitoringStatusOverviewCard from '@/components/cards/MonitoringStatusOverviewCard.vue'
 import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
@@ -65,7 +62,6 @@ export default Vue.extend({
     PositiveRateCard,
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
-    ConfirmedCasesIncreaseRatioByWeekCard,
     HospitalizedNumberCard,
     MonitoringStatusOverviewCard
   }

--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -19,7 +19,7 @@
       <agency-card />
     </card-row>
     <card-row class="DataBlock">
-      <!-- 旧モニタリング指標(3)週単位の陽性者増加比 -->
+      <!-- 週単位の陽性者増加比 -->
       <confirmed-cases-increase-ratio-by-week-card />
     </card-row>
   </div>

--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -18,6 +18,10 @@
       <!-- 都庁来庁者数の推移 -->
       <agency-card />
     </card-row>
+    <card-row class="DataBlock">
+      <!-- 旧モニタリング指標(3)週単位の陽性者増加比 -->
+      <confirmed-cases-increase-ratio-by-week-card />
+    </card-row>
   </div>
 </template>
 
@@ -31,6 +35,7 @@ import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvi
 import MetroCard from '@/components/cards/MetroCard.vue'
 import AgencyCard from '@/components/cards/AgencyCard.vue'
 import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
+import ConfirmedCasesIncreaseRatioByWeekCard from '@/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue'
 
 export default Vue.extend({
   components: {
@@ -41,7 +46,8 @@ export default Vue.extend({
     TelephoneAdvisoryReportsNumberCard,
     MetroCard,
     AgencyCard,
-    PositiveNumberByDiagnosedDateCard
+    PositiveNumberByDiagnosedDateCard,
+    ConfirmedCasesIncreaseRatioByWeekCard
   }
 })
 </script>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -56,6 +56,9 @@
         />
       </template>
     </scrollable-chart>
+    <template v-slot:attentionNote>
+      <slot name="attentionNote" />
+    </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />
     </template>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -3,7 +3,6 @@
     :title="title"
     :title-id="titleId"
     :date="date"
-    :head-title="title + infoTitles.join(',')"
   >
     <template v-slot:description>
       <slot name="description" />
@@ -65,9 +64,8 @@
     <template v-slot:dataTable>
       <data-view-table :headers="tableHeaders" :items="tableData" />
     </template>
-    <template v-slot:dataSetPanel>
-      <data-view-data-set-panel
-        :title="infoTitles[0]"
+    <template v-slot:infoPanel>
+      <data-view-basic-info-panel
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
         :unit="displayInfo[0].unit"
@@ -91,7 +89,7 @@ import DataViewTable, {
   TableHeader,
   TableItem
 } from '@/components/DataViewTable.vue'
-import DataViewDataSetPanel from '@/components/DataViewDataSetPanel.vue'
+import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 import ScrollableChart from '@/components/ScrollableChart.vue'
 import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
@@ -131,7 +129,6 @@ type Computed = {
 type Props = {
   title: string
   titleId: string
-  infoTitles: string[]
   chartId: string
   chartData: GraphDataType[]
   formatter: Function
@@ -156,7 +153,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   components: {
     DataView,
     DataViewTable,
-    DataViewDataSetPanel,
+    DataViewBasicInfoPanel,
     ScrollableChart,
     OpenDataLink
   },
@@ -168,10 +165,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     titleId: {
       type: String,
       default: ''
-    },
-    infoTitles: {
-      type: Array,
-      default: () => []
     },
     chartId: {
       type: String,

--- a/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
+++ b/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
@@ -12,6 +12,15 @@
       :unit="''"
       :table-labels="tableLabels"
     >
+      <template v-slot:attentionNote>
+        <p>
+          {{
+            $t(
+              '本グラフは、新たなモニタリング項目から除外されたこと、日々公開している陽性者数から算出可能であることから、7月17日をもって削除いたします。'
+            )
+          }}
+        </p>
+      </template>
       <template v-slot:additionalDescription>
         <ul class="ListStyleNone">
           <li>

--- a/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
+++ b/components/cards/ConfirmedCasesIncreaseRatioByWeekCard.vue
@@ -1,9 +1,8 @@
 <template>
   <v-col cols="12" md="6" class="DataCard">
     <confirmed-cases-increase-ratio-by-week-chart
-      :title="$t('旧モニタリング指標(3)')"
+      :title="$t('週単位の陽性者増加比')"
       :title-id="'increase-ratio-of-confirmed-cases-by-daily'"
-      :info-titles="[$t('週単位の陽性者増加比')]"
       :chart-id="'time-line-chart-patients-increase-ratio'"
       :chart-data="graphData"
       :formatter="formatter"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4968 

## ⛏ 変更内容 / Details of Changes
- `旧モニタリング指標(3)` に削除予告を追加
- 配置を `その他参考指標` タブへ移動

## 📸 スクリーンショット / Screenshots
https://deploy-preview-4971--dev-covid19-tokyo.netlify.app

モニタリング指標タブから削除
![image](https://user-images.githubusercontent.com/24243541/86913257-59bc8a80-c159-11ea-8705-0960ce68ac3e.png)

削除予告を追加
<img width="480" src="https://user-images.githubusercontent.com/24243541/86913189-3d205280-c159-11ea-99c4-9d69d68bcafc.png">
