### PR TITLE
カード上部の数値付近にテキスト「７日間移動平均」「７日間移動平均値をもとに算出」を追加

### DIFF
--- a/components/DataViewBasicInfoPanel.vue
+++ b/components/DataViewBasicInfoPanel.vue
@@ -6,6 +6,10 @@
     </span>
     <br v-if="lText !== ''" />
     <small class="DataView-DataInfo-date">{{ sText }}</small>
+    <br v-if="sTextUnder !== ''" />
+    <small v-if="sTextUnder !== ''" class="DataView-DataInfo-date">{{
+      sTextUnder
+    }}</small>
   </div>
 </template>
 
@@ -57,6 +61,11 @@ export default Vue.extend({
     sText: {
       type: String,
       required: true,
+    },
+    sTextUnder: {
+      type: String,
+      required: false,
+      default: '',
     },
     unit: {
       type: String,

--- a/components/DataViewDataSetPanel.vue
+++ b/components/DataViewDataSetPanel.vue
@@ -8,6 +8,10 @@
       </span>
       <br v-if="lText !== ''" />
       <small class="DataView-DataSet-DataInfo-date">{{ sText }}</small>
+      <br v-if="sTextUnder !== ''" />
+      <small v-if="sTextUnder !== ''" class="DataView-DataSet-DataInfo-date">{{
+        sTextUnder
+      }}</small>
     </div>
   </div>
 </template>
@@ -16,19 +20,28 @@
 .DataView {
   &-DataSet {
     display: flex;
-    width: 100%;
+    flex-flow: column;
     margin-bottom: 10px;
+
+    @include largerThan($large) {
+      justify-content: space-between;
+      flex-flow: row;
+    }
 
     &-title {
       font-size: 2rem;
-      flex: 1 1 auto;
+      flex: 1 1 50%;
+      margin-bottom: 10px;
     }
 
     &-DataInfo {
-      text-align: right;
+      flex: 1 1 50%;
+
+      @include largerThan($large) {
+        text-align: right;
+      }
 
       &-summary {
-        flex: 0 1 auto;
         display: inline-block;
         color: $gray-2;
         white-space: nowrap;
@@ -48,7 +61,6 @@
         width: 100%;
         color: $gray-3;
         line-height: initial;
-        text-align: right;
         @include font-size(12);
       }
     }
@@ -74,6 +86,11 @@ export default Vue.extend({
     sText: {
       type: String,
       required: true,
+    },
+    sTextUnder: {
+      type: String,
+      required: false,
+      default: '',
     },
     unit: {
       type: String,

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -75,6 +75,7 @@
         :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
+        :s-text-under="displayInfo[0].sTextUnder"
         :unit="displayInfo[0].unit"
       />
     </template>
@@ -118,6 +119,7 @@ type Computed = {
     {
       lText: string
       sText: string
+      sTextUnder: string
       unit: string
     }
   ]
@@ -236,7 +238,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
             date: lastDay,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
+          })}（${this.$t('７日間移動平均')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
+            this.unit
+          }）`,
           unit: this.unit,
         },
       ]

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -75,6 +75,7 @@
         :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
+        :s-text-under="displayInfo[0].sTextUnder"
         :unit="displayInfo[0].unit"
       />
     </template>
@@ -118,6 +119,7 @@ type Computed = {
     {
       lText: string
       sText: string
+      sTextUnder: string
       unit: string
     }
   ]
@@ -241,7 +243,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
             date: lastDay,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
+          })}（${this.$t('７日間移動平均')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
+            this.unit
+          }）`,
           unit: this.unit,
         },
       ]

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -69,6 +69,7 @@
       <data-view-basic-info-panel
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
+        :s-text-under="displayInfo[0].sTextUnder"
         :unit="displayInfo[0].unit"
       />
     </template>
@@ -111,6 +112,7 @@ type Computed = {
     {
       lText: string
       sText: string
+      sTextUnder: string
       unit: string
     }
   ]
@@ -216,7 +218,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
             date: lastDay,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
+          })}（${this.$t('７日間移動平均')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
+            this.unit
+          }）`,
           unit: this.unit,
         },
       ]

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -87,12 +87,14 @@
         :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
+        :s-text-under="displayInfo[0].sTextUnder"
         :unit="displayInfo[0].unit"
       />
       <data-view-data-set-panel
         :title="infoTitles[1]"
         :l-text="displayInfo[1].lText"
         :s-text="displayInfo[1].sText"
+        :s-text-under="displayInfo[1].sTextUnder"
         :unit="displayInfo[1].unit"
       />
     </template>
@@ -139,6 +141,7 @@ type Methods = {
 type DisplayInfo = {
   lText: string
   sText: string
+  sTextUnder: string
   unit: string
 }
 type Computed = {
@@ -277,14 +280,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
             date: lastDay,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
+          })}（${this.$t('７日間移動平均値をもとに算出')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
+            this.unit
+          }）`,
           unit: this.unit,
         },
         {
           lText: lastDayData4,
           sText: `${this.$t('{date} の数値', {
             date: lastDay4,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio4} ${this.optionUnit}）`,
+          })}（${this.$t('７日間移動平均')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio4} ${
+            this.optionUnit
+          }）`,
           unit: this.optionUnit,
         },
       ]

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -90,12 +90,14 @@
         :title="infoTitles[0]"
         :l-text="displayInfo[0].lText"
         :s-text="displayInfo[0].sText"
+        :s-text-under="displayInfo[0].sTextUnder"
         :unit="displayInfo[0].unit"
       />
       <data-view-data-set-panel
         :title="infoTitles[1]"
         :l-text="displayInfo[1].lText"
         :s-text="displayInfo[1].sText"
+        :s-text-under="displayInfo[1].sTextUnder"
         :unit="displayInfo[1].unit"
       />
     </template>
@@ -133,20 +135,15 @@ type Methods = {
   makeLineData: (value: number) => number[]
   onClickLegend: (i: number) => void
 }
+type DisplayInfo = {
+  lText: string
+  sText: string
+  sTextUnder: string
+  unit: string
+}
 
 type Computed = {
-  displayInfo: [
-    {
-      lText: string
-      sText: string
-      unit: string
-    },
-    {
-      lText: string
-      sText: string
-      unit: string
-    }
-  ]
+  displayInfo: DisplayInfo[]
   displayData: DisplayData
   displayOption: Chart.ChartOptions
   displayDataHeader: DisplayData
@@ -279,14 +276,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
             date: lastDay,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit[0]}）`,
