### PR TITLE
npm scriptsから lint-and-generate を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "generate:deploy": "cross-env GENERATE_ENV=production nuxt-ts generate",
     "generate:dev": "cross-env GENERATE_ENV=development nuxt-ts generate",
     "generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
-    "lint-and-generate": "eslint './**/*.{js,ts,vue}' && nuxt-ts generate",
     "test": "echo 'skip tests (there is no test)'",
     "lint": "eslint './**/*.{js,ts,vue}'",
     "lint:fix": "eslint './**/*.{js,ts,vue}' --fix",


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5244

## ⛏ 変更内容 / Details of Changes
- npm scriptsから `lint-and-generate` を削除
  - `generate` と内容がまったく同じ
  -  `lint-and-generate` は少なくともこのプロジェクトのコード上では使用されていない
