### PR TITLE
「都内の最新感染動向」ページ内の外部リンクに外部リンクであることを示すアイコンを追加

### DIFF
--- a/components/MonitoringCommentCard.vue
+++ b/components/MonitoringCommentCard.vue
@@ -24,13 +24,11 @@
         }}
       </p>
       <v-icon color="#D9D9D9">mdi-chevron-right</v-icon>
-      <a
-        href="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/monitoring.html"
-        target="_blank"
-        rel="noopener noreferrer"
+      <external-link
+        url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/monitoring.html"
       >
         {{ $t('最新のモニタリング項目の分析・総括コメントについて') }}
-      </a>
+      </external-link>
     </div>
     <div class="MonitoringComment-comments">
       <v-row>
@@ -55,11 +53,13 @@
 
 <script lang="ts">
 import Vue from 'vue'
+import ExternalLink from '@/components/ExternalLink.vue'
 import MonitoringCommentFrame from '@/components/MonitoringCommentFrame.vue'
 import monitoringItems from '@/data/monitoring_items.json'
 
 export default Vue.extend({
   components: {
+    ExternalLink,
     MonitoringCommentFrame,
   },
   data() {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5271

## ⛏ 変更内容 / Details of Changes
- 「[都内の最新感染動向](https://stopcovid19.metro.tokyo.lg.jp/)」ページ内の「最新のモニタリング項目の分析・総括コメントについて」に外部リンクであることを示すアイコン（[mdi-open-in-new](https://materialdesignicons.com/icon/open-in-new)）を追加
   - `ExternalLink.vue` を使用

## 📸 スクリーンショット / Screenshots

### Before

![](https://user-images.githubusercontent.com/20086673/90308301-75b20980-df19-11ea-8220-555e6a367bb3.png)

### After

![](https://user-images.githubusercontent.com/20086673/90308307-7c408100-df19-11ea-838c-4f7038dee237.png)
