### PR TITLE
kyoto.stopcovid19.jpの公式化に伴い、表記を変更

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -43,7 +43,7 @@
 |[](24)三重県|https://mie.stopcovid19.jp/|高専生チーム（有志）|[FlexiblePrintedCircuits/covid19-mie](https://github.com/FlexiblePrintedCircuits/covid19-mie)||
 |[](25)滋賀県|https://stopcovid19.pref.shiga.jp/|滋賀県（**公式**）|[Shiga-pref-org/covid19](https://github.com/Shiga-pref-org/covid19)||
 |[](26)京都府|https://stopcovid19-kyoto.netlify.app/|有志|[stopcovid19-kyoto/covid19](https://github.com/stopcovid19-kyoto/covid19)||
-|[](26)京都府|https://kyoto.stopcovid19.jp/|有志|[stop-covid19-kyoto/covid19-kyoto](https://github.com/stop-covid19-kyoto/covid19-kyoto)||
+|[](26)京都府|https://kyoto.stopcovid19.jp/|京都府（**公式**）|[stop-covid19-kyoto/covid19-kyoto](https://github.com/stop-covid19-kyoto/covid19-kyoto)||
 |[](27)大阪府|https://covid19-osaka.info/|大阪府（**公式**）|[codeforosaka/covid19](https://github.com/codeforosaka/covid19)||
 |[](28)兵庫県|https://stop-covid19-hyogo.org/|有志|[stop-covid19-hyogo/covid19](https://github.com/stop-covid19-hyogo/covid19)||
 |[](29)奈良県|https://stopcovid19.code4nara.org/|有志|[code4nara/covid19](https://github.com/code4nara/covid19)||


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #6092 

## ⛏ 変更内容 / Details of Changes
- FORKED_SITES.mdのkyoto.stopcovid19.jpの体制を「有志」から「京都府（**公式**）」に変更
