### PR TITLE
FORKED_SITES.mdから福井県（丹南ケーブルテレビ運営）サイトを削除

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -32,7 +32,6 @@
 [](17)石川県|https://stopcovid19.pref.ishikawa.jp/|石川県（**公式**）||
 [](17)石川県|https://ishikawa-covid19.netlify.app/|個人|[Retsuki/covid19-ishikawa/](https://github.com/Retsuki/covid19-ishikawa/)|
 [](18)福井県|https://covid19-fukui.com/|地元有志（**福井県公認**）|[nomunomu0504/covid19](https://github.com/nomunomu0504/covid19)|
-[](18)福井県|https://covid19-fukui.bosai-signal.jp/|丹南ケーブルテレビ株式会社|[westar7/fukui-covid19](https://github.com/westar7/fukui-covid19)|
 [](19)山梨県|https://stopcovid19.yamanashi.dev/|stopcovid19.yamanashi.devチーム|[covid19-yamanashi/covid19](https://github.com/covid19-yamanashi/covid19)|
 [](20)長野県|https://stop-covid19-nagano.netlify.app/|有志|[Stop-COVID19-Nagano/covid19](https://github.com/Stop-COVID19-Nagano/covid19)|
 [](20)長野県|https://covid19-nagano.info/|個人|[kanai3id/covid19](https://github.com/kanai3id/covid19)|


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5015
## 📝 関連issue / Related Issues
## ⛏ 変更内容 / Details of Changes
- FORKED_SITES.mdから福井県（丹南ケーブルテレビ運営）サイトを削除

## 📸 スクリーンショット / Screenshots
ありません