### PR TITLE
モニタリング項目のモバイルサイズ時のフォントサイズを小さくする

### DIFF
--- a/assets/monitoringItemsTableCommon.scss
+++ b/assets/monitoringItemsTableCommon.scss
@@ -9,9 +9,7 @@ $default-pad: 0.5rem 0.2rem;
   @include font-size(16);
 
   @include lessThan($small) {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
+    @include font-size(12);
   }
 
   th,


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4992 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- $small（600px）以下の時のfont-sizeを1.2rem（12px）にしました。
- 横スクロールはナシにしました。
- #5089 と比較検討する必要があります。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
|日本語|英語|
|---|---|
|![日本語](https://user-images.githubusercontent.com/14883063/88262198-afb93280-cd02-11ea-98d0-ea6a82f8130b.png)|![英語](https://user-images.githubusercontent.com/14883063/88262217-b9429a80-cd02-11ea-871b-d4d8858f4e59.png)|

