### PR TITLE
for文/Array.forEach()を削減 (components/cards/TestedNumberCard.vue)

### DIFF
--- a/components/cards/TestedNumberCard.vue
+++ b/components/cards/TestedNumberCard.vue
@@ -58,17 +58,13 @@ export default {
   },
   data() {
     // 検査実施日別状況
-    const l = Data.inspections_summary.data['都内'].length
-    const domestic = []
-    const insurance = []
-    for (let i = 0; i < l; i++) {
-      domestic.push(
-        Data.inspections_summary.data['都内'][i] +
-          Data.inspections_summary.data['その他'][i]
-      )
-      insurance.push(Data.inspections_summary.data['保険適用分'][i])
-    }
-
+    const { data } = Data.inspections_summary
+    const domestic = Array.from(data['都内'].keys()).map(
+      (i) => data['都内'][i] + data['その他'][i]
+    )
+    const insurance = Array.from(data['都内'].keys()).map(
+      (i) => data['保険適用分'][i]
+    )
     const inspectionsGraph = [domestic, insurance]
     const inspectionsItems = [
       this.$t('健康安全研究センターが行った検査件数'),


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5219
  - 他にも該当箇所があるので、closeはしない

## ⛏ 変更内容 / Details of Changes
- for文/Array.forEach()とArray.push()の組み合わせで別の配列を作っているところを、Array.map()、Array.filter()などでつくるように修正
