### PR TITLE
タブ切り替え ->「テーブルを表示」のレイアウト崩れを修正

### DIFF
--- a/components/cards/CardRow.vue
+++ b/components/cards/CardRow.vue
@@ -61,7 +61,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       side.dataset.height = side.dataset.height || `${side.offsetHeight}`
 
       self.style.height =
-        self.style.height === `auto` ? `${self.dataset.height}px` : 'auto'
+        self.style.height === 'auto' ? `${self.dataset.height}px` : 'auto'
       side.style.height =
         side.style.height === 'auto' ? 'auto' : `${side.dataset.height}px`
     }
@@ -73,8 +73,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const cards = this.$el.children
       const self = this.payload.dataView.$el.parentElement
       const index = Array.prototype.indexOf.call(cards, self) + 1
+      if (index === 0) return [null, null]
+
       const sideIndex = index % 2 === 0 ? index - 1 : index + 1
-      const side = document.querySelector(
+      const side = this.$el.querySelector(
         `${cardClassName}:nth-child(${sideIndex}`
       ) as HTMLElement
       return [self, side]
@@ -82,7 +84,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   mounted() {
     window.addEventListener('resize', this.handleCardHeight)
-
     EventBus.$on(TOGGLE_EVENT, (payload: Payload) => {
       this.payload = payload
       this.alignHeight()
@@ -90,6 +91,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   },
   beforeDestroy() {
     window.removeEventListener('resize', this.handleCardHeight)
+    EventBus.$off(TOGGLE_EVENT)
   }
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,12 +1,13 @@
 <template>
   <div>
     <site-top-upper />
-    <v-tabs v-model="tab" hide-slider @change="change">
+    <v-tabs v-model="tab" hide-slider>
       <v-tab
         v-for="(item, i) in items"
         :key="i"
         v-ripple="false"
         :href="`#tab-${i}`"
+        @click="change"
       >
         <v-icon class="TabIcon">
           mdi-chart-timeline-variant

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -67,6 +67,9 @@ const createCustomChart = () => {
       EventBus.$on(TOGGLE_EVENT, () => {
         setTimeout(() => this.renderChart(this.chartData, this.options))
       })
+    },
+    beforeDestroy() {
+      EventBus.$off(TOGGLE_EVENT)
     }
   })
 


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #5055

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
- 「テーブルを表示」実行時にカードの高さを揃えるロジックを修正
  - ページ全体から探索するのではなく、`CardRow` コンポーネントの子要素から探索
- タブ切り替え判定のイベントハンドラを `v-tabs` -> `v-tab` に変更
  - `v-tabs` の `change` イベントはページ切替時にも発火して Chart のレンダリングでエラーとなっていたため
- イベントが繰り返し呼ばれていたので、`beforeDestory` でイベントハンドラを削除

## 📸 スクリーンショット / Screenshots
issue にある操作をしても、レイアウトが崩れていないことを確認しました。

![deploy-preview-5057--dev-covid19-tokyo netlify app_(iPad Pro)](https://user-images.githubusercontent.com/5207601/87870996-d9fbaf00-c9e7-11ea-941f-8c6b98b4a0b3.png)

Chrome の Developer Tools で、言語切替やページ遷移してもエラーがでていないことを確認しました。

![スクリーンショット 2020-07-19 17 46 30](https://user-images.githubusercontent.com/5207601/87870998-dcf69f80-c9e7-11ea-8fd7-4e6d9eeed23b.png)

