### PR TITLE
各グラフの見出しの日付に年を追加

### DIFF
--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -217,7 +217,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
         },

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -228,7 +228,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return {
         lText: lastDayData,
         sText: `${this.$t('{date} の数値', {
-          date: this.$d(lastDay, 'dateWithoutYear'),
+          date: this.$d(lastDay, 'date'),
         })}（${this.$t('７日間移動平均')}）`,
         sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
         unit: this.unit,

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -239,7 +239,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -244,7 +244,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -222,7 +222,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -275,7 +275,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('７日間移動平均値をもとに算出')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit
@@ -285,7 +285,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData4,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay4, 'dateWithoutYear'),
+            date: this.$d(lastDay4, 'date'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio4} ${
             this.optionUnit

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -164,7 +164,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('前日比')}: ${dayBeforeRatio} ${this.unit}）`,
           unit: this.unit,
         },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -183,7 +183,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         displayData: this.displayData,
         dataIndex: 1,
       })
-      const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
+      const formattedLastDay = this.$d(lastDay, 'date')
       if (this.dataKind === 'transition' && this.byDate) {
         return {
           lText: lastDayData,

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -224,7 +224,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   computed: {
     displayInfo() {
       const lastDay = this.labels[this.labels.length - 1]
-      const date = this.$d(getDayjsObject(lastDay).toDate(), 'dateWithoutYear')
+      const date = this.$d(getDayjsObject(lastDay).toDate(), 'date')
 
       if (this.dataKind === 'transition') {
         return {

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -272,7 +272,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay, 'dateWithoutYear'),
+            date: this.$d(lastDay, 'date'),
           })}（${this.$t('７日間移動平均')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio} ${
             this.unit[0]
@@ -282,7 +282,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         {
           lText: lastDayData3,
           sText: `${this.$t('{date} の数値', {
-            date: this.$d(lastDay3, 'dateWithoutYear'),
+            date: this.$d(lastDay3, 'date'),
           })}（${this.$t('７日間移動平均値をもとに算出')}）`,
           sTextUnder: `（${this.$t('前日比')}: ${dayBeforeRatio3} ${
             this.unit[1]

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -121,10 +121,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     // 感染者数グラフ
     const patientsGraph = formatGraph(Data.patients_summary.data)
     const lastData = patientsGraph[patientsGraph.length - 1]
-    const lastDay = this.$d(
-      getDayjsObject(lastData.label).toDate(),
-      'dateWithoutYear'
-    )
+    const lastDay = this.$d(getDayjsObject(lastData.label).toDate(), 'date')
     const dataLength = lastData.cumulative
     const sumInfoOfPatients = {
       lText: dataLength.toLocaleString(),

--- a/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
+++ b/components/cards/ConfirmedCasesByMunicipalitiesCard.vue
@@ -100,7 +100,7 @@ export default {
 
     const info = {
       sText: this.$t('{date}の累計', {
-        date: this.$d(new Date(datasets.date), 'dateWithoutYear'),
+        date: this.$d(new Date(datasets.date), 'date'),
       }),
     }
 

--- a/components/cards/PositiveNumberByDevelopedDateCard.vue
+++ b/components/cards/PositiveNumberByDevelopedDateCard.vue
@@ -59,7 +59,7 @@ export default {
             displayData: this.displayData,
             dataIndex: 1,
           })
-          const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
+          const formattedLastDay = this.$d(lastDay, 'date')
           if (this.dataKind === 'transition') {
             return {
               lText: lastDayData,

--- a/components/cards/PositiveNumberByDevelopedDateCard.vue
+++ b/components/cards/PositiveNumberByDevelopedDateCard.vue
@@ -97,7 +97,7 @@ export default {
       getDayjsObject(
         positiveByDeveloped.data.slice(-1)[0].developed_date
       ).toDate(),
-      'dateWithoutYear'
+      'date'
     )
 
     return {

--- a/components/cards/PositiveNumberByDiagnosedDateCard.vue
+++ b/components/cards/PositiveNumberByDiagnosedDateCard.vue
@@ -42,7 +42,7 @@ export default {
             displayData: this.displayData,
             dataIndex: 1,
           })
-          const formattedLastDay = this.$d(lastDay, 'dateWithoutYear')
+          const formattedLastDay = this.$d(lastDay, 'date')
           if (this.dataKind === 'transition') {
             return {
               lText: lastDayData,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5750

## 📝 関連する issue / Related Issues
- #5790
- 関連PR
  - #5826 
  - #5827

## ⛏ 変更内容 / Details of Changes
- 各グラフの見出しの日付に年を追加した

### その他
- 各グラフのテーブルの表示内容については #5826 で実装した
- 各グラフの注釈の日付については #5827 で実装した
- 各グラフのツールチップについては #5828 で実装した
- 各グラフのX軸については別途実装する

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-12-20 20 59 32](https://user-images.githubusercontent.com/23148331/102712682-49aef680-4306-11eb-82bd-3ee7156ccc2b.png)

### After
![スクリーンショット 2020-12-20 20 58 06](https://user-images.githubusercontent.com/23148331/102712644-1b311b80-4306-11eb-8c1e-7e1df83240f6.png)
