### PR TITLE
Card component の import の順序に一貫性がなく可読性が悪いので改善する

### DIFF
--- a/components/CardsMonitoring.vue
+++ b/components/CardsMonitoring.vue
@@ -28,6 +28,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import CardRow from '@/components/cards/CardRow.vue'
+
+// NOTE: 以下，ブラウザでの表示順に合わせて component を import する
 // 検査陽性者の状況
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
 // 報告日別による陽性者数の推移

--- a/components/CardsMonitoring.vue
+++ b/components/CardsMonitoring.vue
@@ -28,30 +28,40 @@
 <script lang="ts">
 import Vue from 'vue'
 import CardRow from '@/components/cards/CardRow.vue'
+// 検査陽性者の状況
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
+// 報告日別による陽性者数の推移
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
-import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringConfirmedCasesNumberCard.vue'
-import PositiveRateCard from '@/components/cards/PositiveRateCard.vue'
-import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
-import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
-import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
+// モニタリング項目
 import MonitoringItemsOverviewCard from '@/components/cards/MonitoringItemsOverviewCard.vue'
+// モニタリング項目(1)新規陽性者数
+import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringConfirmedCasesNumberCard.vue'
+// モニタリング項目(2)#7119における発熱等相談件数
 import ConsultationAboutFeverNumberCard from '@/components/cards/ConsultationAboutFeverNumberCard.vue'
+// モニタリング項目(3)新規陽性者における接触歴等不明者数
+import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
+// モニタリング項目(4)検査の陽性率
+import PositiveRateCard from '@/components/cards/PositiveRateCard.vue'
+// モニタリング項目(5)救急医療の東京ルールの適用件数
 import TokyoRulesApplicationNumberCard from '@/components/cards/TokyoRulesApplicationNumberCard.vue'
+// モニタリング項目(6)入院患者数
+import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
+// モニタリング項目(7)重症患者数
+import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
 
 export default Vue.extend({
   components: {
     CardRow,
-    MonitoringConfirmedCasesNumberCard,
-    UntrackedRateCard,
-    SevereCaseCard,
-    PositiveRateCard,
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
-    HospitalizedNumberCard,
-    ConsultationAboutFeverNumberCard,
-    TokyoRulesApplicationNumberCard,
     MonitoringItemsOverviewCard,
+    MonitoringConfirmedCasesNumberCard,
+    ConsultationAboutFeverNumberCard,
+    UntrackedRateCard,
+    PositiveRateCard,
+    TokyoRulesApplicationNumberCard,
+    HospitalizedNumberCard,
+    SevereCaseCard,
   },
 })
 </script>

--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -30,6 +30,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import CardRow from '@/components/cards/CardRow.vue'
+
+// NOTE: 以下，ブラウザでの表示順に合わせて component を import する
 // 陽性者の属性
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
 // 陽性者数（区市町村別）

--- a/components/CardsReference.vue
+++ b/components/CardsReference.vue
@@ -3,7 +3,7 @@
     <card-row class="DataBlock">
       <!-- 陽性者の属性 -->
       <confirmed-cases-attributes-card />
-      <!-- 区市町村別患者数 -->
+      <!-- 陽性者数（区市町村別） -->
       <confirmed-cases-by-municipalities-card />
       <!-- 発症日別による陽性者数の推移 -->
       <positive-number-by-developed-date-card />
@@ -30,28 +30,37 @@
 <script lang="ts">
 import Vue from 'vue'
 import CardRow from '@/components/cards/CardRow.vue'
+// 陽性者の属性
 import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
+// 陽性者数（区市町村別）
 import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'
-import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
-import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
-import MetroCard from '@/components/cards/MetroCard.vue'
-import AgencyCard from '@/components/cards/AgencyCard.vue'
-import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
-import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
+// 発症日別による陽性者数の推移
 import PositiveNumberByDevelopedDateCard from '@/components/cards/PositiveNumberByDevelopedDateCard.vue'
