### PR TITLE
perf: 使用しているアイコンのみ `@mdi/js` で読み込む

### DIFF
--- a/components/AppLink.vue
+++ b/components/AppLink.vue
@@ -10,12 +10,13 @@
       role="img"
       :aria-hidden="false"
     >
-      {{ iconType }}
+      {{ iconPath }}
     </v-icon>
   </component>
 </template>
 
 <script lang="ts">
+import { mdiOpenInNew } from '@mdi/js'
 import Vue from 'vue'
 
 import { isExternal } from '@/utils/urls.ts'
@@ -46,9 +47,9 @@ export default Vue.extend({
       type: Number,
       default: 12,
     },
-    iconType: {
+    iconPath: {
       type: String,
-      default: 'mdi-open-in-new',
+      default: mdiOpenInNew,
     },
     iconClass: {
       type: String,

--- a/components/DataViewExpantionPanel.vue
+++ b/components/DataViewExpantionPanel.vue
@@ -8,7 +8,7 @@
           @click="toggleDetails"
         >
           <div class="v-expansion-panel-header__icon">
-            <v-icon left size="2.4rem">mdi-chevron-right</v-icon>
+            <v-icon left size="2.4rem">{{ mdiChevronRight }}</v-icon>
           </div>
           <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
         </v-expansion-panel-header>
@@ -24,6 +24,7 @@
 </template>
 
 <script lang="ts">
+import { mdiChevronRight } from '@mdi/js'
 import Vue from 'vue'
 
 import { EventBus, TOGGLE_EVENT } from '@/utils/card-event-bus'
@@ -32,6 +33,7 @@ export default Vue.extend({
   data() {
     return {
       showDetails: false,
+      mdiChevronRight,
     }
   },
   mounted() {

--- a/components/DataViewShare.vue
+++ b/components/DataViewShare.vue
@@ -34,9 +34,9 @@
       @click="stopClosingShareMenu"
     >
       <div class="Close-Button">
-        <v-icon :aria-label="$t('閉じる')" @click="closeShareMenu"
-          >mdi-close</v-icon
-        >
+        <v-icon :aria-label="$t('閉じる')" @click="closeShareMenu">
+          {{ mdiClose }}
+        </v-icon>
       </div>
 
       <h4>{{ $t('埋め込み用コード') }}</h4>
@@ -47,7 +47,7 @@
           class="EmbedCode-Copy"
           :aria-label="$t('クリップボードにコピー')"
           @click="copyEmbedCode"
-          >mdi-clipboard-outline</v-icon
+          >{{ mdiClipboardOutline }}</v-icon
         >
         {{ graphEmbedValue }}
       </div>
@@ -109,6 +109,7 @@
 </template>
 
 <script lang="ts">
+import { mdiClipboardOutline, mdiClose } from '@mdi/js'
 import Vue from 'vue'
 export default Vue.extend({
   props: {
@@ -126,6 +127,8 @@ export default Vue.extend({
       openGraphEmbed: false,
       displayShare: false,
       showOverlay: false,
+      mdiClipboardOutline,
+      mdiClose,
     }
   },
   computed: {

--- a/components/LinkToInformationAboutEmergencyMeasure.vue
+++ b/components/LinkToInformationAboutEmergencyMeasure.vue
@@ -5,7 +5,7 @@
         size="2rem"
         class="link-to-information-about-emergency-measure-icon"
       >
-        mdi-bullhorn
+        {{ mdiBullhorn }}
       </v-icon>
       {{ $t('東京都緊急事態措置について') }}
     </app-link>
@@ -13,12 +13,18 @@
 </template>
 
 <script lang="ts">
+import { mdiBullhorn } from '@mdi/js'
 import Vue from 'vue'
 
 import AppLink from '@/components/AppLink.vue'
 
 export default Vue.extend({
   components: { AppLink },
+  data() {
+    return {
+      mdiBullhorn,
+    }
+  },
 })
 </script>
 

--- a/components/MenuList.vue
+++ b/components/MenuList.vue
@@ -7,9 +7,15 @@
       @click="$emit('click', $event)"
     >
       <app-link :to="item.link" class="MenuList-Link">
-        <span v-if="item.icon" class="MenuList-Icon">
-          <v-icon :is="iconTag(item.icon)" v-bind="iconAttrs(item.icon)">
-            {{ item.icon }}
+        <span v-if="item.svg || item.iconPath" class="MenuList-Icon">
+          <svg
+            :is="item.svg"
+            v-if="item.svg"
+            class="MenuList-SvgIcon"
+            aria-hidden="true"
+          />
+          <v-icon v-if="item.iconPath" size="2rem" class="MenuList-MdIcon">
+            {{ item.iconPath }}
           </v-icon>
         </span>
         <span class="MenuList-Title">{{ item.title }}</span>
@@ -28,42 +34,19 @@ import ParentIcon from '@/static/parent.svg'
 import SupportIcon from '@/static/support.svg'
 
 type MenuItem = {
-  icon?: string
+  iconPath?: string
+  svg?: string
   title: string
   link: string
   divider?: boolean
 }
 
 export default Vue.extend({
-  components: {
-    CovidIcon,
-    MaskTrashIcon,
-    ParentIcon,
-    AppLink,
-    SupportIcon,
-  },
+  components: { AppLink, CovidIcon, MaskTrashIcon, ParentIcon, SupportIcon },
   props: {
     items: {
       type: Array as PropType<MenuItem[]>,
       required: true,
-    },
-  },
-  methods: {
-    iconTag(icon: MenuItem['icon']) {
-      return icon ? (icon.startsWith('mdi') ? 'v-icon' : icon) : null
-    },
-    iconAttrs(icon: MenuItem['icon']) {
-      return icon
-        ? icon.startsWith('mdi')
-          ? {
-              size: '2rem',
-              class: 'MenuList-MdIcon',
-            }
-          : {
-              'aria-hidden': true,
-              class: 'MenuList-SvgIcon',
-            }
-        : null
     },
   },
 })

--- a/components/MonitoringCommentCard.vue
+++ b/components/MonitoringCommentCard.vue
@@ -13,7 +13,7 @@
           )
         }}
       </p>
-      <v-icon color="#D9D9D9">mdi-chevron-right</v-icon>
+      <v-icon color="#D9D9D9">{{ mdiChevronRight }}</v-icon>
       <app-link
         to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/monitoring.html"
       >
@@ -42,6 +42,7 @@
 </template>
 
 <script lang="ts">
+import { mdiChevronRight } from '@mdi/js'
 import Vue from 'vue'
 
 import AppLink from '@/components/AppLink.vue'
@@ -67,6 +68,7 @@ export default Vue.extend({
     )
     return {
       monitoringComment,
+      mdiChevronRight,
     }
   },
   methods: {

--- a/components/PageHeader.vue
+++ b/components/PageHeader.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="header">
     <h2 class="pageTitle">
-      <v-icon v-if="icon" size="4rem" class="mr-2">
-        {{ icon }}
+      <v-icon v-if="iconPath" size="4rem" class="mr-2">
+        {{ iconPath }}
       </v-icon>
       <slot />
     </h2>
@@ -14,7 +14,7 @@ import Vue from 'vue'
 
 export default Vue.extend({
   props: {
-    icon: {
+    iconPath: {
       type: String,
       required: false,
       default: '',

--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -6,7 +6,7 @@
         :aria-label="$t('サイドメニュー項目を開く')"
         @click="$emit('openNavi', $event)"
       >
-        mdi-menu
+        {{ mdiMenu }}
       </v-icon>
       <h1 class="SideNavigation-HeaderTitle">
         <app-link :to="localePath('/')" class="SideNavigation-HeaderLink">
@@ -30,7 +30,7 @@
         :aria-label="$t('サイドメニュー項目を閉じる')"
         @click="$emit('closeNavi', $event)"
       >
-        mdi-close
+        {{ mdiClose }}
       </v-icon>
 
       <nav class="SideNavigation-Menu">
@@ -126,6 +126,13 @@
 </template>
 
 <script lang="ts">
+import {
+  mdiAccountMultiple,
+  mdiChartTimelineVariant,
+  mdiClose,
+  mdiDomain,
+  mdiMenu,
+} from '@mdi/js'
 import Vue from 'vue'
 import { TranslateResult } from 'vue-i18n'
 
@@ -134,7 +141,8 @@ import LanguageSelector from '@/components/LanguageSelector.vue'
 import MenuList from '@/components/MenuList.vue'
 
 type Item = {
-  icon?: string
+  iconPath?: string
+  svg?: string
   title: TranslateResult
   link: string
   divider?: boolean
@@ -152,28 +160,34 @@ export default Vue.extend({
       required: true,
     },
   },
+  data() {
+    return {
+      mdiClose,
+      mdiMenu,
+    }
+  },
   computed: {
     items(): Item[] {
       return [
         {
-          icon: 'mdi-chart-timeline-variant',
+          iconPath: mdiChartTimelineVariant,
           title: this.$t('都内の最新感染動向'),
           link: this.localePath('/'),
         },
         {
-          icon: 'CovidIcon',
+          svg: 'CovidIcon',
           title: this.$t('新型コロナウイルス感染症が心配なときに.nav'),
           link:
             'https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html',
         },
         {
-          icon: 'CovidIcon',
+          svg: 'CovidIcon',
           title: this.$t('新型コロナウイルスの感染が判明した方へ'),
           link:
             'https://www.fukushihoken.metro.tokyo.lg.jp/oshirase/corona_0401.html',
         },
         {
-          icon: 'SupportIcon',
+          svg: 'SupportIcon',
           title: this.$t(
             '新型コロナウイルス感染症の患者発生状況に関するよくあるご質問'
           ),
@@ -181,24 +195,24 @@ export default Vue.extend({
             'https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronafaq.html',
         },
         {
-          icon: 'MaskTrashIcon',
+          svg: 'MaskTrashIcon',
           title: this.$t('ご家庭でのマスク等の捨て方'),
           link:
             'https://www.kankyo.metro.tokyo.lg.jp/resource/500200a20200221162304660.files/200327_chirashi.pdf',
           divider: true,
         },
         {
-          icon: 'ParentIcon',
+          svg: 'ParentIcon',
           title: this.$t('お子様をお持ちの皆様へ'),
           link: this.localePath('/parent'),
         },
         {
-          icon: 'mdi-account-multiple',
+          iconPath: mdiAccountMultiple,
           title: this.$t('都民の皆様へ'),
           link: 'https://www.metro.tokyo.lg.jp/tosei/tosei/news/2019-ncov.html',
         },
         {
-          icon: 'mdi-domain',
+          iconPath: mdiDomain,
           title: this.$t('企業の皆様・はたらく皆様へ'),
           link: this.localePath('/worker'),
           divider: true,

--- a/components/SiteTopUpper.vue
+++ b/components/SiteTopUpper.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="MainPage">
     <div class="Header mb-3">
-      <page-header :icon="headerItem.icon">{{ headerItem.title }}</page-header>
+      <page-header :icon-path="headerItem.iconPath">{{
+        headerItem.title
+      }}</page-header>
       <div class="UpdatedAt">
         <span>{{ $t('最終更新') }}</span>
         <time :datetime="updatedAt">{{ formattedDateForDisplay }}</time>
@@ -26,6 +28,7 @@
 </template>
 
 <script lang="ts">
+import { mdiChartTimelineVariant } from '@mdi/js'
 import Vue from 'vue'
 import { MetaInfo } from 'vue-meta'
 
@@ -53,7 +56,7 @@ export default Vue.extend({
     return {
       TokyoAlert,
       headerItem: {
-        icon: 'mdi-chart-timeline-variant',
+        iconPath: mdiChartTimelineVariant,
         title: this.$t('都内の最新感染動向'),
       },
       lastUpdate,

--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -3,7 +3,7 @@
     <div class="WhatsNew-heading">
       <h3 class="WhatsNew-title">
         <v-icon size="2.4rem" class="WhatsNew-title-icon">
-          mdi-information
+          {{ mdiInformation }}
         </v-icon>
         {{ $t('最新のお知らせ') }}
       </h3>
@@ -30,6 +30,7 @@
 </template>
 
 <script lang="ts">
+import { mdiInformation } from '@mdi/js'
 import Vue from 'vue'
 
 import AppLink from '@/components/AppLink.vue'
@@ -51,6 +52,11 @@ export default Vue.extend({
       required: false,
       default: false,
     },
+  },
+  data() {
+    return {
+      mdiInformation,
+    }
   },
   methods: {
     formattedDate(dateString: string) {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -77,10 +77,6 @@ const config: NuxtConfig = {
       src: '@/plugins/axe',
       ssr: true,
     },
-    {
-      src: '@/plugins/vuetify.ts',
-      ssr: true,
-    },
   ],
   /*
    ** Nuxt.js dev-modules

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -106,6 +106,7 @@ const config: NuxtConfig = {
    */
   vuetify: {
     customVariables: ['@/assets/variables.scss'],
+    optionsPath: './plugins/vuetify.options.ts',
     treeShake: true,
     defaultAssets: {
       icons: false,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/core": "7.12.8",
     "@babel/runtime-corejs3": "7.12.5",
-    "@mdi/font": "5.8.55",
     "@mdi/js": "^5.8.55",
     "@nuxt/typescript-build": "2.0.3",
     "@nuxtjs/eslint-config": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@babel/core": "7.12.8",
     "@babel/runtime-corejs3": "7.12.5",
     "@mdi/font": "5.8.55",
+    "@mdi/js": "^5.8.55",
     "@nuxt/typescript-build": "2.0.3",
     "@nuxtjs/eslint-config": "3.1.0",
     "@nuxtjs/eslint-config-typescript": "3.0.0",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -9,7 +9,7 @@
         :href="`#tab-${i}`"
         @click="change"
       >
-        <v-icon class="TabIcon"> mdi-chart-timeline-variant </v-icon>
+        <v-icon class="TabIcon">{{ mdiChartTimelineVariant }}</v-icon>
         {{ item.label }}
       </v-tab>
       <v-tabs-items v-model="tab" touchless>
@@ -22,6 +22,7 @@
 </template>
 
 <script lang="ts">
+import { mdiChartTimelineVariant } from '@mdi/js'
 import Vue from 'vue'
 
 import CardsMonitoring from '@/components/CardsMonitoring.vue'
@@ -42,6 +43,7 @@ export default Vue.extend({
         { label: this.$t('モニタリング項目'), component: CardsMonitoring },
         { label: this.$t('その他 参考指標'), component: CardsReference },
       ],
+      mdiChartTimelineVariant,
     }
   },
   methods: {

--- a/plugins/vuetify.options.ts
+++ b/plugins/vuetify.options.ts
@@ -1,0 +1,13 @@
+import { mdiChevronLeft, mdiChevronRight, mdiMenuDown } from '@mdi/js'
+
+// Vueitfy options
+// https://github.com/nuxt-community/vuetify-module#optionspath
+export default {
+  icons: {
+    values: {
+      prev: mdiChevronLeft,
+      next: mdiChevronRight,
+      dropdown: mdiMenuDown,
+    },
+  },
+}

--- a/plugins/vuetify.ts
+++ b/plugins/vuetify.ts
@@ -1,1 +1,0 @@
-import '@mdi/font/css/materialdesignicons.css'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1007,6 +1007,11 @@
   resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.8.55.tgz#1464155bcbc8a6e4af6dffd611fe8e38e09af285"
   integrity sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA==
 
+"@mdi/js@^5.8.55":
+  version "5.8.55"
+  resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.8.55.tgz#630bc5fafd8b1d2f6e63489a9ab170177559e41b"
+  integrity sha512-2bvln56SW6V/nSDC/0/NTu1bMF/CgSyZox8mcWbAPWElBN3UYIrukKDUckEER8ifr8X2YJl1RLKQqi7T7qLzmg==
+
 "@microsoft/tsdoc-config@0.13.6":
   version "0.13.6"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.13.6.tgz#2154785e264edaa515ce5bb2a6c9cd7865f356cf"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,11 +1002,6 @@
     js-yaml "^3.13.1"
     json5 "^2.1.1"
 
-"@mdi/font@5.8.55":
-  version "5.8.55"
-  resolved "https://registry.yarnpkg.com/@mdi/font/-/font-5.8.55.tgz#1464155bcbc8a6e4af6dffd611fe8e38e09af285"
-  integrity sha512-8mrwfFBsmj+D67ZiGQSe5TU/lcWCtDyli2eshQ2fvLCZGRPqFMM23YQp4+JMOTpk5yMZKTeAwNWIYfITy76OHA==
-
 "@mdi/js@^5.8.55":
   version "5.8.55"
   resolved "https://registry.yarnpkg.com/@mdi/js/-/js-5.8.55.tgz#630bc5fafd8b1d2f6e63489a9ab170177559e41b"


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #5191

## 📝 関連する issue / Related Issues
- #5478

## ⛏ 変更内容 / Details of Changes
- #5478 が止まっていたので、こちらで引き継いで実装してみました :pray:
- `@mdi/font` はアンインストールして、必要なアイコンのみを `@mdi/js` で読み込む構成に変更しました
- アイコンの実装は [Vuetify の公式ドキュメント](https://vuetifyjs.com/en/features/icons/#material-design-icons---js-svg)に習いました

## 📸 スクリーンショット / Screenshots

### Webpack Bundle Analyzer

`@mdi/font` -> `@mdi/js` に置き換えて、parsed sizeが 13 KB -> 2 KB に減りました。
`@mdi/js` は stat size が 2.03 MB ありますが、Tree Shaking が効くようになったので実際にビルドに組み込まれるのは 2KB になります。
ref: https://github.com/webpack-contrib/webpack-bundle-analyzer#size-definitions

#### Before
![スクリーンショット 2020-11-24 19 19 28](https://user-images.githubusercontent.com/5207601/100081110-fde56a80-2e89-11eb-871c-ac5fc83a02a1.png)


#### After
![スクリーンショット 2020-11-24 19 16 22](https://user-images.githubusercontent.com/5207601/100080783-929b9880-2e89-11eb-96cf-1d0ae118fbf5.png)


### Lighthouse
手元のローカル環境で計測しました。
実行タイミングによって前後しますが、以前よりは数ポイント上がっていると思います。

| before | after |
| --- | --- |
| ![スクリーンショット 2020-11-24 19 08 11](https://user-images.githubusercontent.com/5207601/100079796-71867800-2e88-11eb-8617-0bcfcacfaabd.png) | ![スクリーンショット 2020-11-24 19 08 02](https://user-images.githubusercontent.com/5207601/100079785-6e8b8780-2e88-11eb-98fc-f1c3372f9489.png) |

## 補足
Webpack Bundle Analyzer を見ていて、開発時にしか使っていないはずの `axe-core.js` がものすごく大きいので、こちらは別に issue を切って `venders/app.js` から除外するようにしたいと思います。