### PR TITLE
モニタリング項目(3)グラフとY軸のスケールが一致していないのを修正・Y軸を左右逆に

### DIFF
--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -323,7 +323,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           },
           {
             type: 'line',
-            yAxisID: 'y-axis-2',
+            yAxisID: 'y-axis-1',
             label: this.dataLabels[2],
             data: this.chartData[2],
             pointBackgroundColor: 'rgba(0,0,0,0)',
@@ -462,7 +462,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           yAxes: [
             {
               id: 'y-axis-1',
-              position: 'right',
+              position: 'left',
               stacked: true,
               gridLines: {
                 display: true,
@@ -478,7 +478,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             {
               id: 'y-axis-2',
-              position: 'left',
+              position: 'right',
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
@@ -595,7 +595,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             {
               id: 'y-axis-1',
               type: 'linear',
-              position: 'right',
+              position: 'left',
               stacked: true,
               gridLines: {
                 display: true,
@@ -612,7 +612,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             {
               id: 'y-axis-2',
               type: 'linear',
-              position: 'left',
+              position: 'right',
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
@@ -639,13 +639,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       for (const i in this.chartData[0]) {
         max = Math.max(max, this.chartData[0][i] + this.chartData[1][i])
       }
+      for (const i in this.chartData[2]) {
+        max = Math.max(max, this.chartData[2][i])
+      }
       return max
     },
     scaledTicksYAxisMaxRight() {
       let max = 0
-      for (const i in this.chartData[2]) {
-        max = Math.max(max, this.chartData[2][i])
-      }
       for (const i in this.chartData[3]) {
         max = Math.max(max, this.chartData[3][i])
       }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5171 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 接触歴等不明者数（７日間移動平均）のY軸の目盛りが一致していなかったのを修正しました
- 視認性を考慮してY軸を左右逆にしました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
|before|after|
|---|---|
|![スクリーンショット 2020-08-03 20 01 29](https://user-images.githubusercontent.com/14883063/89176518-a8c4d680-d5c4-11ea-84f2-4b55d2df3fca.png)|![スクリーンショット 2020-08-03 20 00 50](https://user-images.githubusercontent.com/14883063/89176549-b5492f00-d5c4-11ea-936a-6ae1fd7daf45.png)|
