### PR TITLE
flow.vue: スクロール時にアイコンを非表示化

### DIFF
--- a/pages/flow.vue
+++ b/pages/flow.vue
@@ -681,6 +681,9 @@ $margin: 20;
     position: fixed;
     top: 0;
     z-index: 1;
+    .fig {
+      display: none;
+    }
   }
 }
 .section {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #4902

## 📝 関連する issue / Related Issues
- #5053
  - #4902 を解決する別のアプローチ

## ⛏ 変更内容 / Details of Changes
- スクロール時に追従するメニューの占有面積が大きいので、スクロール時にはアイコンを表示しないようにした

## 📸 スクリーンショット / Screenshots

<table>
  <tr>
    <th>
      before
    </th>
    <th>
      after
    </th>
  </tr>
  <tr>
    <td>
      <img src="https://user-images.githubusercontent.com/20086673/87941260-d6465600-cad5-11ea-8544-3fabb5ac2218.png">
    </td>
    <td>
      <img src="https://user-images.githubusercontent.com/20086673/87941268-da727380-cad5-11ea-8e4e-9860716e5b19.png">
    </td>
  </tr>
</table>

<details>
<summary>Play GIF</summary>

![](https://user-images.githubusercontent.com/20086673/87945248-72269080-cadb-11ea-8e45-fde49f249ad8.gif)

</details>