### PR TITLE
components/SiteTopUpper.vue の不要な import を削除する

### DIFF
--- a/components/SiteTopUpper.vue
+++ b/components/SiteTopUpper.vue
@@ -37,7 +37,6 @@ import StayingPopulation from '@/components/StayingPopulation.vue'
 import WhatsNew from '@/components/WhatsNew.vue'
 import Data from '@/data/data.json'
 import News from '@/data/news.json'
-import TokyoAlert from '@/data/tokyo_alert.json'
 import { convertDatetimeToISO8601Format } from '@/utils/formatDate'
 
 export default Vue.extend({
@@ -52,7 +51,6 @@ export default Vue.extend({
     const { lastUpdate } = Data
 
     return {
-      TokyoAlert,
       headerItem: {
         iconPath: mdiChartTimelineVariant,
         title: this.$t('都内の最新感染動向'),


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6110

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `components/SiteTopUpper.vue` で不要な `data/tokyo_alert.json` が import されているため削除する

## 📸 スクリーンショット / Screenshots
見た目の変更はなし
