### PR TITLE
[bugfix]モニタリング項目(3)接触歴等不明者数（７日間移動平均）を左Y軸に修正

### DIFF
--- a/components/UntrackedRateMixedChart.vue
+++ b/components/UntrackedRateMixedChart.vue
@@ -523,9 +523,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             borderWidth: 0,
           },
           {
-            data: [this.displayData.datasets[2].data[n]],
+            data: [0],
             backgroundColor: 'transparent',
-            yAxisID: 'y-axis-2',
+            yAxisID: 'y-axis-1',
             borderWidth: 0,
           },
           {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5862 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- モニタリング項目(3)のグラフで、接触歴等不明者数（７日間移動平均）が右Y軸に設定されていたため、右Y軸の目盛りが実際の値と合っていなかったのを修正しました。
- `labels: ['2020-01-01']` のdatasetsで、接触歴等不明者数（７日間移動平均）のグラフの値を「0」にすることで、左Y軸のずれも解消しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-01-04 11 55 11](https://user-images.githubusercontent.com/14883063/103497449-e89a2d80-4e84-11eb-9581-6b881dfa059c.png)
