### PR TITLE
本番環境で未使用の CSS を削除する

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -91,6 +91,7 @@ const config: NuxtConfig = {
     '@nuxt/typescript-build',
     '@nuxtjs/google-analytics',
     '@nuxtjs/gtm',
+    'nuxt-purgecss',
   ],
   /*
    ** Nuxt.js modules
@@ -155,19 +156,13 @@ const config: NuxtConfig = {
     // https://ja.nuxtjs.org/api/configuration-build/#hardsource
     // hardSource: process.env.NODE_ENV === 'development'
   },
-  'nuxt-purgecss': {
-    mode: 'postcss',
-    enabled: environment !== 'development' && process.client,
-    '@fullhuman/postcss-purgecss': {
-      content: [
-        '@/pages/**/*.vue',
-        '@/layouts/**/*.vue',
-        '@/components/**/*.vue',
-        'vuetify/dist/vuetify.js',
-        'vue-spinner/src/ScaleLoader.vue',
-      ],
-      safelist: ['html', 'body', 'nuxt-progress', 'DataCard', /(col|row)/],
-    },
+  purgeCSS: {
+    paths: [
+      './node_modules/vuetify/dist/vuetify.js',
+      './node_modules/vue-spinner/src/ScaleLoader.vue',
+    ],
+    whitelist: ['DataCard', 'GraphLegend'],
+    whitelistPatterns: [/(col|row)/],
   },
   manifest: {
     name: '東京都 新型コロナウイルス感染症対策サイト',

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/core": "7.12.7",
     "@babel/runtime-corejs3": "7.12.5",
-    "@fullhuman/postcss-purgecss": "3.0.0",
     "@mdi/font": "5.8.55",
     "@nuxt/typescript-build": "2.0.3",
     "@nuxtjs/eslint-config": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,14 +964,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fullhuman/postcss-purgecss@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-3.0.0.tgz#e39bf7a7d2a2c664ed151b639785b2efcbca33ff"
-  integrity sha512-cvuOgMwIVlfgWcUMqg5p33NbGUxLwMrKtDKkm3QRfOo4PRVNR6+y/xd9OyXTVZiB1bIpKNJ0ZObYPWD3DRQDtw==
-  dependencies:
-    postcss "7.0.32"
-    purgecss "^3.0.0"
-
 "@fullhuman/postcss-purgecss@^2.0.5":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz#50a954757ec78696615d3e118e3fee2d9291882e"
@@ -8386,16 +8378,6 @@ purgecss@^2.0.5, purgecss@^2.3.0:
   integrity sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==
   dependencies:
     commander "^5.0.0"
-    glob "^7.0.0"
-    postcss "7.0.32"
-    postcss-selector-parser "^6.0.2"
-
-purgecss@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-3.0.0.tgz#039c191871bb999894222a00c4c8b179fccdb043"
-  integrity sha512-t3FGCwyX9XWV3ffvnAXTw6Y3Z9kNlcgm14VImNK66xKi5sdqxSA2I0SFYxtmZbAKuIZVckPdazw5iKL/oY/2TA==
-  dependencies:
-    commander "^6.0.0"
     glob "^7.0.0"
     postcss "7.0.32"
     postcss-selector-parser "^6.0.2"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5685

## 📝 関連する issue / Related Issues
- #5443

## ⛏ 変更内容 / Details of Changes
- 未使用の CSS を削除して、586KB -> 56KB にダイエットしました :scissors:
- [`nuxt-purgecss`](https://github.com/Developmint/nuxt-purgecss) の設定を見直しました
  - [こちらの PR](https://github.com/tokyo-metropolitan-gov/covid19/pull/5443/files#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L145-L156) で削除されたもともとの設定をサルベージ 
  - `nuxt-purgecss` のデフォルトの設定を継承して、このプロジェクトで必要な設定のみを記述しました
    - ref: https://github.com/Developmint/nuxt-purgecss#defaults
  - `@fullhuman/postcss-purgecss` は `nuxt-purgecss` に組み込まれているので、`package.json` からは削除しました
     - ref: https://github.com/Developmint/nuxt-purgecss#features


## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-11-22 10 50 59](https://user-images.githubusercontent.com/5207601/99891749-a5a74080-2cb0-11eb-8d8c-813c508296f2.png)

### After
![スクリーンショット 2020-11-22 10 50 24](https://user-images.githubusercontent.com/5207601/99891750-a7710400-2cb0-11eb-9942-c13dca41f9f8.png)