### PR TITLE
perf: 本番環境で読み込むファイルから `axe-core` を分離する

### DIFF
--- a/plugins/axe.ts
+++ b/plugins/axe.ts
@@ -1,12 +1,11 @@
 import Vue from 'vue'
+const VueAxe = () => import('vue-axe')
+const AXE_LOCALE_JA = () => import('axe-core/locales/ja.json')
 
 const NODE_ENV = process.env.NODE_ENV
 const VUE_AXE = process.env.VUE_AXE
 
 if (NODE_ENV === 'development' && VUE_AXE === 'true') {
-  const VueAxe = require('vue-axe')
-  const AXE_LOCALE_JA = require('axe-core/locales/ja.json')
-
   Vue.use(VueAxe, {
     config: {
       locale: AXE_LOCALE_JA,


### PR DESCRIPTION
##  👏 解決する issue / Resolved Issues
- close #5717

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- `venders/app.js` から `vue-axe` 関連のライブラリを分離しました
- ビルドファイルに出力はされますがファイルを分離して参照はしなくなったので、本番環境で読み込まれることはありません

## 📸 スクリーンショット / Screenshots

`venders/app.js` の parsed size が 774 KB ->354 KB になりました :scissors:

![スクリーンショット 2020-11-24 20 51 45](https://user-images.githubusercontent.com/5207601/100090677-e2cd2780-2e96-11eb-9a03-361cd08f8936.png)

### Lighthouse

「Remove unused JavaScript」の警告が消えました 🎉 
 
![スクリーンショット 2020-11-24 20 53 04](https://user-images.githubusercontent.com/5207601/100090792-1445f300-2e97-11eb-9c38-94932726ed7f.png)

| before | after |
| --- | --- |
| ![スクリーンショット 2020-11-24 20 52 42](https://user-images.githubusercontent.com/5207601/100090882-36d80c00-2e97-11eb-8065-4a001476328c.png) |  ![スクリーンショット 2020-11-24 20 52 51](https://user-images.githubusercontent.com/5207601/100090894-3b9cc000-2e97-11eb-85b4-e37f313398c7.png) |
