### PR TITLE
nuxt.config.ts で @fullhuman/postcss-purgecss をimport文でインポートする

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,7 @@
+import purgecss from '@fullhuman/postcss-purgecss'
 import { NuxtConfig } from '@nuxt/types'
 
 import i18n from './nuxt-i18n.config'
-const purgecss = require('@fullhuman/postcss-purgecss')
 const autoprefixer = require('autoprefixer')
 const environment = process.env.NODE_ENV || 'development'
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5456

## ⛏ 変更内容 / Details of Changes
- `nuxt.config.ts` で `purgecss` に型をつけるために `@fullhuman/postcss-purgecss` のインポートを `require()` からimport文に変更
 - 記載位置が変更されているのはESLintの `simple-import-sort/sort` ルールによるものです
