### PR TITLE
v-alert表示崩れのためv-row,v-colを削除（IE11対応）

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -11,17 +11,11 @@
     </v-overlay>
     <v-overlay v-if="error" absolute justify-center align-center>
       <v-alert color="#AD2121">
-        <v-row>
-          <v-col class="shrink">
-            <v-icon>
-              {{ mdiAlert }}
-            </v-icon>
-          </v-col>
-          <v-col class="grow">
-            {{ title }} {{ $t('の読み込みに失敗しました') }} <br />
-            エラーメッセージ: {{ error.message }}
-          </v-col>
-        </v-row>
+        <v-icon>
+          {{ mdiAlert }}
+        </v-icon>
+        {{ title }} {{ $t('の読み込みに失敗しました') }} <br />
+        エラーメッセージ: {{ error.message }}
       </v-alert>
     </v-overlay>
     <v-layout :class="{ loading: !loaded || error }" column>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #5715 
- #5767 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性者の属性」のv-alertが、IE11で表示が崩れていたのを修正しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
|before|after|
|-----|-----|
|![before](https://user-images.githubusercontent.com/14883063/102007074-38e00d00-3d69-11eb-9dfa-4c598d0444e4.png)|![after](https://user-images.githubusercontent.com/14883063/102007081-45fcfc00-3d69-11eb-91ea-4cdf5d8d11ee.png)|

