### PR TITLE
fix: focus share button on close

### DIFF
--- a/components/index/_shared/DataView/Share.vue
+++ b/components/index/_shared/DataView/Share.vue
@@ -3,6 +3,7 @@
     <v-tooltip left nudge-right="20" nudge-bottom="4">
       <template #activator="{ on }">
         <button
+          ref="shareOpener"
           class="DataView-Share-Opener"
           @click="toggleShareMenu"
           v-on="on"
@@ -159,6 +160,7 @@ export default Vue.extend({
     },
     closeShareMenu() {
       this.displayShare = false
+      ;(this.$refs.shareOpener as HTMLButtonElement).focus()
     },
     isCopyAvailable() {
       return !!navigator.clipboard


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6403 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 共有ポップアップを閉じたときにフォーカスをボタンに戻すよう変更

閉じるボタンで閉じたときと埋め込み用コードをコピーするボタンで閉じたときの両方で期待通りになることを確認しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![focus](https://user-images.githubusercontent.com/24248467/123077399-fc4a4800-d454-11eb-994a-db98ee71e3ed.gif)
