### PR TITLE
perf: レイアウトシフトを防止するために `img` タグに `width` と `height` 属性を追加

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -13,6 +13,8 @@
           <img
             class="SideNavigation-HeaderLogo"
             src="/logo.svg"
+            width="111"
+            height="28"
             :alt="$t('東京都')"
           />
           <div class="SideNavigation-HeaderText">
@@ -57,7 +59,7 @@
           >
             <picture>
               <source srcset="/line.webp" type="image/webp" />
-              <img src="/line.png" alt="LINE" />
+              <img src="/line.png" width="130" height="130" alt="LINE" />
             </picture>
           </app-link>
           <app-link
@@ -67,7 +69,7 @@
           >
             <picture>
               <source srcset="/twitter.webp" type="image/webp" />
-              <img src="/twitter.png" alt="Twitter" />
+              <img src="/twitter.png" width="130" height="130" alt="Twitter" />
             </picture>
           </app-link>
           <app-link
@@ -77,7 +79,12 @@
           >
             <picture>
               <source srcset="/facebook.webp" type="image/webp" />
-              <img src="/facebook.png" alt="Facebook" />
+              <img
+                src="/facebook.png"
+                width="130"
+                height="130"
+                alt="Facebook"
+              />
             </picture>
           </app-link>
           <app-link
@@ -87,7 +94,7 @@
           >
             <picture>
               <source srcset="/github.webp" type="image/webp" />
-              <img src="/github.png" alt="GitHub" />
+              <img src="/github.png" width="130" height="130" alt="GitHub" />
             </picture>
           </app-link>
           <app-link
@@ -97,7 +104,7 @@
           >
             <picture>
               <source srcset="/youtube.webp" type="image/webp" />
-              <img src="/youtube.png" alt="YouTube" />
+              <img src="/youtube.png" width="130" height="130" alt="YouTube" />
             </picture>
           </app-link>
         </div>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5721

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- SSIA

## 📸 スクリーンショット / Screenshots

「Image elements have explicit width and height」の警告が消えました 🎉 

![スクリーンショット 2020-11-24 21 54 30](https://user-images.githubusercontent.com/5207601/100096886-b7026f80-2e9f-11eb-8af0-a6585a6047ed.png) 

| before | after|
| --- | --- |
| ![スクリーンショット 2020-11-24 20 52 42](https://user-images.githubusercontent.com/5207601/100096588-91756600-2e9f-11eb-8647-d41c06a5d5c2.png) | ![スクリーンショット 2020-11-24 21 54 24](https://user-images.githubusercontent.com/5207601/100096817-b36ee880-2e9f-11eb-9742-f505fd692049.png) |


