### PR TITLE
「感染状況・医療提供体制（サマリ）」数値の要素を em に修正

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -145,7 +145,7 @@ Tokyo Covid-19 response site contributors
 | hanapei00 | [@hanapei00](https://github.com/hanapei00) | | Coding |
 | Rikiya Ihara | [@magi1125](https://github.com/magi1125) | [@magi1125](https://twitter.com/magi1125) | Accessibility, Triage |
 | [Arthit Suriyawongkul](https://bact.cc) | [@bact](https://github.com/bact) | [@bact](https://twitter.com/bact) | Translation (Thai) |
-| [Soichi Ikebe (AQUA)](https://www.aqua-ix.com/) | [@Aqua-ix](https://github.com/Aqua-ix) | [@Aqua_ix](https://twitter.com/Aqua_ix) | Coding |
+| Soichi Ikebe | [@Aqua-ix](https://github.com/Aqua-ix) | [@Aqua_ix](https://twitter.com/Aqua_ix) | Coding |
 | yuuton414 | [@yuuton414](https://github.com/yuuton414) | | Coding |
 | Hiroki Kobayashi | [@khsacc](https://github.com/khsacc) | [@khsacc](https://twitter.com/khsacc) | Coding |
 | Rafał Chłodnicki | [@rchl](https://github.com/rchl) | | nuxt-i18n |

--- a/components/index/SiteTopUpper/InfectionMedicalCareProvisionStatus.vue
+++ b/components/index/SiteTopUpper/InfectionMedicalCareProvisionStatus.vue
@@ -23,32 +23,32 @@
         path="新規陽性者{newPositiveCases}人 / 検査数{tests}件（{statisticDate}参考値 （3日間移動平均））、うち65歳以上の高齢者数{older65}人、死亡者数{deaths}人、都外からの持込検体による陽性数{samplesFromOutside}"
       >
         <template #newPositiveCases>
-          <span>
+          <em>
             {{ statuses['新規陽性者'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #tests>
-          <span>
+          <em>
             {{ statuses['検査数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #statisticDate>
           {{ formatDate(statisticDate) }}
         </template>
         <template #older65>
-          <span>
+          <em>
             {{ statuses['うち65歳以上の高齢者数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #deaths>
-          <span>
+          <em>
             {{ statuses['死亡者数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #samplesFromOutside>
-          <span>
+          <em>
             {{ statuses['都外からの持込検体による陽性数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
       </i18n>
     </div>
@@ -66,24 +66,24 @@
         path="入院数{hospitalized}人（確保病床数{bedsSecured}床）、うち重症者数{severeCases}人（うち重症病床数{bedsSevereSymptoms}床）"
       >
         <template #hospitalized>
-          <span>
+          <em>
             {{ statuses['入院数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #bedsSecured>
-          <span>
+          <em>
             {{ statuses['確保病床数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #severeCases>
-          <span>
+          <em>
             {{ statuses['うち重症者数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
         <template #bedsSevereSymptoms>
-          <span>
+          <em>
             {{ statuses['うち重症病床数'].toLocaleString() }}
-          </span>
+          </em>
         </template>
       </i18n>
     </div>

--- a/components/index/SiteTopUpper/InfectionMedicalCareProvisionStatus.vue
+++ b/components/index/SiteTopUpper/InfectionMedicalCareProvisionStatus.vue
@@ -182,14 +182,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       padding: 3px 0 0 0;
       margin: 0;
 
-      > span {
+      > em {
         color: $green-1;
-      }
-
-      > a {
-        @include text-link();
-
-        text-decoration: none;
+        font-style: normal;
       }
     }
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6396

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「感染状況・医療提供体制（サマリ）」数値の要素を`span`から`em`に修正し、セマンティクスを持つようにした。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

修正前
![スクリーンショット 2021-06-16 2 48 38](https://user-images.githubusercontent.com/29789286/122099780-5cd1f780-ce4d-11eb-9e96-50fb46cce234.png)

修正後
![スクリーンショット 2021-06-16 2 49 10](https://user-images.githubusercontent.com/29789286/122099846-6eb39a80-ce4d-11eb-8bc2-72571fb35833.png)

