### PR TITLE
各グラフのX軸に年を追加する

### DIFF
--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -316,7 +316,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -400,7 +400,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -255,8 +255,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOption() {
-      const self = this
       const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -264,12 +265,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return tooltipItem.datasetIndex !== 1
           },
           callbacks: {
-            label(tooltipItem) {
+            label: (tooltipItem) => {
               return `${parseInt(tooltipItem.value!).toLocaleString()} ${unit}`
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -330,18 +331,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -357,6 +360,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -414,16 +419,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -331,7 +331,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -373,7 +373,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -386,14 +386,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -407,13 +407,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では設定なし
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -326,6 +326,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
+                drawOnChartArea: true,
                 color: '#E5E5E5',
               },
               ticks: {
@@ -409,7 +410,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false, // displayOption では設定なし
+                drawOnChartArea: false, // displayOption では true
                 color: '#E5E5E5',
               },
               ticks: {

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -357,11 +357,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -375,7 +375,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -399,6 +398,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],

--- a/components/DashedRectangleTimeBarChart.vue
+++ b/components/DashedRectangleTimeBarChart.vue
@@ -323,7 +323,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
@@ -407,7 +407,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: false, // displayOption では true

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -388,12 +388,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -453,7 +453,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
@@ -465,14 +465,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -489,13 +489,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               position: 'left',
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -305,15 +305,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit[1]
-      const getFormatter = this.getFormatter
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {
-              const formatter = getFormatter(tooltipItem.datasetIndex!)
+              const formatter = this.getFormatter(tooltipItem.datasetIndex!)
               const cases = formatter(parseFloat(tooltipItem.value!))
               let label = `${
                 this.dataLabels[tooltipItem.datasetIndex!]
@@ -325,10 +325,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               }
               return label
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               if (tooltipItem[0].datasetIndex! < 4) {
                 const label = data.labels![tooltipItem[0].index!] as string
-                return self.$d(new Date(label), 'date')
+                return this.$d(new Date(label), 'date')
               }
               return ''
             },
@@ -391,18 +391,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -436,6 +438,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -493,16 +497,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -384,7 +384,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
@@ -486,7 +486,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: false,

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -437,11 +437,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -455,7 +455,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent',
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -479,13 +478,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
-              type: 'linear',
-              position: 'left',
               stacked: true,
               gridLines: {
                 display: true,

--- a/components/FeverMixedChart.vue
+++ b/components/FeverMixedChart.vue
@@ -377,7 +377,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -479,7 +479,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -380,12 +380,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -425,7 +425,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -438,14 +438,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -460,13 +460,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               position: 'left',
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -409,11 +409,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -427,7 +427,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -451,12 +450,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
-              type: 'linear',
               position: 'left',
               gridLines: {
                 display: true,

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -306,8 +306,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -320,9 +321,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 this.dataLabels[tooltipItem.datasetIndex!]
               } : ${cases} ${unit}`
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -383,18 +384,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -408,6 +411,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -465,16 +470,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/MixedBarAndLineChart.vue
+++ b/components/MixedBarAndLineChart.vue
@@ -369,7 +369,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -451,7 +451,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -381,12 +381,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -426,7 +426,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => dayjs(label).format('D'),
@@ -437,14 +437,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -459,13 +459,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               position: 'left',
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -370,7 +370,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -452,7 +452,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -410,11 +410,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -428,8 +428,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
-                callback: (label: string) => dayjs(label).format('D'),
+                callback: (label: string) => {
+                  return dayjs(label).format('D')
+                },
               },
             },
             {
@@ -450,12 +451,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
-              type: 'linear',
               position: 'left',
               gridLines: {
                 display: true,

--- a/components/MonitoringConfirmedCasesChart.vue
+++ b/components/MonitoringConfirmedCasesChart.vue
@@ -304,8 +304,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -318,10 +319,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 this.dataLabels[tooltipItem.datasetIndex!]
               } : ${cases} ${unit}`
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               if (tooltipItem[0].datasetIndex! < 2) {
                 const label = data.labels![tooltipItem[0].index!] as string
-                return self.$d(new Date(label), 'date')
+                return this.$d(new Date(label), 'date')
               }
               return ''
             },
@@ -384,18 +385,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -409,6 +412,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -466,16 +471,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -282,8 +282,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -295,9 +296,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ).toLocaleString()
               return `${labelText} : ${numberAsString} ${unit}`
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -358,18 +359,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -383,6 +386,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -440,16 +445,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -344,7 +344,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -426,7 +426,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -355,12 +355,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -400,7 +400,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -413,14 +413,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -435,13 +435,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               position: 'left',
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/MonitoringConsultationDeskReportChart.vue
+++ b/components/MonitoringConsultationDeskReportChart.vue
@@ -384,11 +384,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -402,7 +402,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -426,12 +425,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
-              type: 'linear',
               position: 'left',
               gridLines: {
                 display: true,

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -479,12 +479,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -494,12 +494,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMaxRight,
                 callback(value) {
                   return `${value}%`
@@ -584,7 +584,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -597,14 +597,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -621,13 +621,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -639,12 +639,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMaxRight,
                 callback(value) {
                   return `${value}%`

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -568,11 +568,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -586,7 +586,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -610,13 +609,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
               id: 'y-axis-1',
-              type: 'linear',
               position: 'left',
               stacked: true,
               gridLines: {
@@ -633,9 +634,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             {
               id: 'y-axis-2',
-              type: 'linear',
               position: 'right',
-              stacked: true,
               gridLines: {
                 display: true,
                 drawOnChartArea: false,

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -397,8 +397,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -417,9 +419,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               }
               return label
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!].toString()
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -482,10 +484,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
             {
@@ -497,11 +499,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMaxRight,
-                callback(value) {
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMaxRight,
+                callback: (value) => {
                   return `${value}%`
                 },
               },
@@ -509,9 +511,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -567,6 +571,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -626,10 +633,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
             {
@@ -641,11 +648,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMaxRight,
-                callback(value) {
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMaxRight,
+                callback: (value) => {
                   return `${value}%`
                 },
               },
@@ -654,6 +661,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/PositiveRateMixedChart.vue
+++ b/components/PositiveRateMixedChart.vue
@@ -466,7 +466,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -610,7 +610,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -256,6 +256,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
+                drawOnChartArea: true,
                 color: '#E5E5E5',
               },
               ticks: {
@@ -342,14 +343,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false, // displayOption では設定なし
+                drawOnChartArea: false, // displayOption では true
                 color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                // displayOption では suggestedMax の設定あり
+                suggestedMax: this.scaledTicksYAxisMax,
               },
             },
           ],

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -306,7 +306,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -319,14 +319,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
                 callback: (label: string) => {
                   const monthStringArry = [
@@ -358,13 +358,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では設定なし
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
+                // displayOption では suggestedMax の設定あり
               },
             },
           ],

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -290,11 +290,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -308,7 +308,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -328,28 +327,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontColor: 'transparent', // displayOption では '#808080'
                 padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
-                callback: (label: string) => {
-                  const monthStringArry = [
-                    'Jan',
-                    'Feb',
-                    'Mar',
-                    'Apr',
-                    'May',
-                    'Jun',
-                    'Jul',
-                    'Aug',
-                    'Sep',
-                    'Oct',
-                    'Nov',
-                    'Dec',
-                  ]
-                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
-                  return month + '月'
-                },
               },
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -184,22 +184,22 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOption() {
-      const self = this
       const unit = this.unit
       const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
           callbacks: {
-            label(tooltipItem) {
+            label: (tooltipItem) => {
               const labelText = `${parseInt(
                 tooltipItem.value!
               ).toLocaleString()} ${unit}`
               return labelText
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -260,18 +260,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
+                suggestedMin: 0,
                 suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -290,6 +292,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -347,16 +351,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -246,7 +246,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -333,7 +333,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/SevereCaseBarChart.vue
+++ b/components/SevereCaseBarChart.vue
@@ -253,7 +253,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
@@ -340,7 +340,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: false, // displayOption では true

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -408,7 +408,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -421,14 +421,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
                 callback: (label: string) => {
                   const monthStringArry = [
@@ -460,13 +460,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では設定なし
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
+                // displayOption では suggestedMax の設定あり
               },
             },
           ],

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -277,22 +277,22 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOption() {
-      const self = this
       const unit = this.unit
       const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
           callbacks: {
-            label(tooltipItem) {
+            label: (tooltipItem) => {
               const labelText = `${parseInt(
                 tooltipItem.value!
               ).toLocaleString()} ${unit}`
               return labelText
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -353,18 +353,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
+                suggestedMin: 0,
                 suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -451,9 +453,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
+                suggestedMin: 0,
                 suggestedMax: scaledTicksYAxisMax,
               },
             },
@@ -461,6 +463,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -392,6 +392,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -452,7 +454,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                // displayOption では suggestedMax の設定あり
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -339,7 +339,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -435,7 +435,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -392,11 +392,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -410,7 +410,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -430,28 +429,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontColor: 'transparent', // displayOption では '#808080'
                 padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
-                callback: (label: string) => {
-                  const monthStringArry = [
-                    'Jan',
-                    'Feb',
-                    'Mar',
-                    'Apr',
-                    'May',
-                    'Jun',
-                    'Jul',
-                    'Aug',
-                    'Sep',
-                    'Oct',
-                    'Nov',
-                    'Dec',
-                  ]
-                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
-                  return month + '月'
-                },
               },
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -346,7 +346,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
@@ -442,7 +442,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: false, // displayOption では true

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -349,6 +349,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
+                drawOnChartArea: true,
                 color: '#E5E5E5',
               },
               ticks: {
@@ -444,7 +445,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false, // displayOption では設定なし
+                drawOnChartArea: false, // displayOption では true
                 color: '#E5E5E5',
               },
               ticks: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -403,7 +403,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
@@ -503,7 +503,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
           yAxes: [
             {
-              stacked: true,
+              position: 'left',
               gridLines: {
                 display: true,
                 drawOnChartArea: false, // displayOption では true

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -396,7 +396,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -496,7 +496,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -406,6 +406,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
+                drawOnChartArea: true,
                 color: '#E5E5E5',
               },
               ticks: {
@@ -505,7 +506,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false, // displayOption では設定なし
+                drawOnChartArea: false, // displayOption では true
                 color: '#E5E5E5',
               },
               ticks: {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -453,11 +453,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -471,7 +471,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -491,28 +490,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 fontColor: 'transparent', // displayOption では '#808080'
                 padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
-                callback: (label: string) => {
-                  const monthStringArry = [
-                    'Jan',
-                    'Feb',
-                    'Mar',
-                    'Apr',
-                    'May',
-                    'Jun',
-                    'Jul',
-                    'Aug',
-                    'Sep',
-                    'Oct',
-                    'Nov',
-                    'Dec',
-                  ]
-                  const month = monthStringArry.indexOf(label.split(' ')[0]) + 1
-                  return `${month}月`
-                },
               },
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -311,7 +311,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit
       const sumArray = this.eachArraySum(this.chartData)
       const data = this.chartData
@@ -319,6 +318,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         return this.cumulative(item)
       })
       const cumulativeSumArray = this.eachArraySum(cumulativeData)
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
@@ -347,9 +348,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               }
               return label
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               const label = data.labels![tooltipItem[0].index!] as string
-              return self.$d(new Date(label), 'date')
+              return this.$d(new Date(label), 'date')
             },
           },
         },
@@ -410,18 +411,20 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
-                suggestedMax: this.scaledTicksYAxisMax,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -453,6 +456,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -510,16 +515,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
           ],
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {

--- a/components/TimeStackedBarChart.vue
+++ b/components/TimeStackedBarChart.vue
@@ -469,7 +469,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -482,14 +482,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
                 callback: (label: string) => {
                   const monthStringArry = [
@@ -521,13 +521,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では設定なし
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -465,12 +465,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: true,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -480,12 +480,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMaxRight,
                 callback(value) {
                   return `${value}%`
@@ -555,7 +555,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               ticks: {
                 fontSize: 9,
                 maxTicksLimit: 20,
-                fontColor: 'transparent',
+                fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
                 minRotation: 0,
                 callback: (label: string) => {
@@ -568,14 +568,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 drawOnChartArea: false,
-                drawTicks: false, // true -> false
+                drawTicks: false, // displayOption では true
                 drawBorder: false,
                 tickMarkLength: 10,
               },
               ticks: {
                 fontSize: 11,
-                fontColor: 'transparent', // #808080
-                padding: 13, // 3 + 10(tickMarkLength)
+                fontColor: 'transparent', // displayOption では '#808080'
+                padding: 13, // 3 + 10(tickMarkLength)，displayOption では 3
                 fontStyle: 'bold',
               },
               type: 'time',
@@ -592,13 +592,13 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               stacked: true,
               gridLines: {
                 display: true,
-                drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                drawOnChartArea: false, // displayOption では true
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMax,
               },
             },
@@ -609,12 +609,12 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
-                color: '#E5E5E5', // #E5E5E5
+                color: '#E5E5E5',
               },
               ticks: {
                 suggestedMin: 0,
                 maxTicksLimit: 8,
-                fontColor: '#808080', // #808080
+                fontColor: '#808080',
                 suggestedMax: this.scaledTicksYAxisMaxRight,
                 callback(value) {
                   return `${value}%`

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -539,11 +539,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayOptionHeader() {
       const options: Chart.ChartOptions = {
+        tooltips: { enabled: false },
         maintainAspectRatio: false,
         legend: {
           display: false,
         },
-        tooltips: { enabled: false },
         scales: {
           xAxes: [
             {
@@ -557,7 +557,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 20,
                 fontColor: 'transparent', // displayOption では '#808080'
                 maxRotation: 0,
-                minRotation: 0,
                 callback: (label: string) => {
                   return dayjs(label).format('D')
                 },
@@ -581,13 +580,15 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               type: 'time',
               time: {
                 unit: 'month',
+                displayFormats: {
+                  month: 'MMM',
+                },
               },
             },
           ],
           yAxes: [
             {
               id: 'y-axis-1',
-              type: 'linear',
               position: 'left',
               stacked: true,
               gridLines: {
@@ -604,7 +605,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             },
             {
               id: 'y-axis-2',
-              type: 'linear',
               position: 'right',
               gridLines: {
                 display: true,

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -452,7 +452,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },
@@ -581,7 +581,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               time: {
                 unit: 'month',
                 displayFormats: {
-                  month: 'MMM',
+                  month: 'YYYY-MM',
                 },
               },
             },

--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -380,16 +380,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const self = this
       const unit = this.unit[1]
-      const getFormatter = this.getFormatter
+
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
+
       const options: Chart.ChartOptions = {
         tooltips: {
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {
-              const formatter = getFormatter(tooltipItem.datasetIndex!)
-              const cases = formatter(parseFloat(tooltipItem.value!))
+              const cases = this.getFormatter(tooltipItem.datasetIndex!)(
+                parseFloat(tooltipItem.value!)
+              )
               let label = `${
                 this.dataLabels[tooltipItem.datasetIndex!]
               } : ${cases} ${this.$t('人')}`
@@ -400,10 +403,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               }
               return label
             },
-            title(tooltipItem, data) {
+            title: (tooltipItem, data) => {
               if (tooltipItem[0].datasetIndex! < 4) {
                 const label = data.labels![tooltipItem[0].index!] as string
-                return self.$d(new Date(label), 'date')
+                return this.$d(new Date(label), 'date')
               }
               return ''
             },
@@ -468,10 +471,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
             {
@@ -483,11 +486,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMaxRight,
-                callback(value) {
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMaxRight,
+                callback: (value) => {
                   return `${value}%`
                 },
               },
@@ -495,9 +498,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
         },
       }
+
       if (this.$route.query.ogp === 'true') {
         Object.assign(options, { animation: { duration: 0 } })
       }
+
       return options
     },
     displayDataHeader() {
@@ -538,6 +543,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
+      const scaledTicksYAxisMax = this.scaledTicksYAxisMax
+      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
+
       const options: Chart.ChartOptions = {
         tooltips: { enabled: false },
         maintainAspectRatio: false,
@@ -597,10 +605,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMax,
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMax,
               },
             },
             {
@@ -612,11 +620,11 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 color: '#E5E5E5',
               },
               ticks: {
-                suggestedMin: 0,
                 maxTicksLimit: 8,
                 fontColor: '#808080',
-                suggestedMax: this.scaledTicksYAxisMaxRight,
-                callback(value) {
+                suggestedMin: 0,
+                suggestedMax: scaledTicksYAxisMaxRight,
+                callback: (value) => {
                   return `${value}%`
                 },
               },
@@ -625,6 +633,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         },
         animation: { duration: 0 },
       }
+
       return options
     },
     scaledTicksYAxisMax() {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5750 
- close #5790 

## 📝 関連する issue / Related Issues
- #5841 

## ⛏ 変更内容 / Details of Changes
- #5825, #5826, #5827, #5828, #5842 のつづき
- ~JSON ファイルに2021年のデータがないとY軸がズレる（あるいは，2021年のデータがあってもズレることがある）ため，すべてのグラフで2021年のデータが揃い，正しく表示されることを確認するまでは WIP とする．~
  - ~2021年のデータがあってもズレるのは，目盛りが二重に描画されているためと思われるので，sticky-chart slot を利用しないようにすることで解消する~
- 2021年のデータが揃っても #5841 にあるようなズレが解消できないケースがあった．同じコンポーネントを使っていてもグラフが異なるとズレたりズレなかったりして原因究明が難しい．
- 月を「2021-01」のような表示すれば，前述の問題も発生せず，見やすさの上でもメリットがあるため，そのような実装に改めた．
- グラフの表示設定が各コンポーネント間で似ているようで異なる形になっており，不要なコメント，意味の不明瞭なコメントも見られたため，今後のリファクタリングのしやすさも考慮の上で改めた．（見た目の変更はなし）

### 変更対象のグラフ
- モニタリング項目
  - [x] 報告日別による陽性者数の推移
  - [x] モニタリング項目(1) 新規陽性者数
  - [x] モニタリング項目(2) #7119における発熱等相談件数
  - [x] モニタリング項目(3) 新規陽性者における接触歴等不明者数
  - [x] モニタリング項目(4) 検査の陽性率
  - [x] モニタリング項目(5) 救急医療の東京ルールの適用件数
  - [x] モニタリング項目(6) 入院患者数
  - [x] モニタリング項目(7) 重症患者数
- その他 参考指標
  - [x] 発症日別による陽性者数の推移
  - [x] 確定日別による陽性者数の推移
  - [x] 検査実施件数
  - [x] 新型コロナコールセンター相談件数
  - [x] 受診相談窓口における相談件数
    - 2020年10月30日で更新が打ち切られているが，コンポーネントの設計は他のグラフに合わせる
  - [x] 東京都発熱相談センターにおける相談件数

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
