### PR TITLE
fix: focus to charts and tables

### DIFF
--- a/components/index/_shared/DataViewTable.vue
+++ b/components/index/_shared/DataViewTable.vue
@@ -1,5 +1,6 @@
 <template>
   <v-data-table
+    :ref="'displayedTable'"
     :headers="headers"
     :items="items"
     :items-per-page="-1"
@@ -83,6 +84,16 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .map((h) => h.value)
         .filter((h) => h !== this.headerKey)
     },
+  },
+  mounted() {
+    const vTables = this.$refs.displayedTable as Vue
+    const vTableElement = vTables.$el
+    const tables = vTableElement.querySelectorAll('table')
+    // NodeListをIE11でforEachするためのワークアラウンド
+    const nodes = Array.prototype.slice.call(tables, 0)
+    nodes.forEach((table: HTMLElement) => {
+      table.setAttribute('tabindex', '0')
+    })
   },
   methods: {
     formatDate(dateString: string): string {

--- a/components/index/_shared/ScrollableChart.vue
+++ b/components/index/_shared/ScrollableChart.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="chartContainer" class="LegendStickyChart">
-    <div ref="scrollable" class="scrollable">
+    <div ref="scrollable" class="scrollable" tabindex="0">
       <div :style="{ width: `${chartWidth}px` }">
         <slot name="chart" :chart-width="chartWidth" />
       </div>


### PR DESCRIPTION

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6400

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- グラフとテーブルにTabでフォーカスできるよう変更

テーブルの対応は既存の実装にそろえています。
https://github.com/tokyo-metropolitan-gov/covid19/blob/development/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue#L151-L160
https://github.com/tokyo-metropolitan-gov/covid19/blob/development/components/index/CardsReference/ConfirmedCasesByMunicipalities/Table.vue#L66-L75

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
グラフ

![chart](https://user-images.githubusercontent.com/24248467/123053639-137e3b00-d43f-11eb-95ed-423ce06852bd.gif)

テーブル

![table](https://user-images.githubusercontent.com/24248467/123053644-14af6800-d43f-11eb-9a5a-58f69c637e36.gif)