### PR TITLE
Reviewdog が適切に動作しない問題を修正

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,6 +30,7 @@ jobs:
       - name: eslint review
         uses: reviewdog/action-eslint@v1
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
           eslint_flags: './**/*.{vue,ts,js}'
 

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   eslint:
     name: check_eslint_error
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: eslint review

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -14,7 +14,6 @@ jobs:
       - name: eslint review
         uses: reviewdog/action-eslint@v1
         with:
-          github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           eslint_flags: './**/*.{vue,ts,js}'
   stylelint:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,11 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Yarn install
+        run: yarn install --frozen-lockfile
+
       - name: eslint review
         uses: reviewdog/action-eslint@v1
         with:
           reporter: github-pr-check
           eslint_flags: './**/*.{vue,ts,js}'
+
   stylelint:
     name: check_stylelint_error
     runs-on: ubuntu-18.04

--- a/components/cards/AgencyCard.vue
+++ b/components/cards/AgencyCard.vue
@@ -30,14 +30,8 @@ export default {
     const labels = AgencyData.labels.map((l) => {
       const dates = l.split('~')
       if (dates.length === 2) {
-        const from = this.$d(
-          getComplementedDate(dates[0]),
-          'dateWithoutYear'
-        )
-        const to = this.$d(
-          getComplementedDate(dates[1]),
-          'dateWithoutYear'
-        )
+        const from = this.$d(getComplementedDate(dates[0]), 'dateWithoutYear')
+        const to = this.$d(getComplementedDate(dates[1]), 'dateWithoutYear')
         return `${from}~${to}`
       } else {
         return ''

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -106,14 +106,8 @@ export default {
 
       const dates = label.split('~')
       if (slashCount === 1 && dates.length === 2) {
-        const from = this.$d(
-          getComplementedDate(dates[0]),
-          'dateWithoutYear'
-        )
-        const to = this.$d(
-          getComplementedDate(dates[1]),
-          'dateWithoutYear'
-        )
+        const from = this.$d(getComplementedDate(dates[0]), 'dateWithoutYear')
+        const to = this.$d(getComplementedDate(dates[1]), 'dateWithoutYear')
         return `${from}~${to}`
       } else {
         return `${dates[0]}~${dates[1]}`

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
         </v-icon>
         {{ item.label }}
       </v-tab>
-      <v-tabs-items v-model="tab" touchless>
+      <v-tabs-items v-model="tab" touchless >
         <v-tab-item v-for="(item, i) in items" :key="i" :value="`tab-${i}`">
           <component :is="item.component" />
         </v-tab-item>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
         </v-icon>
         {{ item.label }}
       </v-tab>
-      <v-tabs-items v-model="tab" touchless >
+      <v-tabs-items v-model="tab" touchless>
         <v-tab-item v-for="(item, i) in items" :key="i" :value="`tab-${i}`">
           <component :is="item.component" />
         </v-tab-item>

--- a/utils/i18nUtils.ts
+++ b/utils/i18nUtils.ts
@@ -1,5 +1,5 @@
 import { LinkPropertyHref } from 'vue-meta'
-import { NuxtVueI18n } from 'nuxt-i18n'
+import type { NuxtVueI18n } from 'nuxt-i18n'
 
 export const getLinksLanguageAlternative = (
   routeBaseName: string,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5038
（パッケージのアップデートも絡むので close はしません）

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- Reviewdog 実行前に Yarn でパッケージをインストール
  - Reviewdog は ESLint がなければ [npm でインストールする](https://github.com/reviewdog/action-eslint/blob/6fe55dfee8be1ff3c8ff89c2de4987bed9483884/entrypoint.sh#L9-L11) ので、開発環境と GitHub Actions で ESLint のインストール方法を揃えました
- [Reviewdog のドキュメント](https://github.com/reviewdog/action-eslint#example-usage) に習って Docker Image を最新のものに更新
- `github_token` を他の GitHub Actions に合わせて `secrets.GITHUB_TOKEN` に変更
- `yarn lint --fix` で既存の ESLint のエラーを修正
  - コンフリクトを避けるために、https://github.com/tokyo-metropolitan-gov/covid19/pull/5212 で対応している部分は除外しました

## 課題
Reviewdog はデフォルトで PR の diff に対する ESLint のエラーのみを表示します。
ESLint や Prettier などのライブラリのアップデート時は、`package.json` や `yarn.lock` にのみ diff が発生するので、Lint が漏れる可能性があります。
development と PR で ESLint のバージョンが異なる場合があるので、development など統合ブランチでも Lint をしないと完璧に防ぐのは難しい気がしています。

ライブラリのアップデート時はコード全体に Lint を実行するなどの仕組みがあると、Renovate の動作確認に関しては自動化できると思います。

## 📸 スクリーンショット / Screenshots

以下のパターンをテストしました。
他にテスト項目があればコメントいただければテストいたします。

### エラーリポート
意図的にフォーマットエラーをコミットして、コードコメントにエラーが表示されることを確認しました。

Commit: https://github.com/tokyo-metropolitan-gov/covid19/pull/5216/commits/2a0ffaa39de93d58027d1e30d940df0ee23d9d78
GitHub Actins: https://github.com/tokyo-metropolitan-gov/covid19/runs/960717626

<details>

```
 eslint review25s
  17:44  error  Delete `·`  prettier/prettier
Run reviewdog/action-eslint@v1
/usr/bin/docker run --name cbf9771b1c3a6840cdb449f98dd7f75222_31e444 --label 8118cb --workdir /github/workspace --rm -e INPUT_GITHUB_TOKEN -e INPUT_REPORTER -e INPUT_ESLINT_FLAGS -e INPUT_LEVEL -e INPUT_FILTER_MODE -e INPUT_FAIL_ON_ERROR -e INPUT_REVIEWDOG_FLAGS -e INPUT_WORKDIR -e INPUT_TOOL_NAME -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/covid19/covid19":"/github/workspace" 8118cb:f9771b1c3a6840cdb449f98dd7f75222
v7.6.0
reviewdog: found at least one result in diff
reviewdog: This is Pull-Request from forked repository.
GitHub token doesn't have write permission of Check API, so reviewdog will
report results via logging command [1].
[1]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
reviewdog: Reporting results for "eslint"
##[error][eslint] reported by reviewdog 🐶
Delete `·`  prettier/prettier

Raw Output:
  17:44  error  Delete `·`  prettier/prettier
```

</details>

![スクリーンショット 2020-08-08 12 05 06](https://user-images.githubusercontent.com/5207601/89701208-973a5080-d96f-11ea-9f3a-fb824adfaf27.png)

### ESLintのバージョン
開発環境の ESLint を `7.5.0` に変更して、GitHub Actions でも同じバージョンを使用していることを確認しました。

Commit: https://github.com/shgtkshruch/covid19/pull/1/commits/5784fb0a9ed130b7335144d1d53eeccc903c49f2
GitHub Actions: https://github.com/shgtkshruch/covid19/runs/960604000
<details> 

```
eslint review24s
    tool_name: eslint
Run reviewdog/action-eslint@v1
/usr/bin/docker run --name cb8347f11376884082aaf1b99b9c37feda_b1f09c --label 8118cb --workdir /github/workspace --rm -e INPUT_REPORTER -e INPUT_ESLINT_FLAGS -e INPUT_GITHUB_TOKEN -e INPUT_LEVEL -e INPUT_FILTER_MODE -e INPUT_FAIL_ON_ERROR -e INPUT_REVIEWDOG_FLAGS -e INPUT_WORKDIR -e INPUT_TOOL_NAME -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/covid19/covid19":"/github/workspace" 8118cb:8347f11376884082aaf1b99b9c37feda
v7.5.0
2020/08/08 01:44:03 [eslint] reported: https://github.com/shgtkshruch/covid19/runs/960605917 (conclusion=success)
```

</details>