### PR TITLE
検査陽性者の状況チャートで使用していない「検査実施人数」に関するtypeとpropsを削除

### DIFF
--- a/components/ConfirmedCasesDetailsTable.vue
+++ b/components/ConfirmedCasesDetailsTable.vue
@@ -96,10 +96,6 @@ import Vue from 'vue'
 /* eslint-disable vue/prop-name-casing */
 export default Vue.extend({
   props: {
-    検査実施人数: {
-      type: Number,
-      required: true,
-    },
     陽性者数: {
       type: Number,
       required: true,

--- a/utils/formatConfirmedCases.ts
+++ b/utils/formatConfirmedCases.ts
@@ -1,6 +1,4 @@
 type DataType = {
-  attr: '検査実施人数'
-  value: number
   children: [
     {
       attr: '陽性患者数'
@@ -46,7 +44,6 @@ type DataType = {
 }
 
 type ConfirmedCasesType = {
-  検査実施人数: number
   陽性者数: number
   入院中: number
   軽症中等症: number
@@ -64,8 +61,8 @@ interface ChildData {
 }
 
 type ChildDataType = {
-  attr: string
-  value: number
+  attr?: string
+  value?: number
   children?: ChildData[]
 }
 
@@ -98,7 +95,6 @@ function getSelectedItem(data: DataType, key: string) {
  */
 export default (data: DataType) => {
   return {
-    検査実施人数: getSelectedItem(data, '検査実施人数'),
     陽性者数: getSelectedItem(data, '陽性患者数'),
     入院中: getSelectedItem(data, '入院中'),
     軽症中等症: getSelectedItem(data, '軽症・中等症'),


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5305 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「検査陽性者の状況」チャートについて「検査実施人数」に関する部分を削除しました。
- data.jsonの `main_summary` の `"attr": "検査実施人数",` `"value": 0,` が削除される前提で修正しました。
なので、 `main_summary` の直下はいきなり `children` となります。ここの `children` は削除（階層を１段階あげる）してもいいように思いました。

見た目に変更ないことを確認しました。
![localhost](https://user-images.githubusercontent.com/14883063/90608579-c8533480-e23d-11ea-85b1-c6a1fff2a4c1.jpg)
