### PR TITLE
@nuxt/typescript-buildのオプションでmemoryLimitを設定

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -93,7 +93,18 @@ const config: NuxtConfig = {
   buildModules: [
     '@nuxtjs/stylelint-module',
     '@nuxtjs/vuetify',
-    '@nuxt/typescript-build',
+    [
+      '@nuxt/typescript-build',
+      {
+        typeCheck: {
+          async: true,
+          typescript: {
+            enable: true,
+            memoryLimit: 16384,
+          },
+        },
+      },
+    ],
     '@nuxtjs/google-analytics',
     '@nuxtjs/gtm',
     'nuxt-purgecss',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -100,7 +100,7 @@ const config: NuxtConfig = {
           async: true,
           typescript: {
             enable: true,
-            memoryLimit: 16384,
+            memoryLimit: 4096,
           },
         },
       },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #6212 ?

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `yarn dev` でTypeScriptのmemoryLimitのエラーが出たので、@nuxt/typescript-buildのオプションでmemoryLimitを設定しました
- 次のようなログが出ていました
![スクリーンショット 2021-04-26 13 47 12](https://user-images.githubusercontent.com/14883063/116030280-2b7f4b80-a696-11eb-93fc-be1d15e97a8b.png)


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
