### PR TITLE
「新規患者に関する報告件数の推移」グラフタイトル修正・リンクボタン追加

### DIFF
--- a/components/CardsMonitoring.vue
+++ b/components/CardsMonitoring.vue
@@ -3,7 +3,7 @@
     <card-row class="DataBlock">
       <!-- 検査陽性者の状況 -->
       <confirmed-cases-details-card />
-      <!-- 新規患者に関する報告件数の推移 -->
+      <!-- 報告日別による陽性者数の推移 -->
       <confirmed-cases-number-card />
       <!-- モニタリング項目 -->
       <monitoring-items-overview-card />

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard">
     <client-only>
       <time-bar-chart
-        :title="$t('新規患者に関する報告件数の推移')"
+        :title="$t('報告日別による陽性者数の推移')"
         :title-id="'number-of-confirmed-cases'"
         :chart-id="'time-bar-chart-patients'"
         :chart-data="patientsGraph"
@@ -11,6 +11,14 @@
         :by-date="true"
         :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
       >
+        <template v-slot:description>
+          <a
+            class="Description-Link"
+            href="/cards/positive-number-by-developed-date"
+          >
+            {{ $t('発症日別による陽性者数の推移はこちら') }}
+          </a>
+        </template>
         <template v-slot:additionalDescription>
           <div class="Description-ExternalLink">
             <external-link
@@ -61,6 +69,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.Description-Link {
+  text-decoration: none;
+  @include button-text('sm');
+}
 .Description-ExternalLink {
   margin-bottom: 10px;
 }

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -12,12 +12,12 @@
         :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000068'"
       >
         <template v-slot:description>
-          <a
+          <nuxt-link
             class="Description-Link"
-            href="/cards/positive-number-by-developed-date"
+            to="/cards/positive-number-by-developed-date"
           >
             {{ $t('発症日別による陽性者数の推移はこちら') }}
-          </a>
+          </nuxt-link>
         </template>
         <template v-slot:additionalDescription>
           <div class="Description-ExternalLink">

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -13,8 +13,10 @@
       >
         <template v-slot:description>
           <nuxt-link
+            :to="`${
+              $i18n.locale !== 'ja' ? $i18n.locale : ''
+            }/cards/positive-number-by-developed-date`"
             class="Description-Link"
-            to="/cards/positive-number-by-developed-date"
           >
             {{ $t('発症日別による陽性者数の推移はこちら') }}
           </nuxt-link>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5201 

## 📝 関連する issue / Related Issues
- #5194 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「新規患者に関する報告件数の推移」グラフのタイトルを修正しました。
-  #5194 で実装される「発症日別による陽性者数の推移」グラフのパーマリンクへのリンクボタンを追加しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![コメント 2020-08-07 150707](https://user-images.githubusercontent.com/14883063/89614604-baa5c280-d8bf-11ea-838e-145b384315ac.jpg)
