### PR TITLE
Lighthouseスコアの改善

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -15,7 +15,9 @@
       :height="240"
     />
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
   </data-view>
 </template>

--- a/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
+++ b/components/ConfirmedCasesIncreaseRatioByWeekChart.vue
@@ -58,7 +58,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -37,7 +37,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -15,7 +15,9 @@
       :height="240"
     />
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:footer>
       <ul>

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -63,7 +63,9 @@
       </template>
     </scrollable-chart>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -66,7 +66,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -58,7 +58,9 @@
       </template>
     </scrollable-chart>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -78,7 +78,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -34,7 +34,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -111,7 +111,7 @@
           <a
             :href="$t('https://creativecommons.org/licenses/by/4.0/deed.ja')"
             target="_blank"
-            rel="license"
+            rel="noreferrer license"
             class="SideNavigation-LicenseLink"
           >
             {{ $t('クリエイティブ・コモンズ 表示 4.0 ライセンス') }}

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -42,7 +42,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -59,7 +59,9 @@
       </template>
     </scrollable-chart>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:additionalDescription>
       <slot name="additionalDescription" />

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -81,7 +81,9 @@
       <slot name="additionalDescription" />
     </template>
     <template v-slot:dataTable>
-      <data-view-table :headers="tableHeaders" :items="tableData" />
+      <client-only>
+        <data-view-table :headers="tableHeaders" :items="tableData" />
+      </client-only>
     </template>
     <template v-slot:dataSetPanel>
       <data-view-data-set-panel

--- a/components/cards/AgencyCard.vue
+++ b/components/cards/AgencyCard.vue
@@ -1,18 +1,20 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <agency-bar-chart
-      :title="$t('都庁来庁者数の推移')"
-      :title-id="'agency'"
-      :chart-id="'agency'"
-      :chart-data="agencyData"
-      :date="agencyData.date"
-      :unit="$t('人')"
-    >
-      <template v-slot:description>
-        {{ $t('※土・日・祝日を除く庁舎開庁日の1週間累計数') }}
-      </template>
-    </agency-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <agency-bar-chart
+        :title="$t('都庁来庁者数の推移')"
+        :title-id="'agency'"
+        :chart-id="'agency'"
+        :chart-data="agencyData"
+        :date="agencyData.date"
+        :unit="$t('人')"
+      >
+        <template v-slot:description>
+          {{ $t('※土・日・祝日を除く庁舎開庁日の1週間累計数') }}
+        </template>
+      </agency-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/AgencyCard.vue
+++ b/components/cards/AgencyCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <agency-bar-chart
         :title="$t('都庁来庁者数の推移')"
         :title-id="'agency'"
@@ -13,8 +13,8 @@
           {{ $t('※土・日・祝日を除く庁舎開庁日の1週間累計数') }}
         </template>
       </agency-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -13,8 +13,9 @@
         "
         :source="$t('オープンデータを入手')"
         :custom-sort="customSort"
-      /> </client-only
-  ></v-col>
+      />
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -1,17 +1,20 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <data-table
-      :title="$t('陽性患者の属性')"
-      :title-id="'attributes-of-confirmed-cases'"
-      :chart-data="patientsTable"
-      :chart-option="{}"
-      :date="Data.patients.date"
-      :info="sumInfoOfPatients"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
-      :source="$t('オープンデータを入手')"
-      :custom-sort="customSort"
-    />
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <data-table
+        :title="$t('陽性患者の属性')"
+        :title-id="'attributes-of-confirmed-cases'"
+        :chart-data="patientsTable"
+        :chart-option="{}"
+        :date="Data.patients.date"
+        :info="sumInfoOfPatients"
+        :url="
+          'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+        "
+        :source="$t('オープンデータを入手')"
+        :custom-sort="customSort"
+      /> </client-only
+  ></v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <data-table
         :title="$t('陽性患者の属性')"
         :title-id="'attributes-of-confirmed-cases'"

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -1,26 +1,28 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <confirmed-cases-by-municipalities-table
-      :title="$t('陽性患者数（区市町村別）')"
-      :title-id="'number-of-confirmed-cases-by-municipalities'"
-      :chart-data="municipalitiesTable"
-      :date="date"
-      :info="info"
-    >
-      <template v-slot:description>
-        <ul class="ListStyleNone">
-          <li>
-            {{ $t('（注）前日までに発生した患者数の累計値') }}
-          </li>
-          <li>
-            {{
-              $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
-            }}
-          </li>
-        </ul>
-      </template>
-    </confirmed-cases-by-municipalities-table>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <confirmed-cases-by-municipalities-table
+        :title="$t('陽性患者数（区市町村別）')"
+        :title-id="'number-of-confirmed-cases-by-municipalities'"
+        :chart-data="municipalitiesTable"
+        :date="date"
+        :info="info"
+      >
+        <template v-slot:description>
+          <ul class="ListStyleNone">
+            <li>
+              {{ $t('（注）前日までに発生した患者数の累計値') }}
+            </li>
+            <li>
+              {{
+                $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
+              }}
+            </li>
+          </ul>
+        </template>
+      </confirmed-cases-by-municipalities-table>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <confirmed-cases-by-municipalities-table
         :title="$t('陽性患者数（区市町村別）')"
         :title-id="'number-of-confirmed-cases-by-municipalities'"
