### PR TITLE
MonitoringCommentCardImageSwipe.vue のデリミタを表示

### DIFF
--- a/components/MonitoringCommentCardImageSwipe.vue
+++ b/components/MonitoringCommentCardImageSwipe.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-carousel cycle width="240" height="260">
+  <v-carousel cycle width="240" height="260" :delimiter-icon="delimiterIcon">
     <v-carousel-item
       v-for="(item, i) in monitoringCommentImage.data.images"
       :key="i"
@@ -18,6 +18,7 @@
 </template>
 
 <script lang="ts">
+import { mdiCircle } from '@mdi/js'
 import Vue from 'vue'
 
 import monitoringCommentImage from '@/data/monitoring_comment_image.json'
@@ -25,6 +26,7 @@ import monitoringCommentImage from '@/data/monitoring_comment_image.json'
 export default Vue.extend({
   data() {
     return {
+      delimiterIcon: mdiCircle,
       monitoringCommentImage,
     }
   },

--- a/components/MonitoringCommentCardImageSwipe.vue
+++ b/components/MonitoringCommentCardImageSwipe.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-carousel cycle width="240" height="180" hide-delimiter-background>
+  <v-carousel cycle width="240" height="180">
     <v-carousel-item
       v-for="(item, i) in monitoringCommentImage.data.images"
       :key="i"

--- a/components/MonitoringCommentCardImageSwipe.vue
+++ b/components/MonitoringCommentCardImageSwipe.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-carousel cycle width="240" height="180">
+  <v-carousel cycle width="240" height="260">
     <v-carousel-item
       v-for="(item, i) in monitoringCommentImage.data.images"
       :key="i"


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #6083

## ⛏ 変更内容 / Details of Changes

- デリミタの背景を表示するために、デリミタの背景を非表示にするオプション（`hide-delimiter-background`）を無効化
- デリミタのアイコンに[circle](https://materialdesignicons.com/icon/circle)を指定
- デリミタ部分が画像に被らないように、カルーセルの高さを`180`から`260`に変更

## 📸 スクリーンショット / Screenshots

|before|after|
|---|---|
|<img width="538" src="https://user-images.githubusercontent.com/20086673/111061560-54cd8900-84e7-11eb-8598-c77127bda32e.png">|<img width="538" src="https://user-images.githubusercontent.com/20086673/111061568-5eef8780-84e7-11eb-972a-4f9ca229bf6b.png">|
