### PR TITLE
for文/Array.forEach()を削減 (components/PositiveRateMixedChart.vue)

### DIFF
--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -661,7 +661,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             this.chartData[2][i] +
             this.chartData[3][i]
         )
-        .reduce((a, b) => Math.max(a, b))
+        .reduce((a, b) => Math.max(a, b), 0)
     },
     scaledTicksYAxisMaxRight() {
       return this.chartData[5].reduce((a, b) => Math.max(a, b))

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -510,19 +510,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     displayDataHeader() {
-      let n = 0
-      let max = 0
-      for (const i in this.displayData.datasets[0].data) {
-        const current =
+      const sums = Array.from(this.displayData.datasets[0].data.keys()).map(
+        (i) =>
           this.displayData.datasets[0].data[i] +
           this.displayData.datasets[1].data[i] +
           this.displayData.datasets[2].data[i] +
           this.displayData.datasets[3].data[i]
-        if (current > max) {
-          max = current
-          n = Number(i)
-        }
-      }
+      )
+      const max = sums.reduce((a, b) => Math.max(a, b))
+      const n = sums.indexOf(max)
       return {
         labels: ['2020-01-01'],
         datasets: [
@@ -657,24 +653,18 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     scaledTicksYAxisMax() {
-      let max = 0
-      for (const i in this.chartData[0]) {
-        max = Math.max(
-          max,
-          this.chartData[0][i] +
+      return Array.from(this.chartData[0].keys())
+        .map(
+          (i) =>
+            this.chartData[0][i] +
             this.chartData[1][i] +
             this.chartData[2][i] +
             this.chartData[3][i]
         )
-      }
-      return max
+        .reduce((a, b) => Math.max(a, b))
     },
     scaledTicksYAxisMaxRight() {
-      let max = 0
-      for (const i in this.chartData[5]) {
-        max = Math.max(max, this.chartData[5][i])
-      }
-      return max
+      return this.chartData[5].reduce((a, b) => Math.max(a, b))
     },
   },
   methods: {

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -664,7 +664,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reduce((a, b) => Math.max(a, b), 0)
     },
     scaledTicksYAxisMaxRight() {
-      return this.chartData[5].reduce((a, b) => Math.max(a, b))
+      return this.chartData[5].reduce((a, b) => Math.max(a, b), 0)
     },
   },
   methods: {

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -517,7 +517,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           this.displayData.datasets[2].data[i] +
           this.displayData.datasets[3].data[i]
       )
-      const max = sums.reduce((a, b) => Math.max(a, b))
+      const max = sums.reduce((a, b) => Math.max(a, b), 0)
       const n = sums.indexOf(max)
       return {
         labels: ['2020-01-01'],


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5219
  - 他にも該当箇所があるので、closeはしない

## ⛏ 変更内容 / Details of Changes
- for文/Array.forEach()とArray.push()の組み合わせで別の配列を作っているところを、Array.map()、Array.filter()などでつくるように修正

## 参考リンク
- [Math.max() - JavaScript | MDN](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Math/max)
