### PR TITLE
for文/Array.forEach()を削減 (components/cards/SevereCaseCard.vue)

### DIFF
--- a/components/cards/SevereCaseCard.vue
+++ b/components/cards/SevereCaseCard.vue
@@ -48,18 +48,13 @@ export default {
     SevereCaseBarChart,
   },
   data() {
-    const graphData = []
-    Data.data
+    const graphData = Data.data
       .filter((d) => new Date(d.date) > new Date('2020-04-26'))
-      .forEach((d) => {
-        const subTotal = d.severe_case
-        if (!isNaN(subTotal)) {
-          graphData.push({
-            label: convertDateToISO8601Format(d.date),
-            transition: subTotal,
-          })
-        }
-      })
+      .filter((d) => !isNaN(d.severe_case))
+      .map((d) => ({
+        label: convertDateToISO8601Format(d.date),
+        transition: d.severe_case,
+      }))
     return {
       Data,
       graphData,


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5219
  - 他にも該当箇所があるので、closeはしない

## ⛏ 変更内容 / Details of Changes
- for文/Array.forEach()とArray.push()の組み合わせで別の配列を作っているところを、Array.map()、Array.filter()などでつくるように修正
