### PR TITLE
日付のフォーマットを統一する

### DIFF
--- a/components/InfectionMedicalcareprovisionStatus.vue
+++ b/components/InfectionMedicalcareprovisionStatus.vue
@@ -57,7 +57,6 @@
 </template>
 
 <script lang="ts">
-import dayjs from 'dayjs'
 import Vue from 'vue'
 
 import InfectionMedicalcareprovisionStatus from '@/data/infection_medicalcareprovision_status.json'
@@ -65,12 +64,12 @@ import InfectionMedicalcareprovisionStatus from '@/data/infection_medicalcarepro
 export default Vue.extend({
   data() {
     const date = InfectionMedicalcareprovisionStatus.date
+    const statisticDate =
+      InfectionMedicalcareprovisionStatus.data['検査統計日時']
     return {
       statuses: InfectionMedicalcareprovisionStatus,
       date: this.$d(new Date(date), 'date'),
-      statisticDate: dayjs(
-        InfectionMedicalcareprovisionStatus.data['検査統計日時']
-      ).format('MM/DD'),
+      statisticDate: this.$d(new Date(statisticDate), 'dateWithoutYear'),
     }
   },
 })

--- a/components/InfectionMedicalcareprovisionStatus.vue
+++ b/components/InfectionMedicalcareprovisionStatus.vue
@@ -64,11 +64,10 @@ import InfectionMedicalcareprovisionStatus from '@/data/infection_medicalcarepro
 
 export default Vue.extend({
   data() {
+    const date = InfectionMedicalcareprovisionStatus.date
     return {
       statuses: InfectionMedicalcareprovisionStatus,
-      date: dayjs(InfectionMedicalcareprovisionStatus.date).format(
-        'YYYY年MM月DD日'
-      ),
+      date: this.$d(new Date(date), 'date'),
       statisticDate: dayjs(
         InfectionMedicalcareprovisionStatus.data['検査統計日時']
       ).format('MM/DD'),

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -46,12 +46,16 @@ export default Vue.extend({
   computed: {
     formattedData() {
       const data = StayingPopulation.data.data
+      const self = this
 
       return data.map((dataForEachMonth) => {
-        const formattedMonth = dayjs(dataForEachMonth.reference_date).format(
-          'YYYY/MM'
-        )
+        const referenceDate = dataForEachMonth.reference_date
         const increaseRate = dataForEachMonth.increase_rate
+
+        const formattedMonth = self.$d(
+          new Date(referenceDate),
+          'dateWithoutDay'
+        )
 
         let increaseRateWithArrow = '0'
         if (increaseRate !== 0) {

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -45,11 +45,12 @@ export default Vue.extend({
     },
   },
   data() {
+    const date = StayingPopulation.data.date
     return {
       mdiChevronRight,
       StayingPopulation,
       placeName: StayingPopulation.data.place.display,
-      date: dayjs(StayingPopulation.data.date).format('YYYY年MM月DD日'),
+      date: this.$d(new Date(date), 'date'),
     }
   },
 })

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -19,8 +19,8 @@
       <div class="StayingPopulation-state">
         [ {{ date }}時点 ]<br />
         <span v-for="(data, key) in StayingPopulation.data.data" :key="key">
-          {{ data['reference_date'] | formatDate }}比
-          {{ data['increase_rate'] | arrow }}％<br />
+          {{ data['reference_date'] | formattedMonth }}比
+          {{ data['increase_rate'] | increaseRateWithArrow }}％<br />
         </span>
       </div>
     </div>
@@ -36,10 +36,10 @@ import StayingPopulation from '@/data/staying_population.json'
 
 export default Vue.extend({
   filters: {
-    formatDate(text: string) {
+    formattedMonth(text: string) {
       return dayjs(text).format('YYYY/MM')
     },
-    arrow: (increaseRate: number) => {
+    increaseRateWithArrow: (increaseRate: number) => {
       if (increaseRate === 0) return 0
       return (increaseRate > 0 ? '↑' : '↓') + Math.abs(increaseRate)
     },

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -17,8 +17,10 @@
       </div>
       <div v-else class="StayingPopulation-place">{{ placeName['@en'] }}</div>
       <div class="StayingPopulation-state">
+        <!-- TODO: 「時点」は辞書を参照するようにする -->
         [ {{ date }}時点 ]<br />
         <span v-for="(data, index) in formattedData" :key="index">
+          <!-- TODO: 「比」は辞書を参照するようにする -->
           {{ data.formattedMonth }}比 {{ data.increaseRateWithArrow }}<br />
         </span>
       </div>

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -18,9 +18,8 @@
       <div v-else class="StayingPopulation-place">{{ placeName['@en'] }}</div>
       <div class="StayingPopulation-state">
         [ {{ date }}時点 ]<br />
-        <span v-for="(data, key) in StayingPopulation.data.data" :key="key">
-          {{ data['reference_date'] | formattedMonth }}比
-          {{ data['increase_rate'] | increaseRateWithArrow }}％<br />
+        <span v-for="(data, index) in formattedData" :key="index">
+          {{ data.formattedMonth }}比 {{ data.increaseRateWithArrow }}％<br />
         </span>
       </div>
     </div>
@@ -35,15 +34,6 @@ import Vue from 'vue'
 import StayingPopulation from '@/data/staying_population.json'
 
 export default Vue.extend({
-  filters: {
-    formattedMonth(text: string) {
-      return dayjs(text).format('YYYY/MM')
-    },
-    increaseRateWithArrow: (increaseRate: number) => {
-      if (increaseRate === 0) return 0
-      return (increaseRate > 0 ? '↑' : '↓') + Math.abs(increaseRate)
-    },
-  },
   data() {
     const date = StayingPopulation.data.date
     return {
@@ -52,6 +42,29 @@ export default Vue.extend({
       placeName: StayingPopulation.data.place.display,
       date: this.$d(new Date(date), 'date'),
     }
+  },
+  computed: {
+    formattedData() {
+      const data = StayingPopulation.data.data
+
+      return data.map((dataForEachMonth) => {
+        const formattedMonth = dayjs(dataForEachMonth.reference_date).format(
+          'YYYY/MM'
+        )
+        const increaseRate = dataForEachMonth.increase_rate
+
+        let increaseRateWithArrow = '0'
+        if (increaseRate !== 0) {
+          const arrow = increaseRate > 0 ? '↑' : '↓'
+          increaseRateWithArrow = `${arrow}${Math.abs(increaseRate)}`
+        }
+
+        return {
+          formattedMonth,
+          increaseRateWithArrow,
+        }
+      })
+    },
   },
 })
 </script>

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -28,7 +28,6 @@
 
 <script lang="ts">
 import { mdiChevronRight } from '@mdi/js'
-import dayjs from 'dayjs'
 import Vue from 'vue'
 
 import StayingPopulation from '@/data/staying_population.json'

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -19,7 +19,7 @@
       <div class="StayingPopulation-state">
         [ {{ date }}時点 ]<br />
         <span v-for="(data, index) in formattedData" :key="index">
-          {{ data.formattedMonth }}比 {{ data.increaseRateWithArrow }}％<br />
+          {{ data.formattedMonth }}比 {{ data.increaseRateWithArrow }}<br />
         </span>
       </div>
     </div>
@@ -59,7 +59,7 @@ export default Vue.extend({
         let increaseRateWithArrow = '0'
         if (increaseRate !== 0) {
           const arrow = increaseRate > 0 ? '↑' : '↓'
-          increaseRateWithArrow = `${arrow}${Math.abs(increaseRate)}`
+          increaseRateWithArrow = `${arrow}${Math.abs(increaseRate)} %`
         }
 
         return {

--- a/components/StayingPopulation.vue
+++ b/components/StayingPopulation.vue
@@ -36,15 +36,16 @@ import StayingPopulation from '@/data/staying_population.json'
 
 export default Vue.extend({
   data() {
-    const date = StayingPopulation.data.date
     return {
       mdiChevronRight,
       StayingPopulation,
       placeName: StayingPopulation.data.place.display,
-      date: this.$d(new Date(date), 'date'),
     }
   },
   computed: {
+    date() {
+      return this.$d(new Date(StayingPopulation.data.date), 'date')
+    },
     formattedData() {
       const data = StayingPopulation.data.data
       const self = this

--- a/nuxt-i18n.config.ts
+++ b/nuxt-i18n.config.ts
@@ -18,6 +18,10 @@ const dateTimeFormatsCommon = {
     month: 'long',
     day: 'numeric',
   },
+  dateWithoutDay: {
+    year: 'numeric',
+    month: 'short',
+  },
   dateWithDayOfWeek: {
     weekday: 'short',
     month: 'short',


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #5973

## ⛏ 変更内容 / Details of Changes
- 日付のフォーマットを「2021年3月2日」の形式に統一した．

## 📸 スクリーンショット / Screenshots
### Before
<img width="1098" alt="スクリーンショット 2021-03-02 19 21 49" src="https://user-images.githubusercontent.com/23148331/109634471-9cb9eb00-7b8c-11eb-98f8-79aa96f632aa.png">

### After
<img width="1098" alt="スクリーンショット 2021-03-02 19 21 58" src="https://user-images.githubusercontent.com/23148331/109634483-a17e9f00-7b8c-11eb-8942-ff3f1cbd629a.png">
