### PR TITLE
「モニタリング項目」テーブルの「確保病床」について，thousands separator を表示する

### DIFF
--- a/components/MonitoringItemsOverviewTableInfectionStatus.vue
+++ b/components/MonitoringItemsOverviewTableInfectionStatus.vue
@@ -6,6 +6,7 @@
         <monitoring-items-overview-table-value-with-translatable-unit
           :value="items['(1)新規陽性者数'].value"
           :unit="items['(1)新規陽性者数'].unit"
+          :bold="items['(1)新規陽性者数'].bold"
         />
       </div>
     </li>
@@ -34,6 +35,11 @@
                   '(2)#7119（東京消防庁救急相談センター）における発熱等相談件数 '
                 ].unit
               "
+              :bold="
+                items[
+                  '(2)#7119（東京消防庁救急相談センター）における発熱等相談件数 '
+                ].bold
+              "
             />
           </div>
         </li>
@@ -52,6 +58,9 @@
                   :unit="
                     items['(3)新規陽性者における接触歴等不明者（人数）'].unit
                   "
+                  :bold="
+                    items['(3)新規陽性者における接触歴等不明者（人数）'].bold
+                  "
                 />
               </div>
             </li>
@@ -64,6 +73,9 @@
                   "
                   :unit="
                     items['(3)新規陽性者における接触歴等不明者（増加比）'].unit
+                  "
+                  :bold="
+                    items['(3)新規陽性者における接触歴等不明者（増加比）'].bold
                   "
                 />
               </div>

--- a/components/MonitoringItemsOverviewTableMedicalSystem.vue
+++ b/components/MonitoringItemsOverviewTableMedicalSystem.vue
@@ -62,7 +62,11 @@
             <li :class="[$style.box]">
               <div :class="$style.content">
                 <span>{{ $t('確保病床') }}</span>
-                <span>{{ items['(6)入院患者確保病床数'].value }}</span>
+                <monitoring-items-overview-table-value-with-translatable-unit
+                  :value="items['(6)入院患者確保病床数'].value"
+                  :unit="items['(6)入院患者確保病床数'].unit"
+                  :bold="items['(6)入院患者確保病床数'].bold"
+                />
               </div>
             </li>
           </ul>
@@ -80,7 +84,11 @@
             <li :class="[$style.box]">
               <div :class="$style.content">
                 <span>{{ $t('確保病床') }}</span>
-                <span>{{ items['(7)重症患者確保病床数'].value }}</span>
+                <monitoring-items-overview-table-value-with-translatable-unit
+                  :value="items['(7)重症患者確保病床数'].value"
+                  :unit="items['(7)重症患者確保病床数'].unit"
+                  :bold="items['(7)重症患者確保病床数'].bold"
+                />
               </div>
             </li>
           </ul>

--- a/components/MonitoringItemsOverviewTableMedicalSystem.vue
+++ b/components/MonitoringItemsOverviewTableMedicalSystem.vue
@@ -16,6 +16,7 @@
                 <monitoring-items-overview-table-value-with-translatable-unit
                   :value="items['(4)PCR・抗原検査（陽性率）'].value"
                   :unit="items['(4)PCR・抗原検査（陽性率）'].unit"
+                  :bold="items['(4)PCR・抗原検査（検査人数）'].bold"
                 />
               </div>
             </li>
@@ -25,6 +26,7 @@
                 <monitoring-items-overview-table-value-with-translatable-unit
                   :value="items['(4)PCR・抗原検査（検査人数）'].value"
                   :unit="items['(4)PCR・抗原検査（検査人数）'].unit"
+                  :bold="items['(4)PCR・抗原検査（検査人数）'].bold"
                 />
               </div>
             </li>
@@ -43,6 +45,7 @@
             <monitoring-items-overview-table-value-with-translatable-unit
               :value="items['(5)救急医療の東京ルールの適用件数'].value"
               :unit="items['(5)救急医療の東京ルールの適用件数'].unit"
+              :bold="items['(5)救急医療の東京ルールの適用件数'].bold"
             />
           </div>
         </li>
@@ -52,6 +55,7 @@
             <monitoring-items-overview-table-value-with-translatable-unit
               :value="items['(6)入院患者数'].value"
               :unit="items['(6)入院患者数'].unit"
+              :bold="items['(6)入院患者数'].bold"
             />
           </div>
           <ul :class="$style.group">
