### PR TITLE
各グラフのテーブルの表示内容の日付に年を追加

### DIFF
--- a/components/DataViewTable.vue
+++ b/components/DataViewTable.vue
@@ -89,7 +89,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     formatDate(dateString: string): string {
       const date = getDayjsObject(dateString)
       if (date.isValid()) {
-        return this.$d(date.toDate(), 'dateWithoutYear')
+        return this.$d(date.toDate(), 'date')
       } else {
         return dateString
       }

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -192,7 +192,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     translateDate(date) {
       const day = dayjs(date)
       if (!day.isValid()) return date
-      return this.$d(day.toDate(), 'dateWithoutYear')
+      return this.$d(day.toDate(), 'date')
     },
     translateAge(_age) {
       const [age, dai] = _age.split(/(代)$/, 2)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- #5750

## 📝 関連する issue / Related Issues
- #5790 
- 関連PR
  - #5825 
  - #5827
  - #5828

## ⛏ 変更内容 / Details of Changes
- 各グラフのテーブルの表示内容の日付に年を追加した

## 📸 スクリーンショット / Screenshots
### Before
![スクリーンショット 2020-12-20 21 21 21](https://user-images.githubusercontent.com/23148331/102713151-57b24680-4309-11eb-8084-16fbe4eccb94.png)

### After
![スクリーンショット 2020-12-20 22 42 09](https://user-images.githubusercontent.com/23148331/102714812-a0bbc800-4314-11eb-99a6-f4f2e89b764a.png)

