### PR TITLE
Lighthouse CI Action のアップデート

### DIFF
--- a/.github/workflows/audit-staging.yml
+++ b/.github/workflows/audit-staging.yml
@@ -18,7 +18,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Audit URLs using Lighthouse
-        uses: treosh/lighthouse-ci-action@v2
+        uses: treosh/lighthouse-ci-action@v3
         with:
           urls: |
             https://stopcovid19.metro.tokyo.lg.jp/


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5708

## ⛏ 変更内容 / Details of Changes
- staging に GitHub Actions で実行される Lighthouse でエラーが発生していた (https://github.com/tokyo-metropolitan-gov/covid19/pull/5707/checks?check_run_id=1445148612)．
- [GitHub Actions のアップデート](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) が影響しているようなので，https://github.com/treosh/lighthouse-ci-action を v2 から v3 にアップデートして解決できないか様子を見る

## 📸 スクリーンショット / Screenshots
見た目の変更はなし
