### PR TITLE
Vue.prototype の参照エラーを解消する

### DIFF
--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -217,7 +217,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
         },

--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -15,7 +15,7 @@
       <tbody>
         <tr v-for="(item, i) in items" :key="i">
           <th scope="row" class="cardTable-header">
-            {{ item[headerKey] | formatDate }}
+            {{ formatDate(item[headerKey]) }}
           </th>
           <td v-for="(dataKey, j) in dataKeys" :key="j" class="text-end">
             {{ item[dataKey] }}
@@ -45,7 +45,9 @@ export type TableItem = {
   [key: number]: number
 }
 type Data = {}
-type Methods = {}
+type Methods = {
+  formatDate: (dateString: string) => string
+}
 type Computed = {
   dataKeys: string[]
 }
@@ -83,14 +85,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .filter((h) => h !== this.headerKey)
     },
   },
-  filters: {
+  methods: {
     formatDate(dateString: string): string {
       const date = getDayjsObject(dateString)
       if (date.isValid()) {
-        return Vue.prototype.$nuxt.$options.i18n.d(
-          date.toDate(),
-          'dateWithoutYear'
-        )
+        return this.$d(date.toDate(), 'dateWithoutYear')
       } else {
         return dateString
       }

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -239,7 +239,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -244,7 +244,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -219,7 +219,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -280,7 +280,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均値をもとに算出')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit
@@ -290,7 +290,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData4,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay4,
+            date: this.$d(lastDay4, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio4} ${
             this.optionUnit

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -164,7 +164,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
         },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -183,10 +183,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         displayData: this.displayData,
         dataIndex: 1,
       })
+      const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
       if (this.dataKind === 'transition' && this.byDate) {
         return {
           lText: lastDayData,
-          sText: `${lastDay} ${this.$t('日別値')}（${this.$t(
+          sText: `${formattedLastDay} ${this.$t('日別値')}（${this.$t(
             '前日比'
           )}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
@@ -194,7 +195,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       } else if (this.dataKind === 'transition') {
         return {
           lText: lastDayData,
-          sText: `${lastDay} ${this.$t('実績値')}（${this.$t(
+          sText: `${formattedLastDay} ${this.$t('実績値')}（${this.$t(
             '前日比'
           )}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
@@ -202,7 +203,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
       return {
         lText: lastDayData,
-        sText: `${lastDay} ${this.$t('累計値')}（${this.$t(
+        sText: `${formattedLastDay} ${this.$t('累計値')}（${this.$t(
           '前日比'
         )}: ${dayBeforeRatio} ${this.unit}）`,
         unit: this.unit,

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -277,7 +277,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay,
+            date: this.$d(lastDay, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit[0]
@@ -287,7 +287,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData3,
           sText: `${this.$t('{date} の数値', {
-            date: lastDay3,
+            date: this.$d(lastDay3, 'dateWithoutYear'),
           })}（${this.$t('７日間移動平均値をもとに算出')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio3} ${
             this.unit[1]

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -17,6 +17,8 @@
 </template>
 
 <script>
+import dayjs from 'dayjs'
+
 import DataTable from '@/components/DataTable.vue'
 import Data from '@/data/data.json'
 import { getDayjsObject } from '@/utils/formatDate'
@@ -61,6 +63,9 @@ export default {
       row['居住地'] = this.getTranslatedWording(row['居住地'])
       row['性別'] = this.getTranslatedWording(row['性別'])
       row['退院'] = this.getTranslatedWording(row['退院'])
+      row['公表日'] = dayjs(date).isValid()
+        ? this.$d(dayjs(date).toDate(), 'dateWithoutYear')
+        : '不明'
 
       if (row['年代'].substr(-1, 1) === '代') {
         const age = row['年代'].substring(0, 2)

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -63,8 +63,8 @@ export default {
       row['居住地'] = this.getTranslatedWording(row['居住地'])
       row['性別'] = this.getTranslatedWording(row['性別'])
       row['退院'] = this.getTranslatedWording(row['退院'])
-      row['公表日'] = dayjs(date).isValid()
-        ? this.$d(dayjs(date).toDate(), 'dateWithoutYear')
+      row['公表日'] = dayjs(row['公表日']).isValid()
+        ? this.$d(dayjs(row['公表日']).toDate(), 'dateWithoutYear')
         : '不明'
 
       if (row['年代'].substr(-1, 1) === '代') {

--- a/components/cards/PositiveNumberByDevelopedDateCard.vue
+++ b/components/cards/PositiveNumberByDevelopedDateCard.vue
@@ -59,10 +59,11 @@ export default {
             displayData: this.displayData,
             dataIndex: 1,
           })
+          const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
           if (this.dataKind === 'transition') {
             return {
               lText: lastDayData,
-              sText: `${lastDay} ${this.$t('日別値')}（${this.$t(
+              sText: `${formattedLastDay} ${this.$t('日別値')}（${this.$t(
                 '現在判明している人数であり、後日修正される場合がある'
               )}）`,
               unit: this.unit,
@@ -70,7 +71,7 @@ export default {
           }
           return {
             lText: lastDayData,
-            sText: `${lastDay} ${this.$t('累計値')}`,
+            sText: `${formattedLastDay} ${this.$t('累計値')}`,
             unit: this.unit,
           }
         },

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -42,10 +42,11 @@ export default {
             displayData: this.displayData,
             dataIndex: 1,
           })
+          const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
           if (this.dataKind === 'transition') {
             return {
               lText: lastDayData,
-              sText: `${lastDay} ${this.$t('日別値')}（${this.$t(
+              sText: `${formattedLastDay} ${this.$t('日別値')}（${this.$t(
                 '現在判明している人数であり、後日修正される場合がある'
               )}）`,
               unit: this.unit,
@@ -53,7 +54,7 @@ export default {
           }
           return {
             lText: lastDayData,
-            sText: `${lastDay} ${this.$t('累計値')}`,
+            sText: `${formattedLastDay} ${this.$t('累計値')}`,
             unit: this.unit,
           }
         },

--- a/utils/formatDayBeforeRatio.ts
+++ b/utils/formatDayBeforeRatio.ts
@@ -1,5 +1,3 @@
-import Vue from 'vue'
-
 import { DisplayData } from '@/plugins/vue-chart'
 import { getDayjsObject } from '@/utils/formatDate'
 import { getCommaSeparatedNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
@@ -10,7 +8,7 @@ interface DayBeforeRatioParameters {
   digit?: number
 }
 interface DayBeforeRatioData {
-  lastDay: string
+  lastDay: Date
   lastDayData: string
   dayBeforeRatio: string
 }
@@ -34,10 +32,7 @@ export const calcDayBeforeRatio = function ({
   const formatter = getCommaSeparatedNumberToFixedFunction(digit)
 
   return {
-    lastDay: Vue.prototype.$nuxt.$options.i18n.d(
-      getDayjsObject(lastDay).toDate(),
-      'dateWithoutYear'
-    ),
+    lastDay: getDayjsObject(lastDay).toDate(),
     lastDayData: formatter(lastDayData),
     dayBeforeRatio: formatDayBeforeRatio(dayBeforeRatio, formatter),
   }

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -1,5 +1,4 @@
 import dayjs from 'dayjs'
-import Vue from 'vue'
 
 type Header = {
   text: string
@@ -45,7 +44,7 @@ type TableDateType = {
 export default function (data: DataType[]): TableDateType {
   const datasets = data
     .map((d) => ({
-      公表日: formatDateString(d['リリース日']) ?? '不明',
+      公表日: d['リリース日'] ?? '不明',
       居住地: d['居住地'] ?? '調査中',
       年代: d['年代'] ?? '不明',
       性別: d['性別'] ?? '不明',
@@ -56,12 +55,5 @@ export default function (data: DataType[]): TableDateType {
   return {
     headers,
     datasets,
-  }
-}
-
-function formatDateString(date: string): string | undefined {
-  const day = dayjs(date)
-  if (day.isValid()) {
-    return Vue.prototype.$nuxt.$options.i18n.d(day.toDate(), 'dateWithoutYear')
   }
 }


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #5545

## 📝 関連する issue / Related Issues

## 原因

Chrome のコンソールのエラーログを見ると、`Vue.prototype.$nuxt.$options` が取れていませんでした。

```
TypeError: Cannot read property '$options' of undefined
    at Object.get (f182ca6.js:2)
    at _ (5f43c6e.js:1)
    at f.displayInfo (5f43c6e.js:1)
    at _n.get (421345c.js:2)
    at _n.evaluate (421345c.js:2)
    at f.displayInfo (421345c.js:2)
    at fn (5f43c6e.js:1)
    at Object.r [as infoPanel] (421345c.js:2)
    at f.<anonymous> (5f43c6e.js:1)
    at f.t._render (421345c.js:2)
```

このエラーは、https://github.com/tokyo-metropolitan-gov/covid19/pull/5529 の Nuxt.js のアップデートに含まれる https://github.com/nuxt/nuxt.js/pull/8170 の影響と考えられます。

もともと `Vue` オブジェクトの prototype に `$nuxt` を生やしていましたが、この実装だと実行順序によっては prototype 汚染で `$nuxt` が書き換わる可能性があるので、コンポーネントのコンテキストに閉じ込める修正が入りました。
これによって `Vue.prototype` 経由で `$nuxt` を参照できなくなりました。

コンポーネントのコンテキストでは参照できるので、`$nuxt` を参照しているコードをコンポーネント内に移植すればエラーは解消されそうです。

## ⛏ 変更内容 / Details of Changes
- エラーを解消するために `Vue.prototype` 経由で `$nuxt` を参照していたコードをコンポーネントへ移植しました。

## 補足
エラー部分は日付フォーマットを変換するために `$nuxt` を参照していました。
今回の修正では一旦各グラフコンポーネントでフォーマットを指定する形にしましたが、本来は共通コンポーネント側に持たせたほうがDRY で良いと思います。
（`DataViewBasicInfoPanel.vue`、`DataViewDataSetPanel.vue` あたり？）

![スクリーンショット 2020-10-21 14 43 36](https://user-images.githubusercontent.com/5207601/96678037-d0e5f980-13ab-11eb-9fef-16f932ef71a8.png)

## 📸 スクリーンショット / Screenshots
![スクリーンショット 2020-10-21 14 39 12](https://user-images.githubusercontent.com/5207601/96677762-371e4c80-13ab-11eb-875e-24335821ec68.png)

