### PR TITLE
"「＃7119」" の太字化・カギカッコ除去

### DIFF
--- a/components/cards/MonitoringItemsOverviewCard.vue
+++ b/components/cards/MonitoringItemsOverviewCard.vue
@@ -10,11 +10,14 @@
           <span>{{ $t('（注）') }}</span>
           <ul>
             <li>
-              {{
-                $t(
-                  '「＃7119」：急病やけがの際に、緊急受診の必要性や診察可能な医療機関をアドバイスする電話相談窓口'
-                )
-              }}
+              <i18n
+                tag="span"
+                path="{number}：急病やけがの際に、緊急受診の必要性や診察可能な医療機関をアドバイスする電話相談窓口"
+              >
+                <template v-slot:number>
+                  <dfn>#7119</dfn>
+                </template>
+              </i18n>
             </li>
             <li>
               {{
@@ -119,5 +122,10 @@ section {
   }
 
   @include button-text('sm');
+}
+
+dfn {
+  font-style: normal;
+  font-weight: bold;
 }
 </style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5218 (not to be closed) 

## ⛏ 変更内容 / Details of Changes
- `「＃7119」` を翻訳対象とせず、またこの部分を正体太字の `<dfn>` タグでマークアップ
- 全角ナンバーサインは半角に置き換え、カギカッコを除去

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/34566290/89965288-674cbf00-dc87-11ea-9893-7ed2c29f514b.png)