@@ -69,6 +73,7 @@
             <monitoring-items-overview-table-value-with-translatable-unit
               :value="items['(7)重症患者数'].value"
               :unit="items['(7)重症患者数'].unit"
+              :bold="items['(7)重症患者数'].bold"
             />
           </div>
           <ul :class="$style.group">

--- a/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
+++ b/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
@@ -4,8 +4,7 @@
       ><strong>{{ value }}</strong></span
     >
     <span v-else>{{ value }}</span>
-    <span v-if="unit.translatable">{{ $t(unit.text) }}</span>
-    <span v-else>{{ unit.text }}</span>
+    <span v-if="translatedUnit">{{ translatedUnit }}</span>
   </span>
 </template>
 
@@ -27,6 +26,26 @@ export default Vue.extend({
     bold: {
       type: Boolean,
       required: true,
+    },
+  },
+  data() {
+    return {
+      currentLocaleCode: this.$root.$i18n.locale,
+    }
+  },
+  computed: {
+    translatedUnit() {
+      const unit = this.unit
+      const { text, translatable, except } = unit
+      if (translatable) {
+        if (except && except.includes(String(this.currentLocaleCode))) {
+          return null
+        }
+
+        return this.$t(unit.text)
+      }
+
+      return text
     },
   },
 })

--- a/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
+++ b/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
@@ -21,6 +21,10 @@ export default Vue.extend({
       type: Object as PropType<Unit>,
       required: true,
     },
+    bold: {
+      type: Boolean,
+      required: true,
+    },
   },
 })
 </script>

--- a/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
+++ b/components/MonitoringItemsOverviewTableValueWithTranslatableUnit.vue
@@ -1,6 +1,9 @@
 <template>
   <span :class="$style.parent">
-    <strong>{{ value }}</strong>
+    <span v-if="bold"
+      ><strong>{{ value }}</strong></span
+    >
+    <span v-else>{{ value }}</span>
     <span v-if="unit.translatable">{{ $t(unit.text) }}</span>
     <span v-else>{{ unit.text }}</span>
   </span>

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -55,6 +55,7 @@ export type Unit = {
 interface MonitoringItemValue {
   value: string
   unit: Unit | null // 元データに無いので独自に追加, 単位がない場合は null
+  bold: boolean // 太字で表示するか否かの設定
 }
 
 export type MonitoringItems = Record<DataKey, MonitoringItemValue>
@@ -79,6 +80,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
     '(1)新規陽性者数': {
       value: toNumberIn10thPlace(rawDataObj['(1)新規陽性者数']),
       unit: unitPerson,
+      bold: true,
     },
     '(2)#7119（東京消防庁救急相談センター）における発熱等相談件数 ': {
       value: toNumberIn10thPlace(
@@ -87,36 +89,43 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
         ]
       ),
       unit: unitReports,
+      bold: true,
     },
     '(3)新規陽性者における接触歴等不明者（人数）': {
       value: toNumberIn10thPlace(
         rawDataObj['(3)新規陽性者における接触歴等不明者（人数）']
       ),
       unit: unitPerson,
+      bold: true,
     },
     '(3)新規陽性者における接触歴等不明者（増加比）': {
       value: toNumberIn10thPlace(
         rawDataObj['(3)新規陽性者における接触歴等不明者（増加比）']
       ),
       unit: unitPercentage,
+      bold: true,
     },
     '(4)PCR・抗原検査（検査人数）': {
       value: toNumberIn10thPlace(rawDataObj['(4)PCR・抗原検査（検査人数）']),
       unit: unitPerson,
+      bold: true,
     },
     '(4)PCR・抗原検査（陽性率）': {
       value: toNumberIn10thPlace(rawDataObj['(4)PCR・抗原検査（陽性率）']),
       unit: unitPercentage,
+      bold: true,
     },
     '(5)救急医療の東京ルールの適用件数': {
       value: toNumberIn10thPlace(
         rawDataObj['(5)救急医療の東京ルールの適用件数']
       ),
       unit: unitReports,
+      bold: true,
     },
     '(6)入院患者数': {
       value: toInteger(rawDataObj['(6)入院患者数']),
       unit: unitPerson,
+      bold: true,
     },
     '(6)入院患者確保病床数': {
       // NOTE:
@@ -129,10 +138,12 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
         parseInt(`${rawDataObj['(6)入院患者確保病床数']}`.replace(/床$/, ''))
       ),
       unit: null,
