### PR TITLE
for文/Array.forEach()を削減 (components/cards/TokyoRulesApplicationNumberCard.vue)

### DIFF
--- a/components/cards/TokyoRulesApplicationNumberCard.vue
+++ b/components/cards/TokyoRulesApplicationNumberCard.vue
@@ -43,16 +43,10 @@ export default {
     MixedBarAndLineChart,
   },
   data() {
-    const applicationReportsCount = []
-    const sevendayMoveAverages = []
-    const labels = []
-
-    TokyoRule.data.forEach((d) => {
-      applicationReportsCount.push(d.count)
-      sevendayMoveAverages.push(d.weekly_average_count)
-      labels.push(d.date)
-    })
-
+    const data = TokyoRule.data
+    const applicationReportsCount = data.map((d) => d.count)
+    const sevendayMoveAverages = data.map((d) => d.weekly_average_count)
+    const labels = data.map((d) => d.date)
     const chartData = [applicationReportsCount, sevendayMoveAverages]
     const dataLabels = [this.$t('適用件数'), this.$t('７日間移動平均')]
     const date = TokyoRule.date


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5219
  - 他にも該当箇所があるので、closeはしない

## ⛏ 変更内容 / Details of Changes
- for文/Array.forEach()とArray.push()の組み合わせで別の配列を作っているところを、Array.map()、Array.filter()などでつくるように修正