+// 確定日別による陽性者数の推移
+import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
+// 検査実施件数
+import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
+// 受診相談窓口における相談件数
+import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
+// 新型コロナコールセンター相談件数
+import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
+// 都営地下鉄の利用者数の推移
+import MetroCard from '@/components/cards/MetroCard.vue'
+// 都庁来庁者数の推移
+import AgencyCard from '@/components/cards/AgencyCard.vue'
 
 export default Vue.extend({
   components: {
     CardRow,
     ConfirmedCasesAttributesCard,
     ConfirmedCasesByMunicipalitiesCard,
+    PositiveNumberByDevelopedDateCard,
+    PositiveNumberByDiagnosedDateCard,
     TestedNumberCard,
     MonitoringConsultationDeskReportsNumberCard,
     TelephoneAdvisoryReportsNumberCard,
     MetroCard,
     AgencyCard,
-    PositiveNumberByDiagnosedDateCard,
-    PositiveNumberByDevelopedDateCard,
   },
 })
 </script>

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script>
+// NOTE: 以下，ブラウザでの表示順に合わせて component を import する
 // ---- モニタリング項目
 // 検査陽性者の状況
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
@@ -73,6 +74,7 @@ export default {
   data() {
     let title, updatedAt, cardComponent
     switch (this.$route.params.card) {
+      // NOTE: 以下，ブラウザでの表示順に合わせて条件分岐を行う
       // ---- モニタリング項目
       // 検査陽性者の状況
       case 'details-of-confirmed-cases':

--- a/pages/cards/_card.vue
+++ b/pages/cards/_card.vue
@@ -3,108 +3,153 @@
 </template>
 
 <script>
+// ---- モニタリング項目
+// 検査陽性者の状況
 import ConfirmedCasesDetailsCard from '@/components/cards/ConfirmedCasesDetailsCard.vue'
+// 報告日別による陽性者数の推移
 import ConfirmedCasesNumberCard from '@/components/cards/ConfirmedCasesNumberCard.vue'
-import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
-import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'
-import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
-import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
-import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringConfirmedCasesNumberCard.vue'
-import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
-import MetroCard from '@/components/cards/MetroCard.vue'
-import AgencyCard from '@/components/cards/AgencyCard.vue'
-import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
-import PositiveRateCard from '@/components/cards/PositiveRateCard.vue'
-import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
-import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
-import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
-import ConsultationAboutFeverNumberCard from '@/components/cards/ConsultationAboutFeverNumberCard.vue'
-import TokyoRulesApplicationNumberCard from '@/components/cards/TokyoRulesApplicationNumberCard.vue'
+// モニタリング項目
 import MonitoringItemsOverviewCard from '@/components/cards/MonitoringItemsOverviewCard.vue'
+// モニタリング項目(1)新規陽性者数
+import MonitoringConfirmedCasesNumberCard from '@/components/cards/MonitoringConfirmedCasesNumberCard.vue'
+// モニタリング項目(2)#7119における発熱等相談件数
+import ConsultationAboutFeverNumberCard from '@/components/cards/ConsultationAboutFeverNumberCard.vue'
+// モニタリング項目(3)新規陽性者における接触歴等不明者数
+import UntrackedRateCard from '@/components/cards/UntrackedRateCard.vue'
+// モニタリング項目(4)検査の陽性率
+import PositiveRateCard from '@/components/cards/PositiveRateCard.vue'
+// モニタリング項目(5)救急医療の東京ルールの適用件数
+import TokyoRulesApplicationNumberCard from '@/components/cards/TokyoRulesApplicationNumberCard.vue'
+// モニタリング項目(6)入院患者数
+import HospitalizedNumberCard from '@/components/cards/HospitalizedNumberCard.vue'
+// モニタリング項目(7)重症患者数
+import SevereCaseCard from '@/components/cards/SevereCaseCard.vue'
+// ---- その他 参考指標
+// 陽性者の属性
+import ConfirmedCasesAttributesCard from '@/components/cards/ConfirmedCasesAttributesCard.vue'
+// 陽性者数（区市町村別）
+import ConfirmedCasesByMunicipalitiesCard from '@/components/cards/ConfirmedCasesByMunicipalitiesCard.vue'
+// 発症日別による陽性者数の推移
 import PositiveNumberByDevelopedDateCard from '@/components/cards/PositiveNumberByDevelopedDateCard.vue'
+// 確定日別による陽性者数の推移
+import PositiveNumberByDiagnosedDateCard from '@/components/cards/PositiveNumberByDiagnosedDateCard.vue'
+// 検査実施件数
+import TestedNumberCard from '@/components/cards/TestedNumberCard.vue'
+// 受診相談窓口における相談件数
+import MonitoringConsultationDeskReportsNumberCard from '@/components/cards/MonitoringConsultationDeskReportsNumberCard.vue'
+// 新型コロナコールセンター相談件数
+import TelephoneAdvisoryReportsNumberCard from '@/components/cards/TelephoneAdvisoryReportsNumberCard.vue'
+// 都営地下鉄の利用者数の推移
+import MetroCard from '@/components/cards/MetroCard.vue'
+// 都庁来庁者数の推移
+import AgencyCard from '@/components/cards/AgencyCard.vue'
+
 import { getLinksLanguageAlternative } from '@/utils/i18nUtils'
 
 export default {
   components: {
-    MonitoringConfirmedCasesNumberCard,
-    SevereCaseCard,
-    MonitoringConsultationDeskReportsNumberCard,
-    PositiveRateCard,
-    UntrackedRateCard,
+    // ---- モニタリング項目
     ConfirmedCasesDetailsCard,
     ConfirmedCasesNumberCard,
+    MonitoringItemsOverviewCard,
+    MonitoringConfirmedCasesNumberCard,
+    ConsultationAboutFeverNumberCard,
+    UntrackedRateCard,
+    PositiveRateCard,
+    TokyoRulesApplicationNumberCard,
+    HospitalizedNumberCard,
+    SevereCaseCard,
+    // ---- その他 参考指標
     ConfirmedCasesAttributesCard,
     ConfirmedCasesByMunicipalitiesCard,
+    PositiveNumberByDevelopedDateCard,
+    PositiveNumberByDiagnosedDateCard,
     TestedNumberCard,
+    MonitoringConsultationDeskReportsNumberCard,
     TelephoneAdvisoryReportsNumberCard,
     MetroCard,
     AgencyCard,
-    PositiveNumberByDiagnosedDateCard,
-    HospitalizedNumberCard,
-    ConsultationAboutFeverNumberCard,
-    TokyoRulesApplicationNumberCard,
-    MonitoringItemsOverviewCard,
-    PositiveNumberByDevelopedDateCard,
   },
   data() {
     let title, updatedAt, cardComponent
     switch (this.$route.params.card) {
+      // ---- モニタリング項目
+      // 検査陽性者の状況
       case 'details-of-confirmed-cases':
         cardComponent = 'confirmed-cases-details-card'
         break
+      // 報告日別による陽性者数の推移
       case 'number-of-confirmed-cases':
         cardComponent = 'confirmed-cases-number-card'
         break
-      case 'number-of-confirmed-cases-by-municipalities':
-        cardComponent = 'confirmed-cases-by-municipalities-card'
-        break
-      case 'attributes-of-confirmed-cases':
-        cardComponent = 'confirmed-cases-attributes-card'
-        break
-      case 'number-of-tested':
-        cardComponent = 'tested-number-card'
-        break
-      case 'number-of-reports-to-covid19-telephone-advisory-center':
-        cardComponent = 'telephone-advisory-reports-number-card'
-        break
-      case 'predicted-number-of-toei-subway-passengers':
-        cardComponent = 'metro-card'
-        break
-      case 'agency':
-        cardComponent = 'agency-card'
-        break
-      case 'positive-number-by-diagnosed-date':
-        cardComponent = 'positive-number-by-diagnosed-date-card'
-        break
-      case 'positive-rate':
-        cardComponent = 'positive-rate-card'
-        break
-      case 'monitoring-number-of-confirmed-cases':
-        cardComponent = 'monitoring-confirmed-cases-number-card'
-        break
-      case 'untracked-rate':
-        cardComponent = 'untracked-rate-card'
-        break
-      case 'positive-status-severe-case':
-        cardComponent = 'severe-case-card'
-        break
-      case 'number-of-hospitalized':
-        cardComponent = 'hospitalized-number-card'
-        break
-      case 'monitoring-number-of-reports-to-covid19-consultation-desk':
-        cardComponent = 'monitoring-consultation-desk-reports-number-card'
-        break
+      // モニタリング項目
       case 'monitoring-items-overview':
         cardComponent = 'monitoring-items-overview-card'
         break
+      // モニタリング項目(1)新規陽性者数
+      case 'monitoring-number-of-confirmed-cases':
+        cardComponent = 'monitoring-confirmed-cases-number-card'
+        break
+      // モニタリング項目(2)#7119における発熱等相談件数
       case 'number-of-reports-to-consultations-about-fever-in-7119':
         cardComponent = 'consultation-about-fever-number-card'
         break
+      // モニタリング項目(3)新規陽性者における接触歴等不明者数
+      case 'untracked-rate':
+        cardComponent = 'untracked-rate-card'
+        break
+      // モニタリング項目(4)検査の陽性率
+      case 'positive-rate':
+        cardComponent = 'positive-rate-card'
+        break
+      // モニタリング項目(5)救急医療の東京ルールの適用件数
       case 'number-of-tokyo-rules-applied':
         cardComponent = 'tokyo-rules-application-number-card'
         break
+      // モニタリング項目(6)入院患者数
+      case 'number-of-hospitalized':
+        cardComponent = 'hospitalized-number-card'
+        break
+      // モニタリング項目(7)重症患者数
+      case 'positive-status-severe-case':
+        cardComponent = 'severe-case-card'
+        break
+      // ---- その他 参考指標
+      // 陽性者の属性
+      case 'attributes-of-confirmed-cases':
+        cardComponent = 'confirmed-cases-attributes-card'
+        break
+      // 陽性者数（区市町村別）
+      case 'number-of-confirmed-cases-by-municipalities':
+        cardComponent = 'confirmed-cases-by-municipalities-card'
+        break
+      // 発症日別による陽性者数の推移
       case 'positive-number-by-developed-date':
         cardComponent = 'positive-number-by-developed-date-card'
+        break
+      // 確定日別による陽性者数の推移
+      case 'positive-number-by-diagnosed-date':
+        cardComponent = 'positive-number-by-diagnosed-date-card'
+        break
+      // 検査実施件数
+      case 'number-of-tested':
+        cardComponent = 'tested-number-card'
+        break
+      // 受診相談窓口における相談件数
+      case 'monitoring-number-of-reports-to-covid19-consultation-desk':
+        cardComponent = 'monitoring-consultation-desk-reports-number-card'
+        break
+      // 新型コロナコールセンター相談件数
+      case 'number-of-reports-to-covid19-telephone-advisory-center':
+        cardComponent = 'telephone-advisory-reports-number-card'
+        break
+      // 都営地下鉄の利用者数の推移
+      case 'predicted-number-of-toei-subway-passengers':
+        cardComponent = 'metro-card'
+        break
+      // 都庁来庁者数の推移
+      case 'agency':
+        cardComponent = 'agency-card'
     }
 
     return {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5272

## ⛏ 変更内容 / Details of Changes
- 以下のファイルでは `components/cards` 以下の多数の component を import しているが，その順序が一貫しておらず可読性が悪いため，https://stopcovid19.metro.tokyo.lg.jp/ で表示されている順序に合わせて並べ替え，適切にコメントも付加する．
  - `components/CardsMonitoring.vue`
  - `components/CardsReference.vue`
  - `pages/cards/_card.vue`
- また，export される components オブジェクトの内部でも component の順序を同様に並び替える．