### PR TITLE
danger により quicktype で自動生成されたファイルの変更に対して注意を出す

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,27 @@
+name: danger
+on:
+  - pull_request
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.16.0'
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: yarn install --frozen-lockfile
+      - name: Run Danger
+        run: yarn danger:ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -1,0 +1,13 @@
+import { danger, warn } from 'danger'
+
+const modifiedConverterFilePaths = danger.git.modified_files.filter(
+  (filePath) => {
+    return /^libraries\/auto_generated\/data_converter\/.*\.ts$/.test(filePath)
+  }
+)
+
+modifiedConverterFilePaths.forEach((modifiedConverterFilePath) => {
+  warn(
+    `\`${modifiedConverterFilePath}\` が変更されています。不要な変更が加えられないよう注意してください。`
+  )
+})

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -8,6 +8,6 @@ const modifiedConverterFilePaths = danger.git.modified_files.filter(
 
 modifiedConverterFilePaths.forEach((modifiedConverterFilePath) => {
   warn(
-    `\`${modifiedConverterFilePath}\` が変更されています。不要な変更が加えられないよう注意してください。`
+    `\`${modifiedConverterFilePath}\` が変更されています。追加したコメントなどが削除されないよう注意してください。`
   )
 })

--- a/libraries/auto_generated/data_converter/convertMonitoringCommentImage.ts
+++ b/libraries/auto_generated/data_converter/convertMonitoringCommentImage.ts
@@ -7,6 +7,7 @@
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
 
+// test comment: MonitoringCommentImage
 export interface MonitoringCommentImage {
     date: string;
     data: Data;

--- a/libraries/auto_generated/data_converter/convertMonitoringItems.ts
+++ b/libraries/auto_generated/data_converter/convertMonitoringItems.ts
@@ -7,6 +7,7 @@
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
 
+// test comment: MonitoringItems
 export interface MonitoringItems {
     date: string;
     data: Data;

--- a/libraries/auto_generated/data_converter/convertVaccination.ts
+++ b/libraries/auto_generated/data_converter/convertVaccination.ts
@@ -7,6 +7,7 @@
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
 
+// test comment: Vaccination
 export interface Vaccination {
     date:     string;
     datasets: Dataset[];

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "functions:dev": "netlify-lambda serve functions",
     "functions:build": "netlify-lambda build functions",
     "generate-data-converters": "ts-node --compiler-options='{\"module\":\"commonjs\"}' ./tool/generateDataConverters.ts",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "danger:ci": "danger ci"
   },
   "lint-staged": {
     "*.{js,ts,css,vue}": [


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6369

## 📝 関連する issue / Related Issues
- #6363, #6364, https://github.com/tokyo-metropolitan-gov/covid19/pull/6102#issuecomment-812517158

## ⛏ 変更内容 / Details of Changes
- `yarn generate-data-converters` の実行により意図しない変更が加えられてしまうことがあったので，quicktype で自動生成されたファイルについての変更があったとき，GitHub 上に警告が出るようにし，不要な変更が加えられないようにする

## 📸 スクリーンショット / Screenshots
見た目の変更はなし