### PR TITLE
ボタン/タブhover時のアイコンの視覚性を改善

### DIFF
--- a/components/index/CardsTab.vue
+++ b/components/index/CardsTab.vue
@@ -78,6 +78,10 @@ export default Vue.extend({
     }
   }
 
+  .TabIcon {
+    transition: none;
+  }
+
   &:not(.v-tab--active) {
     color: $green-1 !important;
     background: $white;

--- a/components/index/SiteTopUpper/WhatsNew.vue
+++ b/components/index/SiteTopUpper/WhatsNew.vue
@@ -155,6 +155,7 @@ export default Vue.extend({
       &-v-icon {
         color: currentColor;
         margin-right: 4px;
+        transition: none;
       }
     }
   }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6660 

## 📝 関連する issue / Related Issues
なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- v-iconが利用されているかつhover時にアイコンの色が変わる箇所に`transition: none;`を設定


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![修正内容](https://gyazo.com/043a078129db3df060f06c195f85c4e9/raw)
![修正内容](https://gyazo.com/74b2dfc5dcf9a0655f7053cf3f3a9b85/raw)

## 補足
### 原因
Vuetifyのv-iconにtransitionが設定されているため。
![image](https://user-images.githubusercontent.com/13850867/130342656-13d9390c-be23-4665-8e24-430afeea78d5.png)

### 修正方針
[assets/variables.css](https://github.com/tokyo-metropolitan-gov/covid19/blob/development/assets/variables.scss)内で、Vuetifyで設定されているsass変数[$primary-transition](https://github.com/vuetifyjs/vuetify/blob/master/packages/vuetify/src/styles/settings/_variables.scss#L246)をoverrideしても修正が可能であるが、$primary-transitionを利用する他の箇所でtransitonの恩恵を受けている可能性があるため、修正対象箇所のみtransitionをoverrideする方針で修正。