### PR TITLE
「変異株情報」ボタンを「自宅での療養」ボタンに差し替え

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -109,7 +109,7 @@ $chinese-hant: "PingFang TC", "Microsoft JhengHei", "Source Han Sans TC", "Noto 
 
 @mixin button-text($size: 'md', $font-size: 14) {
   @if ($size == 'sm') {
-    padding: 4px 8px;
+    padding: 5px 8px;
   }
 
   @else {
@@ -118,7 +118,8 @@ $chinese-hant: "PingFang TC", "Microsoft JhengHei", "Source Han Sans TC", "Noto 
 
   @include font-size($font-size);
 
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   border-radius: 4px;
   background-color: $white;
   border: 1px solid $green-1;

--- a/components/_shared/AppLink.vue
+++ b/components/_shared/AppLink.vue
@@ -91,6 +91,11 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .ExternalLink {
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
+}
+.ExternalLinkIcon {
+  margin-left: 4px;
 }
 </style>

--- a/components/index/SiteTopUpper/WhatsNew.vue
+++ b/components/index/SiteTopUpper/WhatsNew.vue
@@ -25,11 +25,13 @@
         <li>
           <app-link
             class="WhatsNew-linkButton"
-            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/henikabu/screening.html"
+            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/shien/index.html"
           >
             <span class="WhatsNew-linkButton-inner">
-              <covid-icon class="WhatsNew-linkButton-icon" aria-hidden="true" />
-              {{ $t('変異株情報') }}
+              <v-icon size="1.2em" class="WhatsNew-linkButton-v-icon">
+                {{ mdiHomeAccount }}
+              </v-icon>
+              {{ $t('自宅での療養') }}
             </span>
           </app-link>
         </li>
@@ -39,7 +41,7 @@
             to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/kensa/index.html"
           >
             <span class="WhatsNew-linkButton-inner">
-              <v-icon size="1em" class="WhatsNew-linkButton-v-icon">
+              <v-icon size="1.1em" class="WhatsNew-linkButton-v-icon">
                 {{ mdiClipboardText }}
               </v-icon>
               {{ $t('検査情報') }}
@@ -66,11 +68,10 @@
 </template>
 
 <script lang="ts">
-import { mdiClipboardText, mdiInformation } from '@mdi/js'
+import { mdiClipboardText, mdiHomeAccount, mdiInformation } from '@mdi/js'
 import Vue from 'vue'
 
 import AppLink from '@/components/_shared/AppLink.vue'
-import CovidIcon from '@/static/covid.svg'
 import VaccineIcon from '@/static/vaccine.svg'
 import { convertDateToISO8601Format } from '@/utils/formatDate'
 
@@ -78,7 +79,6 @@ export default Vue.extend({
   components: {
     AppLink,
     VaccineIcon,
-    CovidIcon,
   },
   props: {
     items: {
@@ -89,6 +89,7 @@ export default Vue.extend({
   data() {
     return {
       mdiClipboardText,
+      mdiHomeAccount,
       mdiInformation,
     }
   },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6600 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 最新のお知らせ内の「変異株情報」ボタンを「自宅での療養」ボタンに差し替えました
- ボタンのスタイルを調整しました
- 外部リンクアイコンの位置を微調整しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-08-13 11 41 56](https://user-images.githubusercontent.com/14883063/129297745-227dc76f-5999-4f27-b120-43594be3179c.png)
