### PR TITLE
「検査陽性者の状況」カードに外部リンク追加

### DIFF
--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -37,6 +37,14 @@
           :aria-label="$t('検査陽性者の状況')"
           v-bind="confirmedCases"
         />
+        <div>
+          <app-link
+            :class="$style.button"
+            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/shibou.html"
+          >
+            {{ $t('死亡日別による死亡者数の推移はこちら') }}
+          </app-link>
+        </div>
       </data-view>
     </client-only>
   </v-col>
@@ -71,3 +79,15 @@ export default {
   },
 }
 </script>
+
+<style lang="scss" module>
+.button {
+  margin: 20px 0 0;
+  color: $green-1 !important;
+  &:hover {
+    color: $white !important;
+  }
+
+  @include button-text('sm');
+}
+</style>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5438

## ⛏ 変更内容 / Details of Changes
- 東京都福祉保健局HPへのリンク追加

## 📸 スクリーンショット / Screenshots
https://deploy-preview-5441--dev-covid19-tokyo.netlify.app/

<kbd><img width="514" alt="feature-5438" src="https://user-images.githubusercontent.com/24243541/93358664-b84e6500-f87c-11ea-8efb-253fd3f4bc77.png"></kbd>