+      bold: false,
     },
     '(7)重症患者数': {
       value: toInteger(rawDataObj['(7)重症患者数']),
       unit: unitPerson,
+      bold: true,
     },
     '(7)重症患者確保病床数': {
       // NOTE:
@@ -145,6 +156,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
         parseInt(`${rawDataObj['(7)重症患者確保病床数']}`.replace(/床$/, ''))
       ),
       unit: null,
+      bold: false,
     },
   }
 }

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -26,9 +26,9 @@ type RawData = {
   '(4)PCR・抗原検査（検査人数）': number
   '(5)救急医療の東京ルールの適用件数': number
   '(6)入院患者数': number
-  '(6)入院患者確保病床数': string
+  '(6)入院患者確保病床数': number
   '(7)重症患者数': number
-  '(7)重症患者確保病床数': string
+  '(7)重症患者確保病床数': number
 }
 
 interface Comment {
@@ -119,7 +119,15 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       unit: unitPerson,
     },
     '(6)入院患者確保病床数': {
-      value: rawDataObj['(6)入院患者確保病床数'],
+      // NOTE:
+      //   data/monitoring_items.json の '(6)入院患者確保病床数' の値が String 型のため，
+      //   末尾の「床」を除去して Integer 型に変換している．
+      // TODO: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にする．
+      // NOTE: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にしても動作するようにしてある．
+      // TODO: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にした後，書き換える．
+      value: toInteger(
+        parseInt(`${rawDataObj['(6)入院患者確保病床数']}`.replace(/床$/, ''))
+      ),
       unit: null,
     },
     '(7)重症患者数': {
@@ -127,7 +135,15 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       unit: unitPerson,
     },
     '(7)重症患者確保病床数': {
-      value: rawDataObj['(7)重症患者確保病床数'],
+      // NOTE:
+      //   data/monitoring_items.json の '(7)重症患者確保病床数' の値が String 型のため，
+      //   末尾の「床」を除去して Integer 型に変換している．
+      // TODO: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にする．
+      // NOTE: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にしても動作するようにしてある．
+      // TODO: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にした後，書き換える．
+      value: toInteger(
+        parseInt(`${rawDataObj['(7)重症患者確保病床数']}`.replace(/床$/, ''))
+      ),
       unit: null,
     },
   }

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -72,6 +72,10 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
     translatable: true,
   }
   const unitPercentage: Unit = { text: '%', translatable: false }
+  const unitBed: Unit = {
+    text: '床',
+    translatable: true,
+  }
 
   const toInteger = getCommaSeparatedNumberToFixedFunction(0)
   const toNumberIn10thPlace = getCommaSeparatedNumberToFixedFunction(1)
@@ -137,7 +141,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       value: toInteger(
         parseInt(`${rawDataObj['(6)入院患者確保病床数']}`.replace(/床$/, ''))
       ),
-      unit: null,
+      unit: unitBed,
       bold: false,
     },
     '(7)重症患者数': {
@@ -155,7 +159,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       value: toInteger(
         parseInt(`${rawDataObj['(7)重症患者確保病床数']}`.replace(/床$/, ''))
       ),
-      unit: null,
+      unit: unitBed,
       bold: false,
     },
   }

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -48,8 +48,9 @@ type RawDataComment = {
 // フォーマット済み モニタリング指標データ用
 
 export type Unit = {
-  text: string // *********** もとの日本語のテキスト
-  translatable: boolean // ** 翻訳が必要かどうか
+  text: string // もとの日本語のテキスト
+  translatable: boolean // 翻訳が必要かどうか
+  except?: Array<String> // 翻訳しない言語の配列
 }
 
 interface MonitoringItemValue {
@@ -75,6 +76,8 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
   const unitBed: Unit = {
     text: '床',
     translatable: true,
+    // 英語では対応する単位を表示しない
+    except: ['en'],
   }
 
   const toInteger = getCommaSeparatedNumberToFixedFunction(0)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5307 

## 📝 関連する issue / Related Issues
- #5324, #5325 

## ⛏ 変更内容 / Details of Changes
- 「モニタリング項目」テーブルの「(6)入院患者数」，「(7)重症患者数」の「確保病床」について，thousands separator が表示されていなかったため，表示されるように変更した．

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-08-22 2 39 34](https://user-images.githubusercontent.com/23148331/90919103-cb5a4a80-e420-11ea-9c34-a4a8b69f79ba.png)

### After
![スクリーンショット 2020-08-22 2 40 55](https://user-images.githubusercontent.com/23148331/90919174-edec6380-e420-11ea-824f-600964bf9e42.png)
