### PR TITLE
components/DataSelector.vue の余分なTODO コメントを削除

### DIFF
--- a/components/DataSelector.vue
+++ b/components/DataSelector.vue
@@ -69,7 +69,6 @@ export default Vue.extend({
     targetId: {
       type: String,
       default: (val: string | null) => {
-        // TODO: type は NullableString 型をとり、default: null とする
         return val && val !== '' ? val : null
       },
     },


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5238

## ⛏ 変更内容 / Details of Changes
- `components/DataSelector.vue` にある余分なTODOコメントを削除
  - すぐ下にあるコードをそのまま説明するような内容なので、おそらく実装時に書いたTODOコメントの消し忘れと思われる
