### PR TITLE
相対パスによる import を禁止するため .eslintrc.js の設定を追加／相対パスによる import をしている箇所を修正

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,11 @@ module.exports = {
     ],
     'tsdoc/syntax': 'error',
     'simple-import-sort/sort': 'error',
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: ['./', '../'],
+      },
+    ],
   },
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,6 @@
 import { NuxtConfig } from '@nuxt/types'
 
+// eslint-disable-next-line no-restricted-imports
 import i18n from './nuxt-i18n.config'
 const environment = process.env.NODE_ENV || 'development'
 

--- a/plugins/vue-chart.ts
+++ b/plugins/vue-chart.ts
@@ -3,7 +3,7 @@ import { Chart, ChartData, ChartOptions } from 'chart.js'
 import Vue, { PropType } from 'vue'
 import { Bar, Doughnut, Line, mixins } from 'vue-chartjs'
 
-import { useDayjsAdapter } from './chartjs-adapter-dayjs'
+import { useDayjsAdapter } from '@/plugins/chartjs-adapter-dayjs'
 
 type ChartVCData = { chartData: ChartData }
 type ChartVCMethod = {


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6021

## 📝 関連する issue / Related Issues
- #6022

## ⛏ 変更内容 / Details of Changes
- 相対パスによる import を禁止するため .eslintrc.js を変更
- 相対パスによる import をしている箇所を修正

## 📸 スクリーンショット / Screenshots
スタイルの変更はなし