### PR TITLE
Fix #5208 ツールチップに日付表記の揺れがある

### DIFF
--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -79,6 +79,7 @@ import {
 
 import { getGraphSeriesStyle } from '@/utils/colors'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
+import { getComplementedDate } from '@/utils/formatDate'
 
 type Data = {
   dataKind: 'transition'
@@ -255,6 +256,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOption() {
+      const self = this
       const unit = this.unit
       const options: Chart.ChartOptions = {
         tooltips: {
@@ -267,11 +269,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               return `${parseInt(tooltipItem.value!).toLocaleString()} ${unit}`
             },
             title(tooltipItem, data) {
-              if (tooltipItem[0].datasetIndex! < 2) {
-                const date = data.labels![tooltipItem[0].index!].toString()
-                return dayjs(date).format('M月D日')
-              }
-              return ''
+              const label = data.labels![tooltipItem[0].index!] as string
+              return self.$d(getComplementedDate(label), 'dateWithoutYear')
             },
           },
         },

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -267,7 +267,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               return `${parseInt(tooltipItem.value!).toLocaleString()} ${unit}`
             },
             title(tooltipItem, data) {
-              return data.labels![tooltipItem[0].index!] as string[]
+              if (tooltipItem[0].datasetIndex! < 2) {
+                const date = data.labels![tooltipItem[0].index!].toString()
+                return dayjs(date).format('M月D日')
+              }
+              return ''
             },
           },
         },

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -101,6 +101,7 @@ import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
+import { getComplementedDate } from '@/utils/formatDate'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
 
 type Data = {
@@ -300,6 +301,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
+      const self = this
       const unit = this.unit
       const options: Chart.ChartOptions = {
         tooltips: {
@@ -314,8 +316,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               } : ${cases} ${unit}`
             },
             title(tooltipItem, data) {
-              const date = data.labels![tooltipItem[0].index!].toString()
-              return dayjs(date).format('M月D日')
+              const label = data.labels![tooltipItem[0].index!] as string
+              return self.$d(getComplementedDate(label), 'dateWithoutYear')
             },
           },
         },

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -315,7 +315,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             title(tooltipItem, data) {
               const date = data.labels![tooltipItem[0].index!].toString()
-              return dayjs(date).format('M/D')
+              return dayjs(date).format('M月D日')
             },
           },
         },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -314,7 +314,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             title(tooltipItem, data) {
               if (tooltipItem[0].datasetIndex! < 2) {
                 const date = data.labels![tooltipItem[0].index!].toString()
-                return dayjs(date).format('M/D')
+                return dayjs(date).format('M月D日')
               }
               return ''
             },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -101,6 +101,7 @@ import ScrollableChart from '@/components/ScrollableChart.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters'
+import { getComplementedDate } from '@/utils/formatDate'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
 
 type Data = {
@@ -298,6 +299,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
+      const self = this
       const unit = this.unit
       const options: Chart.ChartOptions = {
         tooltips: {
@@ -313,8 +315,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             title(tooltipItem, data) {
               if (tooltipItem[0].datasetIndex! < 2) {
-                const date = data.labels![tooltipItem[0].index!].toString()
-                return dayjs(date).format('M月D日')
+                const label = data.labels![tooltipItem[0].index!] as string
+                return self.$d(getComplementedDate(label), 'dateWithoutYear')
               }
               return ''
             },

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -285,8 +285,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               } : ${cases} ${unit}`
             },
             title(tooltipItem, data) {
-              const date = data.labels![tooltipItem[0].index!].toString()
-              return dayjs(date).format('M/D')
+              if (tooltipItem[0].datasetIndex! < 2) {
+                const date = data.labels![tooltipItem[0].index!].toString()
+                return dayjs(date).format('M月D日')
+              }
+              return ''
             },
           },
         },

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -95,6 +95,7 @@ import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
+import { getComplementedDate } from '@/utils/formatDate'
 
 type Data = {
   canvas: boolean
@@ -273,6 +274,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
+      const self = this
       const unit = this.unit
       const options: Chart.ChartOptions = {
         tooltips: {
@@ -285,11 +287,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               } : ${cases} ${unit}`
             },
             title(tooltipItem, data) {
-              if (tooltipItem[0].datasetIndex! < 2) {
-                const date = data.labels![tooltipItem[0].index!].toString()
-                return dayjs(date).format('M月D日')
-              }
-              return ''
+              const label = data.labels![tooltipItem[0].index!] as string
+              return self.$d(getComplementedDate(label), 'dateWithoutYear')
             },
           },
         },

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -196,7 +196,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               return labelText
             },
             title(tooltipItem, data) {
-              return data.labels![tooltipItem[0].index!] as string[]
+              if (tooltipItem[0].datasetIndex! < 2) {
+                const date = data.labels![tooltipItem[0].index!].toString()
+                return dayjs(date).format('M月D日')
+              }
+              return ''
             },
           },
         },

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -66,6 +66,7 @@ import OpenDataLink from '@/components/OpenDataLink.vue'
 import { DisplayData, yAxesBgPlugin } from '@/plugins/vue-chart'
 import { getGraphSeriesStyle } from '@/utils/colors'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
+import { getComplementedDate } from '@/utils/formatDate'
 
 type Data = {
   canvas: boolean
@@ -183,6 +184,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOption() {
+      const self = this
       const unit = this.unit
       const scaledTicksYAxisMax = this.scaledTicksYAxisMax
       const options: Chart.ChartOptions = {
@@ -196,11 +198,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               return labelText
             },
             title(tooltipItem, data) {
-              if (tooltipItem[0].datasetIndex! < 2) {
-                const date = data.labels![tooltipItem[0].index!].toString()
-                return dayjs(date).format('M月D日')
-              }
-              return ''
+              const label = data.labels![tooltipItem[0].index!] as string
+              return self.$d(getComplementedDate(label), 'dateWithoutYear')
             },
           },
         },

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -404,7 +404,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               if (tooltipItem[0].datasetIndex! < 4) {
                 const date = dayjs(
                   data.labels![tooltipItem[0].index!].toString()
-                ).format('M/D')
+                ).format('M月D日')
                 return String(date)
               }
               return ''

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -123,6 +123,7 @@ import {
 import { getGraphSeriesColor, SurfaceStyle } from '@/utils/colors'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters'
 import { calcDayBeforeRatio } from '@/utils/formatDayBeforeRatio'
+import { getComplementedDate } from '@/utils/formatDate'
 
 type Data = {
   canvas: boolean
@@ -381,6 +382,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
+      const self = this
       const unit = this.unit[1]
       const getFormatter = this.getFormatter
       const options: Chart.ChartOptions = {
@@ -402,10 +404,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             title(tooltipItem, data) {
               if (tooltipItem[0].datasetIndex! < 4) {
-                const date = dayjs(
-                  data.labels![tooltipItem[0].index!].toString()
-                ).format('M月D日')
-                return String(date)
+                const label = data.labels![tooltipItem[0].index!] as string
+                return self.$d(getComplementedDate(label), 'dateWithoutYear')
               }
               return ''
             },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #5208 ツールチップに日付表記の揺れがある


## ⛏ 変更内容 / Details of Changes
- グラフのツールチップにおける日付表示形式を「M月D日」に統一

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/47020182/90269201-36d97080-de93-11ea-9b36-7960ece3f3df.png)
![image](https://user-images.githubusercontent.com/47020182/90269253-540e3f00-de93-11ea-88de-ff7a1d55be54.png)
![image](https://user-images.githubusercontent.com/47020182/90269327-6c7e5980-de93-11ea-9d53-37c9fb2072f5.png)

