### PR TITLE
カードが1枚だけ表示されるページでカードの幅を広げる

### DIFF
--- a/components/index/CardsMonitoring/ConfirmedCasesDetails/Card.vue
+++ b/components/index/CardsMonitoring/ConfirmedCasesDetails/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard ConfirmedCasesDetailsCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard ConfirmedCasesDetailsCard"
+  >
     <client-only>
       <data-view
         :title="$t('検査陽性者の状況')"
@@ -74,6 +78,7 @@ import OpenDataLink from '@/components/index/_shared/OpenDataLink.vue'
 import ConfirmedCasesDetailsTable from '@/components/index/CardsMonitoring/ConfirmedCasesDetails/Table.vue'
 import Data from '@/data/data.json'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
+import { isSingleCard } from '@/utils/urls'
 
 const options = {
   components: {
@@ -93,6 +98,11 @@ const options = {
       confirmedCases,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 

--- a/components/index/CardsMonitoring/ConfirmedCasesNumber/Card.vue
+++ b/components/index/CardsMonitoring/ConfirmedCasesNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard ConfirmedCasesNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard ConfirmedCasesNumberCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('報告日別による陽性者数の推移')"
@@ -52,6 +56,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import TimeBarChart from '@/components/index/_shared/TimeBarChart.vue'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -67,6 +72,11 @@ export default {
       patientsGraph,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/ConsultationAboutFeverNumber/Card.vue
+++ b/components/index/CardsMonitoring/ConsultationAboutFeverNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard ConsultationAboutFeverNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard ConsultationAboutFeverNumberCard"
+  >
     <client-only>
       <mixed-bar-and-line-chart
         :title="$t('モニタリング項目(2)')"
@@ -43,6 +47,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   dataLabels: string[]
@@ -55,6 +60,7 @@ type Computed = {
   labels: string[]
   consultationAboutFeverData: IConsultationAboutFeverDatum[]
   consultationAboutFever: IConsultationAboutFever
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -104,6 +110,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     consultationAboutFever() {
       return this.$store.state.consultationAboutFever
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsMonitoring/HospitalizedNumber/Card.vue
+++ b/components/index/CardsMonitoring/HospitalizedNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard HospitalizedNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard HospitalizedNumberCard"
+  >
     <client-only>
       <chart
         :title="$t('モニタリング項目(6)')"
@@ -42,6 +46,7 @@
 import Chart from '@/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue'
 import positiveStatus from '@/data/positive_status.json'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -63,6 +68,11 @@ export default {
       patientsGraph,
       tableLabels,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Card.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard MonitoringConfirmedCasesNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard MonitoringConfirmedCasesNumberCard"
+  >
     <client-only>
       <chart
         :title="$t('モニタリング項目(1)')"
@@ -53,6 +57,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   dataLabels: string[]
@@ -66,6 +71,7 @@ type Computed = {
   labels: string[]
   dailyPositiveDetailData: IDailyPositiveDetailDatum[]
   dailyPositiveDetail: IDailyPositiveDetail
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -119,6 +125,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     dailyPositiveDetail() {
       return this.$store.state.dailyPositiveDetail
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsMonitoring/MonitoringItemsOverview/Card.vue
+++ b/components/index/CardsMonitoring/MonitoringItemsOverview/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard MonitoringItemsOverviewCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard MonitoringItemsOverviewCard"
+  >
     <client-only>
       <data-view
         :title="$t('モニタリング項目')"
@@ -81,6 +85,7 @@ import InfectionStatus from '@/components/index/CardsMonitoring/MonitoringItemsO
 import MedicalSystem from '@/components/index/CardsMonitoring/MonitoringItemsOverview/Table/MedicalSystem.vue'
 import monitoringItemsData from '@/data/monitoring_items.json'
 import { formatMonitoringItems } from '@/utils/formatMonitoringItems'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -95,6 +100,11 @@ export default {
       monitoringItemsData,
       monitoringItems,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/PositiveRate/Card.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard PositiveRateCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard PositiveRateCard">
     <client-only>
       <chart
         :title="$t('モニタリング項目(4)')"
@@ -85,6 +85,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 dayjs.extend(duration)
 
 export default {
@@ -141,6 +142,11 @@ export default {
       positiveRateTableLabels,
       getFormatter,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/SevereCase/Card.vue
+++ b/components/index/CardsMonitoring/SevereCase/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard SevereCaseCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard SevereCaseCard">
     <client-only>
       <chart
         :title="$t('モニタリング項目(7)')"
@@ -45,6 +45,7 @@ import AppLink from '@/components/_shared/AppLink.vue'
 import Chart from '@/components/index/CardsMonitoring/SevereCase/Chart.vue'
 import Data from '@/data/positive_status.json'
 import { convertDateToISO8601Format } from '@/utils/formatDate.ts'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -64,6 +65,11 @@ export default {
       graphData,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsMonitoring/TokyoRulesApplicationNumber/Card.vue
+++ b/components/index/CardsMonitoring/TokyoRulesApplicationNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard TokyoRulesApplicationNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard TokyoRulesApplicationNumberCard"
+  >
     <client-only>
       <mixed-bar-and-line-chart
         :title="$t('モニタリング項目(5)')"
@@ -50,6 +54,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   dataLabels: string[]
@@ -62,6 +67,7 @@ type Computed = {
   labels: string[]
   tokyoRuleData: ITokyoRuleDatum[]
   tokyoRule: ITokyoRule
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -107,6 +113,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     tokyoRule() {
       return this.$store.state.tokyoRule
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsMonitoring/UntrackedRate/Card.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard UntrackedRateCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard UntrackedRateCard">
     <client-only>
       <chart
         :title="$t('モニタリング項目(3)')"
@@ -62,6 +62,7 @@ import {
   getNumberToFixedFunction,
   getNumberToLocaleStringFunction,
 } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   dataLabels: string[]
@@ -76,6 +77,7 @@ type Computed = {
   labels: string[]
   filteredDailyPositiveDetailData: IDailyPositiveDetailDatum[]
   dailyPositiveDetail: IDailyPositiveDetail
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -152,6 +154,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     dailyPositiveDetail() {
       return this.$store.state.dailyPositiveDetail
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsReference/Agency/Card.vue
+++ b/components/index/CardsReference/Agency/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard AgencyCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard AgencyCard">
     <client-only>
       <chart
         :title="$t('都庁来庁者数の推移')"
@@ -26,6 +26,7 @@ import Vue from 'vue'
 import Chart from '@/components/index/CardsReference/Agency/Chart.vue'
 import { Agency as IAgency } from '@/libraries/auto_generated/data_converter/convertAgency'
 import { convertDateToISO8601Format } from '@/utils/formatDate'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   agencyItems: string[]
@@ -36,6 +37,7 @@ type Computed = {
   date: string
   labels: string[]
   periods: string[]
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -71,6 +73,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
         const to = this.$d(p.end, 'dateWithoutYear')
         return `${from}~${to}`
       })
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsReference/ConfirmedCasesAttributes/Card.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard ConfirmedCasesAttributesCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard ConfirmedCasesAttributesCard"
+  >
     <client-only>
       <data-table
         :title="$t('陽性者の属性')"
@@ -79,6 +83,7 @@ import {
   TableDateType,
 } from '@/utils/formatConfirmedCasesAttributesTable'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 interface MetaData {
   endCursor: string
@@ -109,6 +114,7 @@ type Methods = {
 type Computed = {
   patientsTable: TableDateType
   dataMargin: number
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -151,6 +157,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     dataMargin() {
       return this.patientsData.length - this.page * this.itemsPerPage
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
   async fetch() {

--- a/components/index/CardsReference/ConfirmedCasesByMunicipalities/Card.vue
+++ b/components/index/CardsReference/ConfirmedCasesByMunicipalities/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard ConfirmedCasesByMunicipalitiesCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard ConfirmedCasesByMunicipalitiesCard"
+  >
     <client-only>
       <confirmed-cases-by-municipalities-table
         :title="$t('陽性者数（区市町村別）')"
@@ -31,7 +35,8 @@ import dayjs from 'dayjs'
 // table タグとの衝突を避けるため ConfirmedCasesByMunicipalitiesTable とする
 import ConfirmedCasesByMunicipalitiesTable from '@/components/index/CardsReference/ConfirmedCasesByMunicipalities/Table.vue'
 import Data from '@/data/patient.json'
-import { getCommaSeparatedNumberToFixedFunction } from '~/utils/monitoringStatusValueFormatters'
+import { getCommaSeparatedNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 const countFormatter = getCommaSeparatedNumberToFixedFunction()
 
@@ -111,6 +116,11 @@ export default {
       municipalitiesTable,
       info,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/DeathsByDeathDate/Card.vue
+++ b/components/index/CardsReference/DeathsByDeathDate/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard DeathsByDeathDateCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard DeathsByDeathDateCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('死亡日別による死亡者数の推移')"
@@ -31,6 +35,7 @@ import TimeBarChart from '@/components/index/_shared/TimeBarChart.vue'
 import deaths from '@/data/deaths.json'
 import calcDayBeforeRatio from '@/utils/calcDayBeforeRatio'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -78,6 +83,11 @@ export default {
       date,
       graphData,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/Metro/Card.vue
+++ b/components/index/CardsReference/Metro/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard MetroCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard MetroCard">
     <client-only>
       <chart
         :title="$t('都営地下鉄の利用者数の推移')"
@@ -42,6 +42,7 @@ import {
   Dataset as IMetroDataset,
   Metro as IMetro,
 } from '@/libraries/auto_generated/data_converter/convertMetro'
+import { isSingleCard } from '@/utils/urls'
 
 interface IMetroDatasetWithLabel extends IMetroDataset {
   label: Date
@@ -67,6 +68,7 @@ type Computed = {
   metroGraphTooltipLabel: (tooltipItem: any, data: any) => string
   metroDatasets: IMetroDataset[]
   metro: IMetro
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -126,6 +128,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     metro() {
       return this.$store.state.metro
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
   methods: {

--- a/components/index/CardsReference/MonitoringConsultationDeskReportsNumber/Card.vue
+++ b/components/index/CardsReference/MonitoringConsultationDeskReportsNumber/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col
     cols="12"
-    md="6"
+    :md="isSingleCard || 6"
     class="DataCard MonitoringConsultationDeskReportsNumberCard"
   >
     <client-only>
@@ -60,6 +60,7 @@
 import AppLink from '@/components/_shared/AppLink.vue'
 import Chart from '@/components/index/CardsReference/MonitoringConsultationDeskReportsNumber/Chart.vue'
 import Data from '@/data/data.json'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -87,6 +88,11 @@ export default {
       labels,
       dataLabels,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/PositiveNumberByDevelopedDate/Card.vue
+++ b/components/index/CardsReference/PositiveNumberByDevelopedDate/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard PositiveNumberByDevelopedDateCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard PositiveNumberByDevelopedDateCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('発症日別による陽性者数の推移')"
@@ -47,7 +51,8 @@ import DataViewCustomInfoPanel from '@/components/index/CardsReference/PositiveN
 import positiveByDeveloped from '@/data/positive_by_developed.json'
 import calcDayBeforeRatio from '@/utils/calcDayBeforeRatio'
 import formatGraph from '@/utils/formatGraph'
-import { getCommaSeparatedNumberToFixedFunction } from '~/utils/monitoringStatusValueFormatters'
+import { getCommaSeparatedNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -105,6 +110,11 @@ export default {
       sText: `${lastDay} ${this.$t('累計値')}`,
       num: unknownCount,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/PositiveNumberByDiagnosedDate/Card.vue
+++ b/components/index/CardsReference/PositiveNumberByDiagnosedDate/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard PositiveNumberByDiagnosedDateCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard PositiveNumberByDiagnosedDateCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('確定日別による陽性者数の推移')"
@@ -32,6 +36,7 @@ import TimeBarChart from '@/components/index/_shared/TimeBarChart.vue'
 import Data from '@/data/positive_by_diagnosed.json'
 import calcDayBeforeRatio from '@/utils/calcDayBeforeRatio'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -79,6 +84,11 @@ export default {
       date,
       graphData,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/TelephoneAdvisoryReportsNumber/Card.vue
+++ b/components/index/CardsReference/TelephoneAdvisoryReportsNumber/Card.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard TelephoneAdvisoryReportsNumberCard">
+  <v-col
+    cols="12"
+    :md="isSingleCard || 6"
+    class="DataCard TelephoneAdvisoryReportsNumberCard"
+  >
     <client-only>
       <time-bar-chart
         :title="$t('新型コロナコールセンター相談件数')"
@@ -19,6 +23,7 @@
 import TimeBarChart from '@/components/index/_shared/TimeBarChart.vue'
 import Data from '@/data/data.json'
 import formatGraph from '@/utils/formatGraph'
+import { isSingleCard } from '@/utils/urls'
 
 export default {
   components: {
@@ -34,6 +39,11 @@ export default {
       contactsGraph,
       date,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/TestedNumber/Card.vue
+++ b/components/index/CardsReference/TestedNumber/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard TestedNumberCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard TestedNumberCard">
     <client-only>
       <chart
         :title="$t('検査実施件数')"
@@ -53,6 +53,7 @@ import duration from 'dayjs/plugin/duration'
 
 import Chart from '@/components/index/CardsReference/TestedNumber/Chart.vue'
 import Data from '@/data/data.json'
+import { isSingleCard } from '@/utils/urls'
 dayjs.extend(duration)
 
 export default {
@@ -93,6 +94,11 @@ export default {
       inspectionsDataLabels,
       inspectionsTableLabels,
     }
+  },
+  computed: {
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
 }
 </script>

--- a/components/index/CardsReference/TokyoFeverConsultationCenterReportsNumber/Card.vue
+++ b/components/index/CardsReference/TokyoFeverConsultationCenterReportsNumber/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <v-col
     cols="12"
-    md="6"
+    :md="isSingleCard || 6"
     class="DataCard TokyoFeverConsultationCenterReportsNumberCard"
   >
     <client-only>
@@ -49,6 +49,7 @@ import {
   FeverConsultationCenter as IFeverConsultationCenter,
 } from '@/libraries/auto_generated/data_converter/convertFeverConsultationCenter'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   labelItems: string[]
@@ -61,6 +62,7 @@ type Computed = {
   labels: string[]
   feverConsultationCenterData: IFeverConsultationCenterDatum[]
   feverConsultationCenter: IFeverConsultationCenter
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -108,6 +110,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     feverConsultationCenter(): IFeverConsultationCenter {
       return this.$store.state.feverConsultationCenter
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsReference/Vaccination/Card.vue
+++ b/components/index/CardsReference/Vaccination/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard VaccinationCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard VaccinationCard">
     <client-only>
       <chart
         :title="$t('ワクチン接種数（累計）')"
@@ -50,6 +50,7 @@ import {
   VaccinationAll as IVaccination,
 } from '@/libraries/auto_generated/data_converter/convertVaccinationAll'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   chartLabels: string[]
@@ -67,6 +68,7 @@ type Computed = {
     infoData: number[][]
   }
   vaccination: IVaccination
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -144,6 +146,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     vaccination() {
       return this.$store.state.vaccination
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
 })

--- a/components/index/CardsReference/Variant/Card.vue
+++ b/components/index/CardsReference/Variant/Card.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-col cols="12" md="6" class="DataCard VariantCard">
+  <v-col cols="12" :md="isSingleCard || 6" class="DataCard VariantCard">
     <client-only>
       <chart
         :title="$t('L452R変異株スクリーニングの実施状況')"
@@ -63,6 +63,7 @@ import {
   Variants as IVariants,
 } from '@/libraries/auto_generated/data_converter/convertVariants'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
+import { isSingleCard } from '@/utils/urls'
 
 dayjs.extend(duration)
 
@@ -86,6 +87,7 @@ type Computed = {
     tableData: number[][]
   }
   variants: IVariants
+  isSingleCard: boolean
 }
 type Props = {}
 
@@ -179,6 +181,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     variants() {
       return this.$store.state.variants
+    },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
     },
   },
   methods: {

--- a/components/index/_shared/ScrollableChart.vue
+++ b/components/index/_shared/ScrollableChart.vue
@@ -15,6 +15,7 @@ import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 
 import { DisplayData } from '@/plugins/vue-chart'
 import { EventBus, TOGGLE_EVENT } from '@/utils/tab-event-bus'
+import { isSingleCard } from '@/utils/urls'
 
 type Data = {
   chartWidth: number
@@ -28,6 +29,7 @@ type Methods = {
 }
 type Computed = {
   labelCount: number
+  isSingleCard: boolean
 }
 type Props = {
   displayData: DisplayData
@@ -67,6 +69,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     labelCount() {
       return this.displayData.labels?.length || 0
     },
+    isSingleCard() {
+      return isSingleCard(this.$route.path)
+    },
   },
   methods: {
     adjustChartWidth() {
@@ -80,7 +85,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const weeks = 24
       const yaxisWidth = 38
       const chartWidth = containerWidth - yaxisWidth
-      const barWidth = chartWidth / (this.isWeekly ? weeks : dates)
+      const barWidth =
+        chartWidth /
+        (this.isWeekly ? weeks : dates) /
+        (this.isSingleCard ? 2 : 1)
       const calcWidth = barWidth * labelCount + yaxisWidth
       return Math.max(calcWidth, containerWidth)
     },

--- a/utils/urls.ts
+++ b/utils/urls.ts
@@ -1,3 +1,7 @@
 export function isExternal(path: string): boolean {
   return /^https?:\/\//.test(path)
 }
+
+export function isSingleCard(path: string): boolean {
+  return path.startsWith('/cards/')
+}


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6598

## 📝 関連する issue / Related Issues
None

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- カードが1枚だけ表示されるページの場合に、カードの幅を2倍に拡大しました。
  - 具体的には、カードのコンポーネントには `col-12` と `md-6` というクラスが設定されているが、カード1枚の場合には `md-6` を設定しないようにしています。
- カードの幅を広げるとグラフの棒の幅も約2倍になるので、グラフがトップページと同様に表示されるように棒の幅を半分にしました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
左がbefore、右がafterです。

<img width="2554" alt="Screen Shot 2021-08-12 at 1 19 24" src="https://user-images.githubusercontent.com/1425259/129186881-246132a0-620b-4e09-9a03-a24532dc96db.png">
<img width="2554" alt="Screen Shot 2021-08-12 at 1 21 03" src="https://user-images.githubusercontent.com/1425259/129186895-71c4ab35-46bf-4a5c-ac66-f6f6d57ceb79.png">
<img width="2554" alt="Screen Shot 2021-08-12 at 1 25 56" src="https://user-images.githubusercontent.com/1425259/129186899-e5802d6e-cb3e-4608-9d0d-dec65d6090da.png">

## プレビュー

- Netlify のリンク: https://deploy-preview-6599--dev-covid19-tokyo.netlify.app/
- 各カードの左下のリンクから変更が確認できます。