### PR TITLE
検査実施件数のテーブルのthにwidthを設定する

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -177,10 +177,3 @@ $expansion-panel-header-padding: 10px 0;
 $expansion-panel-header-min-height: 26px;
 $expansion-panel-active-header-min-height: 26px;
 $expansion-panel-header-font-size: .875rem;
-
-// Data tables
-// https://vuetifyjs.com/en/components/data-tables/
-$data-table-regular-header-font-size: 1.2rem;
-$data-table-regular-header-height: 36px;
-$data-table-regular-row-font-size: 1.2rem;
-$data-table-regular-row-height: 36px;

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -65,11 +65,11 @@
 .cardTable {
   &.v-data-table {
     th {
-      padding: 8px 10px;
-      height: auto;
-      border-bottom: 1px solid $gray-4;
-      color: $gray-2;
-      @include font-size(12);
+      padding: 8px 10px !important;
+      height: auto !important;
+      border-bottom: 1px solid $gray-4 !important;
+      color: $gray-2 !important;
+      @include font-size(12, true);
 
       &.text-center {
         text-align: center;
@@ -83,9 +83,9 @@
           font-weight: normal;
         }
         td {
-          padding: 8px 10px;
-          height: auto;
-          @include font-size(12);
+          padding: 8px 10px !important;
+          height: auto !important;
+          @include font-size(12, true);
 
           &.text-center {
             text-align: center;

--- a/components/DataViewExpantionPanel.vue
+++ b/components/DataViewExpantionPanel.vue
@@ -8,7 +8,7 @@
           @click="toggleDetails"
         >
           <div class="v-expansion-panel-header__icon">
-            <v-icon left>mdi-chevron-right</v-icon>
+            <v-icon left size="2.4rem">mdi-chevron-right</v-icon>
           </div>
           <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
         </v-expansion-panel-header>

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -84,7 +84,7 @@ export default Vue.extend(options)
 
 <style lang="scss">
 .cardTable-header {
-  white-space: nowrap;
+  white-space: nowrap !important;
 }
 .v-data-table .text-end {
   text-align: right;

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -279,7 +279,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return arr
           }, [] as string[])
           .map((text, i) => {
-            return { text, value: String(i), align: 'end', width: this.isSmall ? '6em' : 'auto' }
+            return {
+              text,
+              value: String(i),
+              align: 'end',
+              width: this.isSmall ? '6em' : 'auto'
+            }
           })
       ]
     },

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -100,6 +100,7 @@ type Data = {
   canvas: boolean
   displayLegends: boolean[]
   colors: SurfaceStyle[]
+  isSmall: boolean
 }
 type Methods = {
   sum: (array: number[]) => number
@@ -108,6 +109,7 @@ type Methods = {
   cumulativeSum: (chartDataArray: number[][]) => number[]
   eachArraySum: (chartDataArray: number[][]) => number[]
   onClickLegend: (i: number) => void
+  handleResize: () => void
 }
 
 type Computed = {
@@ -213,7 +215,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     dataKind: 'transition',
     displayLegends: [true, true],
     colors: getGraphSeriesStyle(2),
-    canvas: true
+    canvas: true,
+    isSmall: false
   }),
   computed: {
     displayInfo() {
@@ -276,7 +279,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return arr
           }, [] as string[])
           .map((text, i) => {
-            return { text, value: String(i), align: 'end' }
+            return { text, value: String(i), align: 'end', width: this.isSmall ? '6em' : 'auto' }
           })
       ]
     },
@@ -582,6 +585,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         sumArray.push(chartDataArray[0][i] + chartDataArray[1][i])
       }
       return sumArray
+    },
+    handleResize() {
+      this.isSmall = window.innerWidth <= 400
     }
   },
   mounted() {
@@ -594,6 +600,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       canvas.setAttribute('role', 'img')
       canvas.setAttribute('aria-labelledby', labelledbyId)
     }
+
+    window.addEventListener('resize', this.handleResize)
+    this.handleResize()
+  },
+  destroyed() {
+    window.removeEventListener('resize', this.handleResize)
   }
 }
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5022 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- テーブルまわりのスタイルを整理しました。
- 検査実施件数のグラフについて、テーブルのthead>thのwidthをブラウザ幅400px以下のときに `6em` に設定するようにしました（他は `auto`）。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2020-07-15 16 08 49](https://user-images.githubusercontent.com/14883063/87516259-106bbe00-c6b8-11ea-87d2-d159202af568.png)
