### PR TITLE
perf: Web font の読み込みを最適化する

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -192,10 +192,6 @@ export default Vue.extend({
 })
 </script>
 <style lang="scss">
-@font-face {
-  font-family: Roboto;
-  font-display: swap;
-}
 .app {
   max-width: 1440px;
   margin: 0 auto;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -103,6 +103,7 @@ const config: NuxtConfig = {
     ['nuxt-i18n', i18n],
     'nuxt-svg-loader',
     ['vue-scrollto/nuxt', { duration: 1000, offset: -72 }],
+    'nuxt-webfontloader',
   ],
   /*
    ** vuetify module configuration
@@ -111,8 +112,15 @@ const config: NuxtConfig = {
   vuetify: {
     customVariables: ['@/assets/variables.scss'],
     treeShake: true,
-    defaultAssets: {
-      icons: false,
+    defaultAssets: false,
+  },
+  /*
+   * Webfontloader
+   * https://github.com/Developmint/nuxt-webfontloader
+   */
+  webfontloader: {
+    google: {
+      families: ['Roboto:100,300,400,500,700,900&display=swap'],
     },
   },
   googleAnalytics: {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lint-staged": "10.5.2",
     "nuxt-purgecss": "1.0.0",
     "nuxt-svg-loader": "1.2.0",
+    "nuxt-webfontloader": "^1.1.0",
     "prettier": "2.2.0",
     "rimraf": "3.0.2",
     "stylelint": "13.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7014,6 +7014,13 @@ nuxt-svg-loader@1.2.0:
     consola "^2.3.2"
     svg-to-vue-component "^0.3.1"
 
+nuxt-webfontloader@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nuxt-webfontloader/-/nuxt-webfontloader-1.1.0.tgz#68b47ffbeaee4c41969f42f57a86946e0c36715c"
+  integrity sha512-GyDgABmI0Oq54s2tA9SZC28TmHy2xGdWSXrfcGPPfDBVhgQQlGL5CJcAlvovcuhefzzZrzGgs35HIcv5qym4fQ==
+  dependencies:
+    webfontloader "^1.6.28"
+
 nuxt@2.14.7:
   version "2.14.7"
   resolved "https://registry.yarnpkg.com/nuxt/-/nuxt-2.14.7.tgz#041bb3f5c659b1fec80042d974f68a0ed4e93aa9"
@@ -10397,6 +10404,11 @@ watchpack@^1.7.4:
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.0"
+
+webfontloader@^1.6.28:
+  version "1.6.28"
+  resolved "https://registry.yarnpkg.com/webfontloader/-/webfontloader-1.6.28.tgz#db786129253cb6e8eae54c2fb05f870af6675bae"
+  integrity sha1-23hhKSU8tujq5UwvsF+HCvZnW64=
 
 webpack-bundle-analyzer@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5719

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- [`nuxt-webfontloader`](https://github.com/Developmint/nuxt-webfontloader) をインストールして、Web font の読み込みがレンダリングをブロックしないようにしました
- `nuxt.config.ts` の設定については、[`@nuxtjs/vuetify` のドキュメント](https://github.com/nuxt-community/vuetify-module#defaultassets) を参考にしました

## 📸 スクリーンショット / Screenshots

「Eliminate render-blocking resources」の警告が消えました :tada:

![スクリーンショット 2020-11-24 21 22 41](https://user-images.githubusercontent.com/5207601/100093683-39d4fb80-2e9b-11eb-92ed-b6f6585290a4.png)

| before | after|
| --- | --- |
| ![スクリーンショット 2020-11-24 20 52 42](https://user-images.githubusercontent.com/5207601/100093125-6b999280-2e9a-11eb-9ef0-4462eb166cfe.png) | ![スクリーンショット 2020-11-24 21 22 30](https://user-images.githubusercontent.com/5207601/100093672-3477b100-2e9b-11eb-930f-cf1c2f17fdad.png) |
