### PR TITLE
N501Y変異株スクリーニングの実施状況グラフの左右の各Y軸にラベル「構成割合」「実施割合」を追加

### DIFF
--- a/components/VariantChart.vue
+++ b/components/VariantChart.vue
@@ -148,6 +148,7 @@ type Props = {
   labels: string[]
   dataLabels: string[] | TranslateResult[]
   tableLabels: string[] | TranslateResult[]
+  scaleLabels: string[] | TranslateResult[]
   periods: string[]
   lastPeriod: Period
   unit: string
@@ -222,6 +223,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       default: () => [],
     },
     tableLabels: {
+      type: Array,
+      default: () => [],
+    },
+    scaleLabels: {
       type: Array,
       default: () => [],
     },
@@ -426,6 +431,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             {
               id: 'y-axis-1',
               position: 'left',
+              scaleLabel: {
+                display: true,
+              },
               stacked: true,
               gridLines: {
                 display: true,
@@ -446,6 +454,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             {
               id: 'y-axis-2',
               position: 'right',
+              scaleLabel: {
+                display: true,
+              },
               gridLines: {
                 display: true,
                 drawOnChartArea: false,
@@ -548,6 +559,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
               id: 'y-axis-1',
               position: 'left',
               stacked: true,
+              scaleLabel: {
+                display: true,
+                labelString: this.scaleLabels[0] as string,
+              },
               gridLines: {
                 display: true,
                 drawOnChartArea: false, // displayOption では true
@@ -567,6 +582,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             {
               id: 'y-axis-2',
               position: 'right',
+              scaleLabel: {
+                display: true,
+                labelString: this.scaleLabels[1] as string,
+              },
               gridLines: {
                 display: true,
                 drawOnChartArea: false,

--- a/components/cards/VariantCard.vue
+++ b/components/cards/VariantCard.vue
@@ -14,6 +14,7 @@
         :periods="variantLabels"
         :data-labels="chartLabels"
         :table-labels="tableLabels"
+        :scale-labels="scaleLabels"
         :last-period="variantData.lastPeriod"
         unit="%"
       >
@@ -60,6 +61,7 @@ dayjs.extend(duration)
 type Data = {
   chartLabels: string[]
   tableLabels: string[]
+  scaleLabels: string[]
   getFormatter: () => (d: number) => string | undefined
 }
 type Methods = {
@@ -97,6 +99,11 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       this.$t('変異株PCR検査実施割合') as string,
     ]
 
+    const scaleLabels = [
+      this.$t('構成割合') as string,
+      this.$t('実施割合') as string,
+    ]
+
     const getFormatter = () => {
       // 陽性率は小数点第1位まで表示する。
       return getNumberToFixedFunction(1)
@@ -105,6 +112,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     return {
       chartLabels,
       tableLabels,
+      scaleLabels,
       getFormatter,
     }
   },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6276 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- N501Y変異株スクリーニングの実施状況グラフの左右の各Y軸にラベル「構成割合」「実施割合」を追加しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-05-11 17 05 53](https://user-images.githubusercontent.com/14883063/117781064-2f58c380-b27b-11eb-8a12-84f2a46313b8.png)
