### PR TITLE
v-alertのerrorアイコンを@mdi/jsのものに入れ替え

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -10,9 +10,18 @@
       <scale-loader color="#00A040" />
     </v-overlay>
     <v-overlay v-if="error" absolute justify-center align-center>
-      <v-alert type="error" color="#AD2121">
-        {{ title }} {{ $t('の読み込みに失敗しました') }} <br />
-        エラーメッセージ: {{ error.message }}
+      <v-alert color="#AD2121">
+        <v-row>
+          <v-col class="shrink">
+            <v-icon>
+              {{ mdiAlert }}
+            </v-icon>
+          </v-col>
+          <v-col class="grow">
+            {{ title }} {{ $t('の読み込みに失敗しました') }} <br />
+            エラーメッセージ: {{ error.message }}
+          </v-col>
+        </v-row>
       </v-alert>
     </v-overlay>
     <v-layout :class="{ loading: !loaded || error }" column>
@@ -81,6 +90,9 @@
 </template>
 
 <script lang="ts">
+import {
+  mdiAlert,
+} from '@mdi/js'
 import Vue from 'vue'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 
@@ -132,6 +144,7 @@ export default Vue.extend({
     return {
       itemsPerPage: 15,
       page: 1,
+      mdiAlert,
     }
   },
   watch: {

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -90,9 +90,7 @@
 </template>
 
 <script lang="ts">
-import {
-  mdiAlert,
-} from '@mdi/js'
+import { mdiAlert } from '@mdi/js'
 import Vue from 'vue'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5715

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性者の属性」でオープンデータAPIからのデータ取得がエラーになった時の表示で、v-alertのアイコンが非表示になっていたので修正しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
|before|after|
|---|---|
|![スクリーンショット 2020-12-09 16 03 27](https://user-images.githubusercontent.com/14883063/101596289-25b30180-3a38-11eb-9b0d-2ece6f13db72.png)|![スクリーンショット 2020-12-09 15 53 46](https://user-images.githubusercontent.com/14883063/101596173-fb614400-3a37-11eb-903f-5f81040819b5.png)|