+          })}（${this.$t('７日間移動平均')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
+            this.unit[0]
+          }）`,
           unit: this.unit[0],
         },
         {
           lText: lastDayData3,
           sText: `${this.$t('{date} の数値', {
             date: lastDay3,
-          })}（${this.$t('前日比')}: ${dayBeforeRatio3} ${this.unit[1]}）`,
+          })}（${this.$t('７日間移動平均値をもとに算出')}）`,
+          sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio3} ${
+            this.unit[1]
+          }）`,
           unit: this.unit[1],
         },
       ]


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5186 

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/issues/5186#issuecomment-670483193

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- https://github.com/tokyo-metropolitan-gov/covid19/issues/5186#issuecomment-670483193 の指示どおりにテキストを追加しました。
- モニタリング項目関連グラフのカードタイトルのスタイルを調整しました（モバイルサイズ時に縦に並ぶようにした）。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2020-08-12 12 35 47](https://user-images.githubusercontent.com/14883063/89972531-09c16e00-dc99-11ea-8c1d-1c4220d7bbd7.png)
![スクリーンショット 2020-08-12 12 36 03](https://user-images.githubusercontent.com/14883063/89972541-0ded8b80-dc99-11ea-98a5-664d446b401b.png)
![スクリーンショット 2020-08-12 12 36 19](https://user-images.githubusercontent.com/14883063/89972549-12b23f80-dc99-11ea-8e3b-c0018f1eeb87.png)
![スクリーンショット 2020-08-12 12 36 36](https://user-images.githubusercontent.com/14883063/89972561-16de5d00-dc99-11ea-9a98-0ea1f5f2f5d2.png)
![スクリーンショット 2020-08-12 12 36 48](https://user-images.githubusercontent.com/14883063/89972567-1ba31100-dc99-11ea-8a85-16382b1092f4.png)
![スクリーンショット 2020-08-12 12 37 15](https://user-images.githubusercontent.com/14883063/89972575-2067c500-dc99-11ea-99b1-d2b11b7a550b.png)
