### PR TITLE
ServiceWorkerの登録を解除する(キャッシュ問題 ローディングで止まってしまう)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -226,7 +226,9 @@ const config: NuxtConfig = {
    * https://pwa.nuxtjs.org/workbox
    */
   pwa: {
-    workbox: false,
+    workbox: {
+      enabled: false,
+    },
   },
   // /*
   // ** hot read configuration for docker


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6023 (キャッシュ問題 ローディングで止まってしまう)

## 📝 関連する issue / Related Issues
- #6134 


## ⛏ 変更内容 / Details of Changes
- #6134 がマージされましたが、それでは解消しないと思うので、正しくServiceWorkerを登録解除する

#6134 のコード
```
pwa: {
  workbox: false,
},
```
だと、sw.jsを生成しなくなってしまうので、一般ユーザーのブラウザにはsw.jsがServiceWorkerとして登録されたまま。


このコード
```
pwa: {
  workbox: {
    enabled: false,
  },
},
```
だと、sw.jsは生成するけど、その生成されたコードの中身は sw.js を ServiceWorker から登録解除する内容になる。


## #6134 がマージされる前のコード(sw.jsがServiceWorkerとして機能している)
<img width="1274" alt="Screen Shot 2021-03-30 at 5 19 35 PM" src="https://user-images.githubusercontent.com/242669/112958476-78e2c880-917d-11eb-9ab0-f47e7ba674c8.png">

## この状態で新しい本番ビルドをすると /_nuxt/[chunk].js の chunkファイル名が変わってしまいローディングが止まってしまう(必要な.jsファイルが404になってしまう)
<img width="1274" alt="Screen Shot 2021-03-30 at 5 20 14 PM" src="https://user-images.githubusercontent.com/242669/112958633-a3348600-917d-11eb-967c-977d1654b7e3.png">

## #6134 がマージされた後のコードでもローディングが止まってしまう(sw.jsが生成されなくなったが、ブラウザにはsw.jsがServiceWorkerとして登録されたままのため不具合は解消しない)
<img width="1274" alt="Screen Shot 2021-03-30 at 5 20 28 PM" src="https://user-images.githubusercontent.com/242669/112958872-d70fab80-917d-11eb-9bf9-0c4f8f2acc3d.png">

## このコードをマージした後(sw.jsがServiceWorkerからunregisterされる)
<img width="1274" alt="Screen Shot 2021-03-30 at 5 21 59 PM" src="https://user-images.githubusercontent.com/242669/112958940-e55dc780-917d-11eb-917d-9d54c8f75139.png">

このコードをマージした後に生成される sw.js の中身は、sw.js を ServiceWorker から unregisterするコードになる。
<img width="1274" alt="Screen Shot 2021-03-30 at 5 22 23 PM" src="https://user-images.githubusercontent.com/242669/112959307-3d94c980-917e-11eb-94d7-ff3813d9616d.png">




