### PR TITLE
カードによって注釈の位置の揺れがあるため統一する

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -1,8 +1,5 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:description>
-      <slot name="description" />
-    </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
@@ -18,6 +15,9 @@
       <client-only>
         <data-view-table :headers="tableHeaders" :items="tableData" />
       </client-only>
+    </template>
+    <template v-slot:additionalDescription>
+      <slot name="additionalDescription" />
     </template>
   </data-view>
 </template>

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -1,8 +1,5 @@
 <template>
   <data-view :title="title" :title-id="titleId" :date="date">
-    <template v-slot:description>
-      <slot name="description" />
-    </template>
     <h4 :id="`${titleId}-graph`" class="visually-hidden">
       {{ $t(`{title}のグラフ`, { title }) }}
     </h4>
@@ -18,6 +15,9 @@
       <client-only>
         <data-view-table :headers="tableHeaders" :items="tableData" />
       </client-only>
+    </template>
+    <template v-slot:additionalDescription>
+      <slot name="additionalDescription" />
     </template>
     <template v-slot:footer>
       <ul>

--- a/components/cards/AgencyCard.vue
+++ b/components/cards/AgencyCard.vue
@@ -9,7 +9,7 @@
         :date="agencyData.date"
         :unit="$t('人')"
       >
-        <template v-slot:description>
+        <template v-slot:additionalDescription>
           {{ $t('※土・日・祝日を除く庁舎開庁日の1週間累計数') }}
         </template>
       </agency-bar-chart>

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -11,8 +11,7 @@
         :tooltips-label="metroGraphTooltipLabel"
         unit="%"
       >
-        <template v-slot:additionalDescription
-          >>
+        <template v-slot:additionalDescription>
           {{
             $t('{range}の利用者数*の平均値を基準としたときの相対値', {
               range: metroGraph.base_period,

--- a/components/cards/MetroCard.vue
+++ b/components/cards/MetroCard.vue
@@ -11,7 +11,8 @@
         :tooltips-label="metroGraphTooltipLabel"
         unit="%"
       >
-        <template v-slot:description>
+        <template v-slot:additionalDescription
+          >>
           {{
             $t('{range}の利用者数*の平均値を基準としたときの相対値', {
               range: metroGraph.base_period,


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #4996 

## 📝 関連する issue / Related Issues
- #5274 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
- 「都営地下鉄の利用者数の推移」「都庁来庁者数の推移」の注釈の位置が他のカードと異なっており、統一感をもたせるため変更を行った
<!-- List down your changes concisely -->


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
### 都営地下鉄の利用者数の推移
上部のテキスト類をグラフ下部に移動した
**before**
<img width="482" alt="スクリーンショット 2020-09-16 12 48 11" src="https://user-images.githubusercontent.com/19372617/93292600-e605c080-f820-11ea-97f9-c81a0cad1b00.png">

**after**
<img width="591" alt="スクリーンショット 2020-09-16 13 33 52" src="https://user-images.githubusercontent.com/19372617/93292981-db97f680-f821-11ea-9555-5d0fc9688494.png">



### 都庁来庁者数の推移
上部のテキスト類をグラフ下部に移動した
**before**
<img width="564" alt="スクリーンショット 2020-09-16 13 37 38" src="https://user-images.githubusercontent.com/19372617/93292991-e18dd780-f821-11ea-83b4-9b3677f0e692.png">


**after**
<img width="479" alt="スクリーンショット 2020-09-16 13 15 27" src="https://user-images.githubusercontent.com/19372617/93292649-f7e76380-f820-11ea-8491-7a2bcfff5902.png">

<!-- Changes in styles would be easier to review with screenshots! -->
