### PR TITLE
nuxt-i18n.config.ts の`as any`を削除

### DIFF
--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -1,4 +1,4 @@
-import { NuxtVueI18n } from 'nuxt-i18n'
+import type { NuxtVueI18n } from 'nuxt-i18n'
 
 const dateTimeFormatsCommon = {
   dateTime: {

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -27,12 +27,7 @@ const dateTimeFormatsCommon = {
 
 const options: NuxtVueI18n.Options.AllOptionsInterface = {
   strategy: 'prefix_except_default',
-  /*
-   * 型定義には boolean が含まれていないが、明示的に false を指定しないと
-   * 'i18n_redirected' cookie がブラウザに残っている場合にリダイレクトしてしまうため
-   * any 型を経由して false を代入している
-   */
-  detectBrowserLanguage: false as any,
+  detectBrowserLanguage: false,
   defaultLocale: 'ja',
   vueI18n: {
     fallbackLocale: 'ja',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5211

## ⛏ 変更内容 / Details of Changes
- `NuxtVueI18n`のimpor文をimport type文に変更した
  - 型のみの使用であるため
- `detectBrowserLanguage`の`false`についている`as any`と、それについてのコメントを削除した
  - 型定義のバグへの対応としてanyにしていたが、既にそのバグが修正されているため
