### PR TITLE
「受診相談窓口における相談件数」の tooltip の値に thousands separator を表示する

### DIFF
--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -286,10 +286,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {
-              const cases = tooltipItem.value!.toLocaleString()
-              return `${
-                this.dataLabels[tooltipItem.datasetIndex!]
-              } : ${cases} ${unit}`
+              const labelText = this.dataLabels[tooltipItem.datasetIndex!]
+              const numberAsString = parseInt(
+                tooltipItem.value!
+              ).toLocaleString()
+              return `${labelText} : ${numberAsString} ${unit}`
             },
             title(tooltipItem, data) {
               const label = data.labels![tooltipItem[0].index!] as string


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues 
- #5307 

## 📝 関連する issue / Related Issues
- #5323, #5324 

## ⛏ 変更内容 / Details of Changes
- 「受診相談窓口における相談件数」の tooltip の値に thousands separator を表示されていなかったため，表示されるように変更した

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-08-22 3 13 00](https://user-images.githubusercontent.com/23148331/90921853-ea0f1000-e425-11ea-847e-531a7c358bfe.png)
![スクリーンショット 2020-08-22 3 13 07](https://user-images.githubusercontent.com/23148331/90921860-ec716a00-e425-11ea-9145-8f9345fab8f2.png)

### After
![スクリーンショット 2020-08-22 3 17 27](https://user-images.githubusercontent.com/23148331/90921919-0c089280-e426-11ea-8cd7-ee0fd7e4e713.png)
![スクリーンショット 2020-08-22 18 26 12](https://user-images.githubusercontent.com/23148331/90953292-030ad600-e4a5-11ea-8707-cc54a7fb27c1.png)