@@ -21,8 +21,8 @@
           </ul>
         </template>
       </confirmed-cases-by-municipalities-table>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -1,39 +1,40 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <data-view
-      :title="$t('検査陽性者の状況')"
-      :title-id="'details-of-confirmed-cases'"
-      :date="updatedAt"
-    >
-      <template v-slot:description>
-        <ul class="ListStyleNone">
-          <li>
-            {{
-              $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '（注）「重症」は、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数を計上'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '（注）退院者数の把握には一定の期間を要しており、確認次第数値を更新している'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-      <confirmed-cases-details-table
-        :aria-label="$t('検査陽性者の状況')"
-        v-bind="confirmedCases"
-      />
-    </data-view>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <data-view
+        :title="$t('検査陽性者の状況')"
+        :title-id="'details-of-confirmed-cases'"
+        :date="updatedAt"
+      >
+        <template v-slot:description>
+          <ul class="ListStyleNone">
+            <li>
+              {{
+                $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '（注）「重症」は、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数を計上'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '（注）退院者数の把握には一定の期間を要しており、確認次第数値を更新している'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+        <confirmed-cases-details-table
+          :aria-label="$t('検査陽性者の状況')"
+          v-bind="confirmedCases"
+        />
+      </data-view> </client-only
+  ></v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -33,8 +33,9 @@
           :aria-label="$t('検査陽性者の状況')"
           v-bind="confirmedCases"
         />
-      </data-view> </client-only
-  ></v-col>
+      </data-view>
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <data-view
         :title="$t('検査陽性者の状況')"
         :title-id="'details-of-confirmed-cases'"

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <time-bar-chart
         :title="$t('新規患者に関する報告件数の推移')"
         :title-id="'number-of-confirmed-cases'"
@@ -29,8 +29,8 @@
           </ul>
         </template>
       </time-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -1,32 +1,36 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <time-bar-chart
-      :title="$t('新規患者に関する報告件数の推移')"
-      :title-id="'number-of-confirmed-cases'"
-      :chart-id="'time-bar-chart-patients'"
-      :chart-data="patientsGraph"
-      :date="Data.patients_summary.date"
-      :unit="$t('人')"
-      :by-date="true"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
-    >
-      <template v-slot:description>
-        <ul class="ListStyleNone">
-          <li>
-            {{ $t('（注）保健所から発生届が提出された日を基準とする') }}
-          </li>
-          <li>
-            {{ $t('（注）医療機関等が行った検査も含む') }}
-          </li>
-          <li>
-            {{
-              $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
-            }}
-          </li>
-        </ul>
-      </template>
-    </time-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <time-bar-chart
+        :title="$t('新規患者に関する報告件数の推移')"
+        :title-id="'number-of-confirmed-cases'"
+        :chart-id="'time-bar-chart-patients'"
+        :chart-data="patientsGraph"
+        :date="Data.patients_summary.date"
+        :unit="$t('人')"
+        :by-date="true"
+        :url="
+          'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'
+        "
+      >
+        <template v-slot:description>
+          <ul class="ListStyleNone">
+            <li>
+              {{ $t('（注）保健所から発生届が提出された日を基準とする') }}
+            </li>
+            <li>
+              {{ $t('（注）医療機関等が行った検査も含む') }}
+            </li>
+            <li>
+              {{
+                $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
+              }}
+            </li>
+          </ul>
+        </template>
+      </time-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/ConsultationAboutFeverNumberCard.vue
+++ b/components/cards/ConsultationAboutFeverNumberCard.vue
@@ -1,31 +1,33 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <mixed-bar-and-line-chart
-      :title="$t('モニタリング項目(2)')"
-      title-id="number-of-reports-to-consultations-about-fever-in-7119"
-      :info-titles="[$t('#7119における発熱等相談件数')]"
-      chart-id="mixed-bar-and-line-chart-fever"
-      :chart-data="chartData"
-      :get-formatter="getFormatter"
-      :date="date"
-      :labels="labels"
-      :data-labels="dataLabels"
-      :unit="$t('件.reports')"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、7月7日の移動平均値は、7月1日から7月7日までの実績値を平均したもの）'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </mixed-bar-and-line-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <mixed-bar-and-line-chart
+        :title="$t('モニタリング項目(2)')"
+        title-id="number-of-reports-to-consultations-about-fever-in-7119"
+        :info-titles="[$t('#7119における発熱等相談件数')]"
+        chart-id="mixed-bar-and-line-chart-fever"
+        :chart-data="chartData"
+        :get-formatter="getFormatter"
+        :date="date"
+        :labels="labels"
+        :data-labels="dataLabels"
+        :unit="$t('件.reports')"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、7月7日の移動平均値は、7月1日から7月7日までの実績値を平均したもの）'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </mixed-bar-and-line-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/ConsultationAboutFeverNumberCard.vue
+++ b/components/cards/ConsultationAboutFeverNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <mixed-bar-and-line-chart
         :title="$t('モニタリング項目(2)')"
         title-id="number-of-reports-to-consultations-about-fever-in-7119"
@@ -26,8 +26,8 @@
           </ul>
         </template>
       </mixed-bar-and-line-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/HospitalizedNumberCard.vue
+++ b/components/cards/HospitalizedNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <dashed-rectangle-time-bar-chart
         :title="$t('モニタリング項目(6)')"
         :title-id="'number-of-hospitalized'"
@@ -37,8 +37,8 @@
           </ul>
         </template>
       </dashed-rectangle-time-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/HospitalizedNumberCard.vue
+++ b/components/cards/HospitalizedNumberCard.vue
@@ -1,40 +1,44 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <dashed-rectangle-time-bar-chart
-      :title="$t('モニタリング項目(6)')"
-      :title-id="'number-of-hospitalized'"
-      :info-titles="[$t('入院患者数')]"
-      :chart-id="'dashed-rectangle-time-bar-chart-hospitalized'"
-      :chart-data="patientsGraph"
-      :date="positiveStatus.date"
-      :unit="$t('人')"
-      :dashed-rectangle-range="'5/11'"
-      :added-value="200"
-      :table-labels="tableLabels"
-    >
-      <template v-slot:additionalDescription>
-        <ul class="ListStyleNone">
-          <li>
-            {{ $t('（注）') }}
-            <ul>
-              <li>
-                {{
-                  $t(
-                    '5月11日までの入院患者数には宿泊療養者・自宅療養者等を含んでいるため、参考値である'
-                  )
-                }}
-              </li>
-              <li>
-                {{
-                  $t('当サイトにおいて入院患者数の公表を開始した3月6日から作成')
-                }}
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </template>
-    </dashed-rectangle-time-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <dashed-rectangle-time-bar-chart
+        :title="$t('モニタリング項目(6)')"
+        :title-id="'number-of-hospitalized'"
+        :info-titles="[$t('入院患者数')]"
+        :chart-id="'dashed-rectangle-time-bar-chart-hospitalized'"
+        :chart-data="patientsGraph"
+        :date="positiveStatus.date"
+        :unit="$t('人')"
+        :dashed-rectangle-range="'5/11'"
+        :added-value="200"
+        :table-labels="tableLabels"
+      >
+        <template v-slot:additionalDescription>
+          <ul class="ListStyleNone">
+            <li>
+              {{ $t('（注）') }}
+              <ul>
+                <li>
+                  {{
+                    $t(
+                      '5月11日までの入院患者数には宿泊療養者・自宅療養者等を含んでいるため、参考値である'
+                    )
+                  }}
+                </li>
+                <li>
+                  {{
+                    $t(
+                      '当サイトにおいて入院患者数の公表を開始した3月6日から作成'
+                    )
+                  }}
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </template>
+      </dashed-rectangle-time-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <metro-bar-chart
         :title="$t('都営地下鉄の利用者数の推移')"
         :title-id="'predicted-number-of-toei-subway-passengers'"
@@ -27,8 +27,8 @@
           }}
         </template>
       </metro-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -1,32 +1,34 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <metro-bar-chart
-      :title="$t('都営地下鉄の利用者数の推移')"
-      :title-id="'predicted-number-of-toei-subway-passengers'"
-      :chart-id="'metro-bar-chart'"
-      :chart-data="metroGraph"
-      :date="metroGraph.date"
-      :tooltips-title="metroGraphTooltipTitle"
-      :tooltips-label="metroGraphTooltipLabel"
-      unit="%"
-    >
-      <template v-slot:description>
-        {{
-          $t('{range}の利用者数*の平均値を基準としたときの相対値', {
-            range: metroGraph.base_period
-          })
-        }}
-        <br />
-        *{{ $t('都営地下鉄4路線の自動改札出場数') }}
-        <br />
-        {{
-          $t(
-            '（注）速報値として公開するものであり、後日確定データとして修正される場合あり'
-          )
-        }}
-      </template>
-    </metro-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <metro-bar-chart
+        :title="$t('都営地下鉄の利用者数の推移')"
+        :title-id="'predicted-number-of-toei-subway-passengers'"
+        :chart-id="'metro-bar-chart'"
+        :chart-data="metroGraph"
+        :date="metroGraph.date"
+        :tooltips-title="metroGraphTooltipTitle"
+        :tooltips-label="metroGraphTooltipLabel"
+        unit="%"
+      >
+        <template v-slot:description>
+          {{
+            $t('{range}の利用者数*の平均値を基準としたときの相対値', {
+              range: metroGraph.base_period
+            })
+          }}
+          <br />
+          *{{ $t('都営地下鉄4路線の自動改札出場数') }}
+          <br />
+          {{
+            $t(
+              '（注）速報値として公開するものであり、後日確定データとして修正される場合あり'
+            )
+          }}
+        </template>
+      </metro-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <monitoring-confirmed-cases-chart
         :title="$t('モニタリング項目(1)')"
         title-id="monitoring-number-of-confirmed-cases"
@@ -43,8 +43,8 @@
           </ul>
         </template>
       </monitoring-confirmed-cases-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/MonitoringConfirmedCasesNumberCard.vue
+++ b/components/cards/MonitoringConfirmedCasesNumberCard.vue
@@ -1,46 +1,50 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <monitoring-confirmed-cases-chart
-      :title="$t('モニタリング項目(1)')"
-      title-id="monitoring-number-of-confirmed-cases"
-      :info-titles="[$t('新規陽性者数')]"
-      chart-id="monitoring-confirmed-cases-chart"
-      :chart-data="chartData"
-      :get-formatter="getFormatter"
-      :date="date"
-      :labels="labels"
-      :data-labels="dataLabels"
-      :table-labels="tableLabels"
-      :unit="$t('人')"
-      url="https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068"
-    >
-      <template v-slot:additionalDescription>
-        <ul class="ListStyleNone">
-          <li>
-            {{ $t('（注）') }}
-            <ul>
-              <li>
-                {{ $t('保健所から発生届が提出された日を基準とする') }}
-              </li>
-              <li>
-                {{ $t('医療機関等が行った検査も含む') }}
-              </li>
-              <li>
-                {{ $t('チャーター機帰国者、クルーズ船乗客等は含まれていない') }}
-              </li>
-              <li>
-                {{
-                  $t(
-                    '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
-                  )
-                }}
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </template>
-    </monitoring-confirmed-cases-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <monitoring-confirmed-cases-chart
+        :title="$t('モニタリング項目(1)')"
+        title-id="monitoring-number-of-confirmed-cases"
+        :info-titles="[$t('新規陽性者数')]"
+        chart-id="monitoring-confirmed-cases-chart"
+        :chart-data="chartData"
+        :get-formatter="getFormatter"
+        :date="date"
+        :labels="labels"
+        :data-labels="dataLabels"
+        :table-labels="tableLabels"
+        :unit="$t('人')"
+        url="https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068"
+      >
+        <template v-slot:additionalDescription>
+          <ul class="ListStyleNone">
+            <li>
+              {{ $t('（注）') }}
+              <ul>
+                <li>
+                  {{ $t('保健所から発生届が提出された日を基準とする') }}
+                </li>
+                <li>
+                  {{ $t('医療機関等が行った検査も含む') }}
+                </li>
+                <li>
+                  {{
+                    $t('チャーター機帰国者、クルーズ船乗客等は含まれていない')
+                  }}
+                </li>
+                <li>
+                  {{
+                    $t(
+                      '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
+                    )
+                  }}
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </template>
+      </monitoring-confirmed-cases-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
+++ b/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
@@ -1,37 +1,39 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <monitoring-consultation-desk-report-chart
-      :title="$t('受診相談窓口における相談件数')"
-      title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
-      chart-id="monitoring-consultation-desk-report-chart"
-      :chart-data="chartData"
-      :date="date"
-      :labels="labels"
-      :data-labels="dataLabels"
-      :unit="$t('件.reports')"
-      url="https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000070"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '曜日などによる数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '新型コロナ受診相談窓口 （帰国者・接触者電話相談センター）を開設した2月7日から作成'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </monitoring-consultation-desk-report-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <monitoring-consultation-desk-report-chart
+        :title="$t('受診相談窓口における相談件数')"
+        title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
+        chart-id="monitoring-consultation-desk-report-chart"
+        :chart-data="chartData"
+        :date="date"
+        :labels="labels"
+        :data-labels="dataLabels"
+        :unit="$t('件.reports')"
+        url="https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000070"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '曜日などによる数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '新型コロナ受診相談窓口 （帰国者・接触者電話相談センター）を開設した2月7日から作成'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </monitoring-consultation-desk-report-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
+++ b/components/cards/MonitoringConsultationDeskReportsNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <monitoring-consultation-desk-report-chart
         :title="$t('受診相談窓口における相談件数')"
         title-id="monitoring-number-of-reports-to-covid19-consultation-desk"
@@ -32,8 +32,8 @@
           </ul>
         </template>
       </monitoring-consultation-desk-report-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/MonitoringItemsOverviewCard.vue
+++ b/components/cards/MonitoringItemsOverviewCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <data-view
         :title="$t('モニタリング項目')"
         title-id="monitoring-items-overview"
@@ -67,8 +67,8 @@
           </external-link>
         </div>
       </data-view>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/MonitoringItemsOverviewCard.vue
+++ b/components/cards/MonitoringItemsOverviewCard.vue
@@ -1,72 +1,74 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <data-view
-      :title="$t('モニタリング項目')"
-      title-id="monitoring-items-overview"
-      :date="monitoringItemsData.date"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '「＃7119」：急病やけがの際に、緊急受診の必要性や診察可能な医療機関をアドバイスする電話相談窓口'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '救急医療の東京ルールの適用件数：救急隊による5医療機関への受入要請又は選定開始から20分以上経過しても搬送先が決定しない事案の件数'
-              )
-            }}
-          </li>
-          <li>
-            {{ $t('(1)～(5)は7日間移動平均で算出') }}
-          </li>
-          <li>
-            {{ $t('(2)(4)(5)は報告日の前日時点の数値') }}
-          </li>
-          <li>
-            {{ $t('(6)の確保病床数には、(7)の確保病床数を含む') }}
-          </li>
-          <li>
-            {{ $t('速報値として公表するものであり、後日修正する場合がある') }}
-          </li>
-          <li>
-            {{
-              $t(
-                '(2)(5)は土曜日、日曜日、祝日は更新しない。(4)は日曜日、祝日は更新しない'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-      <section>
-        <h4>{{ $t('感染状況') }}</h4>
-        <monitoring-items-overview-table-infection-status
-          :aria-label="$t('感染状況')"
-          :items="monitoringItems"
-        />
-      </section>
-      <section>
-        <h4>{{ $t('医療提供体制') }}</h4>
-        <monitoring-items-overview-table-medical-system
-          :aria-label="$t('医療提供体制')"
-          :items="monitoringItems"
-        />
-      </section>
-      <div>
-        <external-link
-          :class="$style.button"
-          url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/monitoring.html"
-        >
-          {{ $t('最新のモニタリング項目の分析・総括コメントについて') }}
-        </external-link>
-      </div>
-    </data-view>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <data-view
+        :title="$t('モニタリング項目')"
+        title-id="monitoring-items-overview"
+        :date="monitoringItemsData.date"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '「＃7119」：急病やけがの際に、緊急受診の必要性や診察可能な医療機関をアドバイスする電話相談窓口'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '救急医療の東京ルールの適用件数：救急隊による5医療機関への受入要請又は選定開始から20分以上経過しても搬送先が決定しない事案の件数'
+                )
+              }}
+            </li>
+            <li>
+              {{ $t('(1)～(5)は7日間移動平均で算出') }}
+            </li>
+            <li>
+              {{ $t('(2)(4)(5)は報告日の前日時点の数値') }}
+            </li>
+            <li>
+              {{ $t('(6)の確保病床数には、(7)の確保病床数を含む') }}
+            </li>
+            <li>
+              {{ $t('速報値として公表するものであり、後日修正する場合がある') }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '(2)(5)は土曜日、日曜日、祝日は更新しない。(4)は日曜日、祝日は更新しない'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+        <section>
+          <h4>{{ $t('感染状況') }}</h4>
+          <monitoring-items-overview-table-infection-status
+            :aria-label="$t('感染状況')"
+            :items="monitoringItems"
+          />
+        </section>
+        <section>
+          <h4>{{ $t('医療提供体制') }}</h4>
+          <monitoring-items-overview-table-medical-system
+            :aria-label="$t('医療提供体制')"
+            :items="monitoringItems"
+          />
+        </section>
+        <div>
+          <external-link
+            :class="$style.button"
+            url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/monitoring.html"
+          >
+            {{ $t('最新のモニタリング項目の分析・総括コメントについて') }}
+          </external-link>
+        </div>
+      </data-view>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <time-bar-chart
         :title="$t('確定日別による陽性者数の推移')"
         :title-id="'positive-number-by-diagnosed-date'"
@@ -23,8 +23,8 @@
           </ul>
         </template>
       </time-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -1,28 +1,30 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <time-bar-chart
-      :title="$t('確定日別による陽性者数の推移')"
-      :title-id="'positive-number-by-diagnosed-date'"
-      :chart-id="'positive-number-by-diagnosed-date'"
-      :chart-data="graphData"
-      :date="data.date"
-      :unit="$t('人')"
-      :by-date="true"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '患者発生の動向をより正確に分析するため、各保健所から報告があった患者の発生情報を、検査により陽性であることを医師が確認した日別（確定日別）に整理したものである'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </time-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <time-bar-chart
+        :title="$t('確定日別による陽性者数の推移')"
+        :title-id="'positive-number-by-diagnosed-date'"
+        :chart-id="'positive-number-by-diagnosed-date'"
+        :chart-data="graphData"
+        :date="data.date"
+        :unit="$t('人')"
+        :by-date="true"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '患者発生の動向をより正確に分析するため、各保健所から報告があった患者の発生情報を、検査により陽性であることを医師が確認した日別（確定日別）に整理したものである'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </time-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <positive-rate-mixed-chart
         :title="$t('モニタリング項目(4)')"
         :title-id="'positive-rate'"
@@ -69,8 +69,8 @@
           </ul>
         </template>
       </positive-rate-mixed-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/PositiveRateCard.vue
+++ b/components/cards/PositiveRateCard.vue
@@ -1,74 +1,76 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <positive-rate-mixed-chart
-      :title="$t('モニタリング項目(4)')"
-      :title-id="'positive-rate'"
-      :info-titles="[$t('検査の陽性率'), $t('検査人数')]"
-      :chart-id="'positive-rate-chart'"
-      :chart-data="positiveRateGraph"
-      :get-formatter="getFormatter"
-      :date="PositiveRate.date"
-      :labels="positiveRateLabels"
-      unit="%"
-      :option-unit="$t('人')"
-      :data-labels="positiveRateDataLabels"
-      :table-labels="positiveRateTableLabels"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '陽性率：陽性判明数（PCR・抗原）の移動平均／検査人数（＝陽性判明数（PCR・抗原）＋陰性判明数（PCR・抗原））の移動平均'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去7日間の移動平均値をもとに算出し、折れ線グラフで示す（例えば、5月7日の陽性率は、5月1日から5月7日までの実績平均を用いて算出）'
-              )
-            }}
-          </li>
-          <li>
-            {{ $t('検査結果の判明日を基準とする') }}
-          </li>
-          <li>
-            {{
-              $t(
-                '5月7日以降は(1)東京都健康安全研究センター、(2)PCRセンター（地域外来・検査センター）、(3)医療機関での保険適用検査実績により算出。4月10日～5月6日は(3)が含まれず(1)(2)のみ、4月9日以前は(2)(3)が含まれず(1)のみのデータ'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '5月13日から6月16日までに行われた抗原検査については、結果が陰性の場合、PCR検査での確定検査が必要であったため、検査件数の二重計上を避けるため、陽性判明数のみ計上。6月17日以降に行われた抗原検査については、陽性判明数、陰性判明数の両方を計上'
-              )
-            }}
-          </li>
-          <li>
-            {{ $t('陰性確認のために行った検査の実施人数は含まない') }}
-          </li>
-          <li>
-            {{
-              $t(
-                '陽性者が1月24日、25日、30日、2月13日にそれぞれ1名、2月14日に2名発生しているが、有意な数値がとれる2月15日から作成'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '速報値として公表するものであり、後日確定データとして修正される場合がある'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </positive-rate-mixed-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <positive-rate-mixed-chart
+        :title="$t('モニタリング項目(4)')"
+        :title-id="'positive-rate'"
+        :info-titles="[$t('検査の陽性率'), $t('検査人数')]"
+        :chart-id="'positive-rate-chart'"
+        :chart-data="positiveRateGraph"
+        :get-formatter="getFormatter"
+        :date="PositiveRate.date"
+        :labels="positiveRateLabels"
+        unit="%"
+        :option-unit="$t('人')"
+        :data-labels="positiveRateDataLabels"
+        :table-labels="positiveRateTableLabels"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '陽性率：陽性判明数（PCR・抗原）の移動平均／検査人数（＝陽性判明数（PCR・抗原）＋陰性判明数（PCR・抗原））の移動平均'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去7日間の移動平均値をもとに算出し、折れ線グラフで示す（例えば、5月7日の陽性率は、5月1日から5月7日までの実績平均を用いて算出）'
+                )
+              }}
+            </li>
+            <li>
+              {{ $t('検査結果の判明日を基準とする') }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '5月7日以降は(1)東京都健康安全研究センター、(2)PCRセンター（地域外来・検査センター）、(3)医療機関での保険適用検査実績により算出。4月10日～5月6日は(3)が含まれず(1)(2)のみ、4月9日以前は(2)(3)が含まれず(1)のみのデータ'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '5月13日から6月16日までに行われた抗原検査については、結果が陰性の場合、PCR検査での確定検査が必要であったため、検査件数の二重計上を避けるため、陽性判明数のみ計上。6月17日以降に行われた抗原検査については、陽性判明数、陰性判明数の両方を計上'
+                )
+              }}
+            </li>
+            <li>
+              {{ $t('陰性確認のために行った検査の実施人数は含まない') }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '陽性者が1月24日、25日、30日、2月13日にそれぞれ1名、2月14日に2名発生しているが、有意な数値がとれる2月15日から作成'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '速報値として公表するものであり、後日確定データとして修正される場合がある'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </positive-rate-mixed-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <severe-case-bar-chart
         :title="$t('モニタリング項目(7)')"
         title-id="positive-status-severe-case"
@@ -34,8 +34,8 @@
           </ul>
         </template>
       </severe-case-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -1,37 +1,41 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <severe-case-bar-chart
-      :title="$t('モニタリング項目(7)')"
-      title-id="positive-status-severe-case"
-      :info-titles="[$t('重症患者数')]"
-      chart-id="time-bar-chart-positive-status-severe-case"
-      :chart-data="graphData"
-      :date="Data.date"
-      :unit="$t('人')"
-    >
-      <template v-slot:additionalDescription>
-        <ul class="ListStyleNone">
-          <li>
-            {{ $t('（注）') }}
-            <ul>
-              <li>
-                {{
-                  $t(
-                    '入院患者数のうち、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数を計上'
-                  )
-                }}
-              </li>
-              <li>
-                {{
-                  $t('上記の考え方で重症患者数の計上を開始した4月27日から作成')
-                }}
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </template>
-    </severe-case-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <severe-case-bar-chart
+        :title="$t('モニタリング項目(7)')"
+        title-id="positive-status-severe-case"
+        :info-titles="[$t('重症患者数')]"
+        chart-id="time-bar-chart-positive-status-severe-case"
+        :chart-data="graphData"
+        :date="Data.date"
+        :unit="$t('人')"
+      >
+        <template v-slot:additionalDescription>
+          <ul class="ListStyleNone">
+            <li>
+              {{ $t('（注）') }}
+              <ul>
+                <li>
+                  {{
+                    $t(
+                      '入院患者数のうち、集中治療室（ICU）等での管理又は人工呼吸器管理が必要な患者数を計上'
+                    )
+                  }}
+                </li>
+                <li>
+                  {{
+                    $t(
+                      '上記の考え方で重症患者数の計上を開始した4月27日から作成'
+                    )
+                  }}
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </template>
+      </severe-case-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -1,16 +1,20 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <time-bar-chart
-      :title="$t('新型コロナコールセンター相談件数')"
-      :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
-      :chart-id="'time-bar-chart-contacts'"
-      :chart-data="contactsGraph"
-      :date="Data.contacts.date"
-      :unit="$t('件.reports')"
-      :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000071'"
-    />
-    <!-- 件.reports = 窓口相談件数 -->
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <time-bar-chart
+        :title="$t('新型コロナコールセンター相談件数')"
+        :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
+        :chart-id="'time-bar-chart-contacts'"
+        :chart-data="contactsGraph"
+        :date="Data.contacts.date"
+        :unit="$t('件.reports')"
+        :url="
+          'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000071'
+        "
+      />
+      <!-- 件.reports = 窓口相談件数 -->
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/TelephoneAdvisoryReportsNumberCard.vue
+++ b/components/cards/TelephoneAdvisoryReportsNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <time-bar-chart
         :title="$t('新型コロナコールセンター相談件数')"
         :title-id="'number-of-reports-to-covid19-telephone-advisory-center'"
@@ -13,8 +13,8 @@
         "
       />
       <!-- 件.reports = 窓口相談件数 -->
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <time-stacked-bar-chart
         :title="$t('検査実施件数')"
         :title-id="'number-of-tested'"
@@ -40,8 +40,8 @@
           </ul>
         </template>
       </time-stacked-bar-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -1,45 +1,47 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <time-stacked-bar-chart
-      :title="$t('検査実施件数')"
-      :title-id="'number-of-tested'"
-      :chart-id="'time-stacked-bar-chart-inspections'"
-      :chart-data="inspectionsGraph"
-      :date="Data.inspections_summary.date"
-      :items="inspectionsItems"
-      :labels="inspectionsLabels"
-      :unit="$t('件.tested')"
-      :data-labels="inspectionsDataLabels"
-      :table-labels="inspectionsTableLabels"
-    >
-      <!-- 件.tested = 検査数 -->
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '検体採取日を基準とする。ただし、一部検査結果判明日に基づくものを含む'
-              )
-            }}
-          </li>
-          <li>
-            {{ $t('同一の対象者について複数の検体を検査する場合がある') }}
-          </li>
-          <li>
-            {{ $t('5月13日以降は、PCR検査に加え、抗原検査の件数を含む') }}
-          </li>
-          <li>
-            {{
-              $t(
-                '速報値として公開するものであり、後日確定データとして修正される場合がある'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </time-stacked-bar-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <time-stacked-bar-chart
+        :title="$t('検査実施件数')"
+        :title-id="'number-of-tested'"
+        :chart-id="'time-stacked-bar-chart-inspections'"
+        :chart-data="inspectionsGraph"
+        :date="Data.inspections_summary.date"
+        :items="inspectionsItems"
+        :labels="inspectionsLabels"
+        :unit="$t('件.tested')"
+        :data-labels="inspectionsDataLabels"
+        :table-labels="inspectionsTableLabels"
+      >
+        <!-- 件.tested = 検査数 -->
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '検体採取日を基準とする。ただし、一部検査結果判明日に基づくものを含む'
+                )
+              }}
+            </li>
+            <li>
+              {{ $t('同一の対象者について複数の検体を検査する場合がある') }}
+            </li>
+            <li>
+              {{ $t('5月13日以降は、PCR検査に加え、抗原検査の件数を含む') }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '速報値として公開するものであり、後日確定データとして修正される場合がある'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </time-stacked-bar-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/TokyoRulesApplicationNumberCard.vue
+++ b/components/cards/TokyoRulesApplicationNumberCard.vue
@@ -1,31 +1,33 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <mixed-bar-and-line-chart
-      :title="$t('モニタリング項目(5)')"
-      title-id="number-of-tokyo-rules-applied"
-      :info-titles="[$t('救急医療の東京ルールの適用件数')]"
-      chart-id="mixed-bar-and-line-chart-tokyo-rules"
-      :chart-data="chartData"
-      :get-formatter="getFormatter"
-      :date="date"
-      :labels="labels"
-      :data-labels="dataLabels"
-      :unit="$t('件.reports')"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、7月7日の移動平均値は、7月1日から7月7日までの実績値を平均したもの）'
-              )
-            }}
-          </li>
-        </ul>
-      </template>
-    </mixed-bar-and-line-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <mixed-bar-and-line-chart
+        :title="$t('モニタリング項目(5)')"
+        title-id="number-of-tokyo-rules-applied"
+        :info-titles="[$t('救急医療の東京ルールの適用件数')]"
+        chart-id="mixed-bar-and-line-chart-tokyo-rules"
+        :chart-data="chartData"
+        :get-formatter="getFormatter"
+        :date="date"
+        :labels="labels"
+        :data-labels="dataLabels"
+        :unit="$t('件.reports')"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去７日間の移動平均値を折れ線グラフで示す（例えば、7月7日の移動平均値は、7月1日から7月7日までの実績値を平均したもの）'
+                )
+              }}
+            </li>
+          </ul>
+        </template>
+      </mixed-bar-and-line-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/TokyoRulesApplicationNumberCard.vue
+++ b/components/cards/TokyoRulesApplicationNumberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <mixed-bar-and-line-chart
         :title="$t('モニタリング項目(5)')"
         title-id="number-of-tokyo-rules-applied"
