### PR TITLE
「陽性者」への用語の統一

### DIFF
--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <card-row class="DataBlock">
-      <!-- 陽性患者の属性 -->
+      <!-- 陽性者の属性 -->
       <confirmed-cases-attributes-card />
       <!-- 区市町村別患者数 -->
       <confirmed-cases-by-municipalities-card />

--- a/components/ConfirmedCasesByMunicipalitiesTable.vue
+++ b/components/ConfirmedCasesByMunicipalitiesTable.vue
@@ -1,8 +1,5 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:description>
-      <slot name="description" />
-    </template>
     <v-data-table
       :ref="'displayedTable'"
       :headers="chartData.headers"
@@ -15,6 +12,9 @@
       :disable-sort="true"
       class="cardTable"
     />
+    <template v-slot:additionalDescription>
+      <slot name="additionalDescription" />
+    </template>
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <client-only>
       <data-table
-        :title="$t('陽性患者の属性')"
+        :title="$t('陽性者の属性')"
         :title-id="'attributes-of-confirmed-cases'"
         :chart-data="patientsTable"
         :chart-option="{}"
@@ -44,12 +44,12 @@ export default {
       unit: this.$t('人'),
     }
 
-    // 陽性患者の属性 ヘッダー翻訳
+    // 陽性者の属性 ヘッダー翻訳
     for (const header of patientsTable.headers) {
       header.text =
         header.value === '退院' ? this.$t('退院※') : this.$t(header.value)
     }
-    // 陽性患者の属性 中身の翻訳
+    // 陽性者の属性 中身の翻訳
     for (const row of patientsTable.datasets) {
       row['居住地'] = this.getTranslatedWording(row['居住地'])
       row['性別'] = this.getTranslatedWording(row['性別'])

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -8,15 +8,14 @@
         :date="date"
         :info="info"
       >
-        <template v-slot:description>
-          <ul class="ListStyleNone">
+        <template v-slot:additionalDescription>
+          <span>{{ $t('（注）') }}</span>
+          <ul>
             <li>
-              {{ $t('（注）前日までに報告された陽性者数の累計値') }}
+              {{ $t('前日までに報告された陽性者数の累計値') }}
             </li>
             <li>
-              {{
-                $t('（注）チャーター機帰国者、クルーズ船乗客等は含まれていない')
-              }}
+              {{ $t('チャーター機帰国者、クルーズ船乗客等は含まれていない') }}
             </li>
           </ul>
         </template>

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <client-only>
       <confirmed-cases-by-municipalities-table
-        :title="$t('陽性患者数（区市町村別）')"
+        :title="$t('陽性者数（区市町村別）')"
         :title-id="'number-of-confirmed-cases-by-municipalities'"
         :chart-data="municipalitiesTable"
         :date="date"
@@ -11,7 +11,7 @@
         <template v-slot:description>
           <ul class="ListStyleNone">
             <li>
-              {{ $t('（注）前日までに発生した患者数の累計値') }}
+              {{ $t('（注）前日までに報告された陽性者数の累計値') }}
             </li>
             <li>
               {{
@@ -35,7 +35,7 @@ export default {
     ConfirmedCasesByMunicipalitiesTable,
   },
   data() {
-    // 区市町村ごとの陽性患者数
+    // 区市町村ごとの陽性者数
     const municipalitiesTable = {
       headers: [],
       datasets: [],
@@ -47,13 +47,13 @@ export default {
         { text: this.$t('地域'), value: 'area' },
         { text: this.$t('ふりがな'), value: 'ruby' },
         { text: this.$t('区市町村'), value: 'label' },
-        { text: this.$t('陽性患者数'), value: 'count', align: 'end' },
+        { text: this.$t('陽性者数'), value: 'count', align: 'end' },
       ]
     } else {
       municipalitiesTable.headers = [
         { text: this.$t('地域'), value: 'area' },
         { text: this.$t('区市町村'), value: 'label' },
-        { text: this.$t('陽性患者数'), value: 'count', align: 'end' },
+        { text: this.$t('陽性者数'), value: 'count', align: 'end' },
       ]
     }
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5202 

## ⛏ 変更内容 / Details of Changes
- 陽性患者の属性
  - カードタイトル変更
- 陽性患者数（区市町村別）
  - カードタイトル変更
  - 表見出し変更
  - 注釈のスタイル変更

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/24243541/89548858-87711e00-d842-11ea-9700-809804b87e86.png)