### PR TITLE
cardTableのwhite-space:nowrapを陽性者の属性のセルに限定的に指定するように修正

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -40,7 +40,7 @@
               <th
                 v-for="(header, i) in headers"
                 :key="i"
-                :class="`text-${header.align || 'start'}`"
+                :class="`text-${header.align || 'start'} DataTable-header`"
               >
                 {{ $t(header.text) }}
               </th>
@@ -158,7 +158,6 @@ export default Vue.extend({
 
 <style lang="scss">
 .cardTable {
-  white-space: nowrap;
   &.v-data-table {
     th {
       padding: 8px 10px !important;
@@ -232,5 +231,8 @@ export default Vue.extend({
 }
 .FooterNote {
   margin: 0 !important;
+}
+.DataTable-header {
+  white-space: nowrap;
 }
 </style>

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -17,13 +17,13 @@
         <template v-slot:tableBody="{ items, headers }">
           <tbody>
             <tr v-for="(item, i) in items" :key="i">
-              <th scope="row" class="text-start">
+              <th scope="row" class="text-start DataTable-cell">
                 {{ translateDate(item['公表日']) }}
               </th>
               <td
                 v-for="(header, j) in headers.slice(1)"
                 :key="j"
-                :class="`text-${header.align || 'start'}`"
+                :class="`text-${header.align || 'start'} DataTable-cell`"
               >
                 <template v-if="header.type === 'date'">
                   {{ translateDate(item[header.value]) }}
@@ -208,3 +208,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 }
 export default options
 </script>
+
+<style lang="scss" scoped>
+.DataTable-cell {
+  white-space: nowrap;
+}
+</style>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5692 

## 📝 関連する issue / Related Issues
- #5674 
- #5676 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `.cardTable` の `white-space:nowrap;` を陽性者の属性のセルに限定的に指定するように修正しました。
