### PR TITLE
総括コメントをmonitoring_items.jsonから読み込むように修正

### DIFF
--- a/components/MonitoringCommentCard.vue
+++ b/components/MonitoringCommentCard.vue
@@ -28,16 +28,14 @@
         <v-col cols="12" sm="12" md="6" lg="6">
           <h4>{{ $t('感染状況') }}</h4>
           <monitoring-comment-frame
-            :level="monitoringCommentItems['総括コメント-感染状況'].level - 1"
+            :level="monitoringComment['総括コメント-感染状況'].level - 1"
             :comment="commentMonitoring('総括コメント-感染状況')"
           />
         </v-col>
         <v-col cols="12" sm="12" md="6" lg="6">
           <h4>{{ $t('医療提供体制') }}</h4>
           <monitoring-comment-frame
-            :level="
-              monitoringCommentItems['総括コメント-医療提供体制'].level - 1
-            "
+            :level="monitoringComment['総括コメント-医療提供体制'].level - 1"
             :comment="commentMonitoring('総括コメント-医療提供体制')"
           />
         </v-col>
@@ -53,7 +51,7 @@ import AppLink from '@/components/AppLink.vue'
 import MonitoringCommentFrame from '@/components/MonitoringCommentFrame.vue'
 import monitoringItemsData from '@/data/monitoring_items.json'
 import {
-  formatMonitoringCommentItems,
+  formatMonitoringComment,
   MonitoringComment,
 } from '@/utils/formatMonitoringItems'
 
