### PR TITLE
Vuetifyのアップデートにともなうスタイルの修正

### DIFF
--- a/components/CardsLazyRow.vue
+++ b/components/CardsLazyRow.vue
@@ -77,13 +77,7 @@ export default options
   margin-top: 20px;
 
   .DataCard {
-    @include largerThan($medium) {
-      padding: 10px;
-    }
-
-    @include lessThan($small) {
-      padding: 4px 8px;
-    }
+    margin: 8px 0;
   }
 }
 </style>


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #5908

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- #5908 でVuetifyがアップデートされ、一部スタイルが変更になっていました。
- `.v-window` に `overflow:hidden` が追加されたために、カードの両はじが切れたようになっていました。
- `.DataCard` に `padding` を設定していたのが影響していたようなので、削除しました。
- 代わりに `margin` を設定しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
before
![スクリーンショット 2021-01-21 21 01 21](https://user-images.githubusercontent.com/14883063/105349236-c4806f80-5c2c-11eb-840f-fe59052b5b5d.png)

after
![スクリーンショット 2021-01-21 21 03 48](https://user-images.githubusercontent.com/14883063/105349263-ccd8aa80-5c2c-11eb-824c-df3dc80b2c43.png)
