### PR TITLE
GitHub Actionsでset-envが非推奨になったため修正

### DIFF
--- a/.github/workflows/audit-staging.yml
+++ b/.github/workflows/audit-staging.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Summary
         run: |
           export LH_SUMMARY_FILE="${GITHUB_WORKSPACE}/.lighthouseci/result.md"
-          echo "::set-env name=LH_SUMMARY_FILE::${LH_SUMMARY_FILE}"
+          echo "LH_SUMMARY_FILE=${LH_SUMMARY_FILE}" >> $GITHUB_ENV
           cat "${GITHUB_WORKSPACE}/.lighthouseci/"lhr-*.json \
           | jq -rs 'def formatScore(s):
               "https://img.shields.io" as $baseUrl |


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #5708 
- #5726

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- SSIA
- [参考](https://dev.classmethod.jp/articles/replace-deprecated-method-on-actions/)
