### PR TITLE
Chart という namespace の import を回避する (2)

### DIFF
--- a/components/AgencyBarChart.vue
+++ b/components/AgencyBarChart.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script lang="ts">
-import { Chart, ChartOptions } from 'chart.js'
+import { ChartOptions } from 'chart.js'
 import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
@@ -285,7 +285,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const options: Chart.ChartOptions = {
+      const options: ChartOptions = {
         maintainAspectRatio: false,
         legend: {
           display: false,

--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -86,7 +86,7 @@
 </template>
 
 <script lang="ts">
-import { Chart, ChartData, ChartOptions } from 'chart.js'
+import { ChartData, ChartOptions, ChartTooltipCallback } from 'chart.js'
 import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
@@ -112,9 +112,9 @@ type Computed = {
   displayData: DisplayData
   tableHeaders: TableHeader[]
   tableData: TableItem[]
-  displayOption: Chart.ChartOptions
+  displayOption: ChartOptions
   displayDataHeader: DisplayData
-  displayOptionHeader: Chart.ChartOptions
+  displayOptionHeader: ChartOptions
 }
 type Props = {
   chartData: ChartData
@@ -126,8 +126,8 @@ type Props = {
   items: string[]
   periods: string[]
   unit: string
-  tooltipsTitle: Chart.ChartTooltipCallback['title']
-  tooltipsLabel: Chart.ChartTooltipCallback['label']
+  tooltipsTitle: ChartTooltipCallback['title']
+  tooltipsLabel: ChartTooltipCallback['label']
 }
 
 const options: ThisTypedComponentOptionsWithRecordProps<
@@ -322,7 +322,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       }
     },
     displayOptionHeader() {
-      const options: Chart.ChartOptions = {
+      const options: ChartOptions = {
         maintainAspectRatio: false,
         legend: {
           display: false,


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6270

#6271 で対応漏れがあったため，修正を追加した．

## 📝 関連する issue / Related Issues
- #2790, #5404, #6271

## ⛏ 変更内容 / Details of Changes

- 既存の
```ts
import { Chart } from 'chart.js'
```
を
```ts
import { ChartOptions, PluginServiceRegistrationOptions } from 'chart.js'
```
などに置き換える．理由については #6270 を参照．

## 📸 スクリーンショット / Screenshots
見た目の変更はなし
