### PR TITLE
data/monitoring_items.json の String の値を Integer にする

### DIFF
--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -136,15 +136,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       bold: true,
     },
     '(6)入院患者確保病床数': {
-      // NOTE:
-      //   data/monitoring_items.json の '(6)入院患者確保病床数' の値が String 型のため，
-      //   末尾の「床」を除去して Integer 型に変換している．
-      // TODO: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にする．
-      // NOTE: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にしても動作するようにしてある．
-      // TODO: data/monitoring_items.json の '(6)入院患者確保病床数' の値を Integer 型にした後，書き換える．
-      value: toInteger(
-        parseInt(`${rawDataObj['(6)入院患者確保病床数']}`.replace(/床$/, ''))
-      ),
+      value: toInteger(rawDataObj['(6)入院患者確保病床数']),
       unit: unitBed,
       bold: false,
     },
@@ -154,15 +146,7 @@ export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
       bold: true,
     },
     '(7)重症患者確保病床数': {
-      // NOTE:
-      //   data/monitoring_items.json の '(7)重症患者確保病床数' の値が String 型のため，
-      //   末尾の「床」を除去して Integer 型に変換している．
-      // TODO: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にする．
-      // NOTE: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にしても動作するようにしてある．
-      // TODO: data/monitoring_items.json の '(7)重症患者確保病床数' の値を Integer 型にした後，書き換える．
-      value: toInteger(
-        parseInt(`${rawDataObj['(7)重症患者確保病床数']}`.replace(/床$/, ''))
-      ),
+      value: toInteger(rawDataObj['(7)重症患者確保病床数']),
       unit: unitBed,
       bold: false,
     },

--- a/utils/formatMonitoringItems.ts
+++ b/utils/formatMonitoringItems.ts
@@ -65,7 +65,7 @@ export type MonitoringItems = Record<DataKey, MonitoringItemValue>
 /**
  * monitoring_items_json のデータを整形
  *
- * @param data - Raw data
+ * @param rawDataObj - Raw data
  */
 export const formatMonitoringItems = (rawDataObj: RawData): MonitoringItems => {
   const unitPerson: Unit = { text: '人', translatable: true }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5329

## 📝 関連する issue / Related Issues
- (issue) #5307, (PR) #5323, #5324, #5325

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- [data/monitoring_items.json](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/data/monitoring_items.json#L12) に
```
"(6)入院患者確保病床数": "2500床",
```

```
"(7)重症患者確保病床数": "150床",
```
と単位も含めた文字列がベタ書きされているので，#5323 で thousands separator を入れるにあたり，「床」を除去して `parseInt` で Integer に変換する処理を入れた．(cf. https://github.com/tokyo-metropolitan-gov/covid19/pull/5323/files#diff-efd4f86cb292769b6e2b9f5b1179422eR127)
#5323 が merge された後，`data/monitoring_items.json` の仕様を変更して JSON に Integer の値を保持するようになり (cf. 5d78f0b)，「「床」を除去して `parseInt` で Integer に変換する処理」が不要となったため，これを除去する．

cf. https://github.com/tokyo-metropolitan-gov/covid19/issues/5307#issuecomment-678411154

## 📸 スクリーンショット / Screenshots
- 見た目の変更はなし
