### PR TITLE
for文/Array.forEach()を削減 (components/TimeStackedBarChart.vue)

### DIFF
--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -538,11 +538,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     scaledTicksYAxisMax() {
-      let max = 0
-      for (const i in this.chartData[0]) {
-        max = Math.max(max, this.chartData[0][i] + this.chartData[1][i])
-      }
-      return max
+      return Array.from(this.chartData[0].keys())
+        .map((i) => this.chartData[0][i] + this.chartData[1][i])
+        .reduce((a, b) => Math.max(a, b))
     },
   },
   methods: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -540,7 +540,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     scaledTicksYAxisMax() {
       return Array.from(this.chartData[0].keys())
         .map((i) => this.chartData[0][i] + this.chartData[1][i])
-        .reduce((a, b) => Math.max(a, b))
+        .reduce((a, b) => Math.max(a, b), 0)
     },
   },
   methods: {


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5219
  - 他にも該当箇所があるので、closeはしない

## ⛏ 変更内容 / Details of Changes
- for文/Array.forEach()とArray.push()の組み合わせで別の配列を作っているところを、Array.map()、Array.filter()などでつくるように修正

## 参考リンク
- [Math.max() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Math/max)