### PR TITLE
「陽性者数（区市町村別）」の「陽性者数」の値に thousands separator を表示する

### DIFF
--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -28,6 +28,9 @@
 import dayjs from 'dayjs'
 import Data from '@/data/patient.json'
 import ConfirmedCasesByMunicipalitiesTable from '~/components/ConfirmedCasesByMunicipalitiesTable.vue'
+import { getCommaSeparatedNumberToFixedFunction } from '~/utils/monitoringStatusValueFormatters'
+
+const countFormatter = getCommaSeparatedNumberToFixedFunction()
 
 export default {
   components: {
@@ -82,19 +85,15 @@ export default {
     municipalitiesTable.datasets = datasets.data
       .filter((d) => d.label !== '小計')
       .map((d) => {
+        const area = this.$t(d.area)
+        const label = this.$t(d.label)
+        const count = countFormatter(d.count)
+
         if (this.$i18n.locale === 'ja') {
-          return {
-            area: this.$t(d.area),
-            ruby: this.$t(d.ruby),
-            label: this.$t(d.label),
-            count: d.count,
-          }
+          const ruby = this.$t(d.ruby)
+          return { area, ruby, label, count }
         } else {
-          return {
-            area: this.$t(d.area),
-            label: this.$t(d.label),
-            count: d.count,
-          }
+          return { area, label, count }
         }
       })
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5307 

## 📝 関連する issue / Related Issues
- #5323, #5325 

## ⛏ 変更内容 / Details of Changes
-「陽性者数（区市町村別）」の「陽性者数」の値に thousands separator を表示する

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-08-22 3 01 40](https://user-images.githubusercontent.com/23148331/90920829-f6926900-e423-11ea-8d2f-e1c0aeb0da39.png)

### After
![スクリーンショット 2020-08-22 3 02 07](https://user-images.githubusercontent.com/23148331/90920835-f85c2c80-e423-11ea-8ebe-f3e3be804da4.png)