@@ -26,8 +26,8 @@
           </ul>
         </template>
       </mixed-bar-and-line-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -1,51 +1,53 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard">
-    <untracked-rate-mixed-chart
-      :title="$t('モニタリング項目(3)')"
-      :title-id="'untracked-rate'"
-      :info-titles="[$t('新規陽性者における接触歴等不明者数'), $t('増加比')]"
-      :chart-id="'untracked-rate-chart'"
-      :chart-data="graphData"
-      :get-formatter="getFormatter"
-      :date="updated"
-      :labels="dateList"
-      :unit="['人', '%']"
-      :data-labels="dataLabels"
-      :table-labels="tableLabels"
-    >
-      <template v-slot:additionalDescription>
-        <span>{{ $t('（注）') }}</span>
-        <ul>
-          <li>
-            {{
-              $t(
-                '保健所から発生届が提出された日別（報告日別）の新規陽性者について、接触歴等の不明者、判明者に区分したものである'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去7日間の移動平均値を不明者数として算出（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t(
-                '濃厚接触者など、患者の発生状況の内訳の公表を開始した3月27日から作成'
-              )
-            }}
-          </li>
-          <li>
-            {{
-              $t('増加比は、１週間前の接触歴等不明者数（移動平均値）との比較')
-            }}
-          </li>
-        </ul>
-      </template>
-    </untracked-rate-mixed-chart>
-  </v-col>
+  <v-col cols="12" md="6" class="DataCard"
+    ><client-only>
+      <untracked-rate-mixed-chart
+        :title="$t('モニタリング項目(3)')"
+        :title-id="'untracked-rate'"
+        :info-titles="[$t('新規陽性者における接触歴等不明者数'), $t('増加比')]"
+        :chart-id="'untracked-rate-chart'"
+        :chart-data="graphData"
+        :get-formatter="getFormatter"
+        :date="updated"
+        :labels="dateList"
+        :unit="['人', '%']"
+        :data-labels="dataLabels"
+        :table-labels="tableLabels"
+      >
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
+            <li>
+              {{
+                $t(
+                  '保健所から発生届が提出された日別（報告日別）の新規陽性者について、接触歴等の不明者、判明者に区分したものである'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '集団感染発生や曜日による数値のばらつきにより、日々の結果が変動するため、こうしたばらつきを平準化し全体の傾向を見る趣旨から、過去7日間の移動平均値を不明者数として算出（例えば、5月7日の移動平均値は、5月1日から5月7日までの実績値を平均したもの）'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t(
+                  '濃厚接触者など、患者の発生状況の内訳の公表を開始した3月27日から作成'
+                )
+              }}
+            </li>
+            <li>
+              {{
+                $t('増加比は、１週間前の接触歴等不明者数（移動平均値）との比較')
+              }}
+            </li>
+          </ul>
+        </template>
+      </untracked-rate-mixed-chart>
+    </client-only></v-col
+  >
 </template>
 
 <script>

--- a/components/cards/UntrackedRateCard.vue
+++ b/components/cards/UntrackedRateCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard"
-    ><client-only>
+  <v-col cols="12" md="6" class="DataCard">
+    <client-only>
       <untracked-rate-mixed-chart
         :title="$t('モニタリング項目(3)')"
         :title-id="'untracked-rate'"
@@ -46,8 +46,8 @@
           </ul>
         </template>
       </untracked-rate-mixed-chart>
-    </client-only></v-col
-  >
+    </client-only>
+  </v-col>
 </template>
 
 <script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -193,6 +193,10 @@ export default Vue.extend({
 })
 </script>
 <style lang="scss">
+@font-face {
+  font-family: Roboto;
+  font-display: swap;
+}
 .app {
   max-width: 1440px;
   margin: 0 auto;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->
ローカル環境では改善しましたが、プレビュー環境でどの程度効果が出るか要検証です。

## 👏 解決する issue / Resolved Issues
- close #5075

## 📝 関連する issue / Related Issues
- #3484

## ⛏ 変更内容 / Details of Changes
1. `cards/`配下のコンポーネントの`v-col`直下の要素を`<client-only>`でラップ
2. `<data-view-table />`を`<client-only>`でラップ（1.があれば不要な気がするのですが、これがあるとPerformanceスコアが4ポイント改善しました）
3. 他、LighthouseのBest Practiceで減点されていた箇所の修正（aタグのrel="noreferrer"、ウェブフォントへの`font-display:swap`の追加）

## 📸 スクリーンショット / Screenshots
![cards_and_data-view-table_with_client-only_and_fixes](https://user-images.githubusercontent.com/1763230/88142785-0eae7700-cc31-11ea-834f-1d509bc7f277.png)
