### PR TITLE
components/CardsMonitoring.vue: 不要な CSS 定義を削除

### DIFF
--- a/components/CardsMonitoring.vue
+++ b/components/CardsMonitoring.vue
@@ -50,18 +50,3 @@ export default Vue.extend({
   },
 })
 </script>
-
-<style lang="scss" scoped>
-.AttentionNote {
-  margin: 10px 0;
-  padding: 12px;
-  background-color: $emergency;
-  border-radius: 4px;
-  color: $gray-2;
-  @include font-size(12);
-
-  p {
-    margin: 0;
-  }
-}
-</style>


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6164

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `components/CardsMonitoring.vue` に，不要な CSS の定義があるので除去した
  - 詳細は #6164 

## 📸 スクリーンショット / Screenshots
見た目の変更はなし
