### PR TITLE
企業の皆様・はたらく皆様へ」ページ内「営業時間短縮に係る感染拡大防止協力金（2/8～3/7実施分）」の外部リンクURLを変更

### DIFF
--- a/pages/worker.vue
+++ b/pages/worker.vue
@@ -54,7 +54,7 @@
     <static-card>
       <h3>
         <app-link
-          to="https://www.sangyo-rodo.metro.tokyo.lg.jp/attention/2021/0205_14245.html"
+          to="https://jitan.metro.tokyo.lg.jp/feb/index.html"
           :icon-size="24"
           >{{ $t('営業時間短縮に係る感染拡大防止協力金（2/8～3/7実施分）') }}
         </app-link>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6065 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「企業の皆様・はたらく皆様へ」ページ内「営業時間短縮に係る感染拡大防止協力金（2/8～3/7実施分）」の外部リンクURLを以下のように修正
  - 修正前：https://www.sangyo-rodo.metro.tokyo.lg.jp/attention/2021/0205_14245.html
  - 修正後：https://jitan.metro.tokyo.lg.jp/feb/index.html

## 📸 スクリーンショット / Screenshots
上の方のリンクの修正です

![image](https://user-images.githubusercontent.com/42486288/110259578-b1164180-7feb-11eb-9818-787d9697e163.png)

