### PR TITLE
「相談の手順を見る 」のコーナーを「新型コロナ保健医療情報ポータル」に変更

### DIFF
--- a/components/index/SiteTopUpper/Consultation.vue
+++ b/components/index/SiteTopUpper/Consultation.vue
@@ -5,9 +5,7 @@
         class="Consultation"
         url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/index.html"
         :text="
-          $t(
-            'ワクチン情報・変異株情報・検査情報等の\n新型コロナ関連情報はこちら'
-          )
+          $t('ワクチン情報・変異株情報・検査情報等の新型コロナ関連情報はこちら')
         "
         :btn-text="$t('新型コロナ保健医療情報ポータル')"
       />

--- a/components/index/SiteTopUpper/Consultation.vue
+++ b/components/index/SiteTopUpper/Consultation.vue
@@ -3,11 +3,13 @@
     <v-lazy>
       <static-info
         class="Consultation"
-        url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronasodan.html"
+        url="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/index.html"
         :text="
-          $t('自分や家族の症状に不安や心配があれば\nまずは電話相談をどうぞ')
+          $t(
+            'ワクチン情報・変異株情報・検査情報等の\n新型コロナ関連情報はこちら'
+          )
         "
-        :btn-text="$t('相談の手順を見る')"
+        :btn-text="$t('新型コロナ保健医療情報ポータル')"
       />
     </v-lazy>
   </v-col>

--- a/components/index/SiteTopUpper/Consultation/StaticInfo.vue
+++ b/components/index/SiteTopUpper/Consultation/StaticInfo.vue
@@ -40,7 +40,6 @@ export default Vue.extend({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap;
 
   &-Text {
     white-space: pre-wrap;

--- a/components/index/SiteTopUpper/Consultation/StaticInfo.vue
+++ b/components/index/SiteTopUpper/Consultation/StaticInfo.vue
@@ -40,12 +40,15 @@ export default Vue.extend({
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
 
   &-Text {
     white-space: pre-wrap;
     @include font-size(12);
 
     font-weight: 600;
+    flex: 1 0 50%;
+    padding-right: 16px;
   }
 
   @include font-size(12);


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6611 


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
ファーストビュー内「自分や家族の症状に不安や心配があればまずは電話相談をどうぞ」のブロックを以下に変更しました。

テキスト：ワクチン情報・変異株情報・検査情報等の新型コロナ関連情報はこちら
ボタンテキスト：新型コロナ保健医療情報ポータル
リンク先URL：https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/index.html

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![IMG_7345](https://user-images.githubusercontent.com/65712721/129923295-4f51702c-f7f1-44be-a094-406c3e2c0c67.JPG)
