### PR TITLE
fix: remove aria-readonly of readonly input

### DIFF
--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -157,6 +157,14 @@ export default Vue.extend({
     nodes.forEach((table: HTMLElement) => {
       table.setAttribute('tabindex', '0')
     })
+
+    const inputs = vTableElement.querySelectorAll('input[aria-readonly]')
+    Array.prototype.slice.call(inputs, 0).forEach((input: Element) => {
+      input.setAttribute(
+        'aria-readonly',
+        String(input.hasAttribute('readonly'))
+      )
+    })
   },
 })
 </script>

--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -160,10 +160,7 @@ export default Vue.extend({
 
     const inputs = vTableElement.querySelectorAll('input[aria-readonly]')
     Array.prototype.slice.call(inputs, 0).forEach((input: Element) => {
-      input.setAttribute(
-        'aria-readonly',
-        String(input.hasAttribute('readonly'))
-      )
+      input.removeAttribute('aria-readonly')
     })
   },
 })


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6412 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「陽性者の属性」の表におけるinput要素の`aria-readonly`を削除

コンポーネントの属性で指定することがVuetifyの仕様により不可能だったため、tabindexと同様に、マウント後に上書きをすることで対応。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/24248467/122755648-40601000-d2d0-11eb-97e9-ae667a3c4638.png)