@@ -67,11 +65,11 @@ export default Vue.extend({
     MonitoringCommentFrame,
   },
   data() {
-    const monitoringCommentItems: CommentKey = formatMonitoringCommentItems(
+    const monitoringComment: CommentKey = formatMonitoringComment(
       monitoringItemsData.data
     )
     return {
-      monitoringCommentItems,
+      monitoringComment,
     }
   },
   methods: {
@@ -83,8 +81,8 @@ export default Vue.extend({
     },
     commentMonitoring(item: string) {
       return ['ja', 'ja-basic'].includes(this.$root.$i18n.locale)
-        ? this.monitoringCommentItems[item].display['@ja']
-        : this.monitoringCommentItems[item].display['@en']
+        ? this.monitoringComment[item].display['@ja']
+        : this.monitoringComment[item].display['@en']
     },
   },
 })

--- a/components/MonitoringCommentCard.vue
+++ b/components/MonitoringCommentCard.vue
@@ -28,15 +28,17 @@
         <v-col cols="12" sm="12" md="6" lg="6">
           <h4>{{ $t('感染状況') }}</h4>
           <monitoring-comment-frame
-            :level="monitoringItems.data['総括コメント-感染状況'].level - 1"
-            :comment="commentCurrentInfectionStatus()"
+            :level="monitoringCommentItems['総括コメント-感染状況'].level - 1"
+            :comment="commentMonitoring('総括コメント-感染状況')"
           />
         </v-col>
         <v-col cols="12" sm="12" md="6" lg="6">
           <h4>{{ $t('医療提供体制') }}</h4>
           <monitoring-comment-frame
-            :level="monitoringItems.data['総括コメント-医療提供体制'].level - 1"
-            :comment="commentMedicalSystemProvisions()"
+            :level="
+              monitoringCommentItems['総括コメント-医療提供体制'].level - 1
+            "
+            :comment="commentMonitoring('総括コメント-医療提供体制')"
           />
         </v-col>
       </v-row>
@@ -49,7 +51,15 @@ import Vue from 'vue'
 
 import AppLink from '@/components/AppLink.vue'
 import MonitoringCommentFrame from '@/components/MonitoringCommentFrame.vue'
-import monitoringItems from '@/data/monitoring_items.json'
+import monitoringItemsData from '@/data/monitoring_items.json'
+import {
+  formatMonitoringCommentItems,
+  MonitoringComment,
+} from '@/utils/formatMonitoringItems'
+
+type CommentKey = {
+  [key: string]: MonitoringComment
+}
 
 export default Vue.extend({
   components: {
@@ -57,26 +67,24 @@ export default Vue.extend({
     MonitoringCommentFrame,
   },
   data() {
+    const monitoringCommentItems: CommentKey = formatMonitoringCommentItems(
+      monitoringItemsData.data
+    )
     return {
-      monitoringItems,
+      monitoringCommentItems,
     }
   },
   methods: {
     commentDate() {
       return this.$d(
-        new Date(monitoringItems.data['総括コメント-更新日']),
+        new Date(monitoringItemsData.data['総括コメント-更新日']),
         'dateWithoutYear'
       )
     },
-    commentCurrentInfectionStatus() {
+    commentMonitoring(item: string) {
       return ['ja', 'ja-basic'].includes(this.$root.$i18n.locale)
-        ? monitoringItems.data['総括コメント-感染状況'].display['@ja']
-        : monitoringItems.data['総括コメント-感染状況'].display['@en']
-    },
-    commentMedicalSystemProvisions() {
-      return ['ja', 'ja-basic'].includes(this.$root.$i18n.locale)
-        ? monitoringItems.data['総括コメント-医療提供体制'].display['@ja']
-        : monitoringItems.data['総括コメント-医療提供体制'].display['@en']
+        ? this.monitoringCommentItems[item].display['@ja']
+        : this.monitoringCommentItems[item].display['@en']
     },
   },
 })

--- a/components/MonitoringCommentCard.vue
+++ b/components/MonitoringCommentCard.vue
@@ -29,14 +29,14 @@
           <h4>{{ $t('感染状況') }}</h4>
           <monitoring-comment-frame
             :level="monitoringItems.data['総括コメント-感染状況'].level - 1"
-            :comment="monitoringItems.data['総括コメント-感染状況'].label"
+            :comment="commentCurrentInfectionStatus()"
           />
         </v-col>
         <v-col cols="12" sm="12" md="6" lg="6">
           <h4>{{ $t('医療提供体制') }}</h4>
           <monitoring-comment-frame
             :level="monitoringItems.data['総括コメント-医療提供体制'].level - 1"
-            :comment="monitoringItems.data['総括コメント-医療提供体制'].label"
+            :comment="commentMedicalSystemProvisions()"
           />
         </v-col>
       </v-row>
@@ -67,6 +67,16 @@ export default Vue.extend({
         new Date(monitoringItems.data['総括コメント-更新日']),
         'dateWithoutYear'
       )
+    },
+    commentCurrentInfectionStatus() {
+      return ['ja', 'ja-basic'].includes(this.$root.$i18n.locale)
+        ? monitoringItems.data['総括コメント-感染状況'].display['@ja']
+        : monitoringItems.data['総括コメント-感染状況'].display['@en']
+    },
+    commentMedicalSystemProvisions() {
+      return ['ja', 'ja-basic'].includes(this.$root.$i18n.locale)
+        ? monitoringItems.data['総括コメント-医療提供体制'].display['@ja']
+        : monitoringItems.data['総括コメント-医療提供体制'].display['@en']
     },
   },
 })

--- a/components/cards/MonitoringItemsOverviewCard.vue
+++ b/components/cards/MonitoringItemsOverviewCard.vue
@@ -80,7 +80,7 @@ import DataView from '@/components/DataView.vue'
 import MonitoringItemsOverviewTableInfectionStatus from '@/components/MonitoringItemsOverviewTableInfectionStatus.vue'
 import MonitoringItemsOverviewTableMedicalSystem from '@/components/MonitoringItemsOverviewTableMedicalSystem.vue'
 import monitoringItemsData from '@/data/monitoring_items.json'
-import formatMonitoringItems from '@/utils/formatMonitoringItems'
+import { formatMonitoringItems } from '@/utils/formatMonitoringItems'
 
 export default {
   components: {

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -15,6 +15,8 @@ type DataKey =
   | '(7)重症患者数'
   | '(7)重症患者確保病床数'
 
+type DataCommentKey = '総括コメント-感染状況' | '総括コメント-医療提供体制'
+
 type RawData = {
   '(1)新規陽性者数': number
   '(2)#7119（東京消防庁救急相談センター）における発熱等相談件数 ': number
@@ -27,6 +29,19 @@ type RawData = {
   '(6)入院患者確保病床数': string
   '(7)重症患者数': number
   '(7)重症患者確保病床数': string
+}
+
+interface Comment {
+  level: number
+  display: {
+    '@ja': string
+    '@en': string
+  }
+}
+
+type RawDataComment = {
+  '総括コメント-感染状況': Comment
+  '総括コメント-医療提供体制': Comment
 }
 
 // -----------------------------------------
@@ -49,7 +64,7 @@ export type Unit = {
  *
  * @param data - Raw data
  */
-export default (rawDataObj: RawData): MonitoringItems => {
+export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
   const unitPerson: Unit = { text: '人', translatable: true }
   const unitReports: Unit = {
     text: '件.reports',
@@ -114,6 +129,42 @@ export default (rawDataObj: RawData): MonitoringItems => {
     '(7)重症患者確保病床数': {
       value: rawDataObj['(7)重症患者確保病床数'],
       unit: null,
+    },
+  }
+}
+
+export type MonitoringCommentItems = Record<DataCommentKey, MonitoringComment>
+
+export type MonitoringComment = {
+  level: number
+  display: {
+    '@ja': string
+    '@en': string
+  }
+}
+
+/**
+ * monitoring_items_json のデータを整形（総括コメント）
+ *
+ * @param data - Raw data
+ */
+export const formatMonitoringCommentItems = (
+  rawDataObj: RawDataComment
+): MonitoringCommentItems => {
+  return {
+    '総括コメント-感染状況': {
+      level: rawDataObj['総括コメント-感染状況'].level,
+      display: {
+        '@ja': rawDataObj['総括コメント-感染状況'].display['@ja'],
+        '@en': rawDataObj['総括コメント-感染状況'].display['@en'],
+      },
+    },
+    '総括コメント-医療提供体制': {
+      level: rawDataObj['総括コメント-医療提供体制'].level,
+      display: {
+        '@ja': rawDataObj['総括コメント-医療提供体制'].display['@ja'],
+        '@en': rawDataObj['総括コメント-医療提供体制'].display['@en'],
+      },
     },
   }
 }

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -144,11 +144,11 @@ export type MonitoringComment = {
 }
 
 /**
- * monitoring_items_json のデータを整形（総括コメント）
+ * monitoring_items_json から総括コメントのみ抜き出し
  *
  * @param data - Raw data
  */
-export const formatMonitoringCommentItems = (
+export const formatMonitoringComment = (
   rawDataObj: RawDataComment
 ): MonitoringCommentItems => {
   return {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5548 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 総括コメントのシステム改修に伴い、コメント部分をmonitoring_items.jsonから読み込むように修正しました。
- 日本語・やさしい日本語 -> `display['@ja']` を表示
- 英語・繁体後・簡体語・韓国語 -> `display['@en']` を表示

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="964" alt="スクリーンショット 2020-10-21 15 49 22" src="https://user-images.githubusercontent.com/14883063/96683511-3db1c180-13b5-11eb-82c1-ba56622f234a.png">
<img width="964" alt="スクリーンショット 2020-10-21 15 50 47" src="https://user-images.githubusercontent.com/14883063/96683529-43a7a280-13b5-11eb-8f55-b348ebcb5b45.png">
<img width="964" alt="スクリーンショット 2020-10-21 15 49 35" src="https://user-images.githubusercontent.com/14883063/96683561-4a361a00-13b5-11eb-8928-8ce8350e6627.png">
<img width="964" alt="スクリーンショット 2020-10-21 15 49 51" src="https://user-images.githubusercontent.com/14883063/96683592-528e5500-13b5-11eb-8ce3-e6bcb2a8227a.png">
<img width="964" alt="スクリーンショット 2020-10-21 15 50 05" src="https://user-images.githubusercontent.com/14883063/96683601-57eb9f80-13b5-11eb-8baf-10d0cde033bb.png">
<img width="964" alt="スクリーンショット 2020-10-21 15 50 22" src="https://user-images.githubusercontent.com/14883063/96683621-5de18080-13b5-11eb-9a79-c729a1427262.png">
