### PR TITLE
「L452R変異株スクリーニングの実施状況」グラフ下に「変異株情報」ボタンを追加

### DIFF
--- a/components/index/CardsReference/Variant/Card.vue
+++ b/components/index/CardsReference/Variant/Card.vue
@@ -18,6 +18,17 @@
         :last-period="variantData.lastPeriod"
         unit="%"
       >
+        <template #additionalButton>
+          <app-link
+            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/henikabu/screening.html"
+            :class="$style.button"
+          >
+            <span :class="$style.buttonInner">
+              <covid-icon :class="$style.buttonIcon" aria-hidden="true" />
+              {{ $t('変異株情報') }}
+            </span>
+          </app-link>
+        </template>
         <template #additionalDescription>
           <span>{{ $t('（注）') }}</span>
           <ul>
@@ -62,6 +73,7 @@ import {
   Period as IVariantsPeriod,
   Variants as IVariants,
 } from '@/libraries/auto_generated/data_converter/convertVariants'
+import CovidIcon from '@/static/covid.svg'
 import { getNumberToFixedFunction } from '@/utils/monitoringStatusValueFormatters'
 
 dayjs.extend(duration)
@@ -93,6 +105,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   components: {
     Chart,
     AppLink,
+    CovidIcon,
   },
   data() {
     const chartLabels = [
@@ -193,3 +206,24 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   },
 })
 </script>
+
+<style lang="scss" module>
+.button {
+  margin-top: 4px;
+  color: $green-1 !important;
+  text-decoration: none;
+  &:hover {
+    color: $white !important;
+  }
+  @include button-text('sm');
+  &Inner {
+    display: inline-flex;
+    align-items: center;
+  }
+  &Icon {
+    width: 1em;
+    height: 1em;
+    margin-right: 4px;
+  }
+}
+</style>

--- a/components/index/CardsReference/Variant/Card.vue
+++ b/components/index/CardsReference/Variant/Card.vue
@@ -23,8 +23,8 @@
             to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/corona_portal/henikabu/screening.html"
             :class="$style.button"
           >
-            <span :class="$style.buttonInner">
-              <covid-icon :class="$style.buttonIcon" aria-hidden="true" />
+            <span :class="$style['button-inner']">
+              <covid-icon :class="$style['button-icon']" aria-hidden="true" />
               {{ $t('変異株情報') }}
             </span>
           </app-link>
@@ -216,11 +216,11 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     color: $white !important;
   }
   @include button-text('sm');
-  &Inner {
+  &-inner {
     display: inline-flex;
     align-items: center;
   }
-  &Icon {
+  &-icon {
     width: 1em;
     height: 1em;
     margin-right: 4px;

--- a/components/index/CardsReference/Variant/Chart.vue
+++ b/components/index/CardsReference/Variant/Chart.vue
@@ -61,6 +61,7 @@
         />
       </template>
     </scrollable-chart>
+    <slot name="additionalButton" />
     <template #additionalDescription>
       <slot name="additionalDescription" />
     </template>

--- a/components/index/CardsReference/Variant/Chart.vue
+++ b/components/index/CardsReference/Variant/Chart.vue
@@ -85,9 +85,9 @@
 
 <script lang="ts">
 import { ChartOptions, PluginServiceRegistrationOptions } from 'chart.js'
-import Vue, { PropType } from 'vue'
+import Vue, { PropType } from 'vue' // eslint-disable-line import/named
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-import { TranslateResult } from 'vue-i18n'
+import { TranslateResult } from 'vue-i18n' // eslint-disable-line import/named
 
 import DataView from '@/components/index/_shared/DataView.vue'
 import DataViewDataSetPanel from '@/components/index/_shared/DataViewDataSetPanel.vue'


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6680

## 📝 関連する issue / Related Issues
- 「L452R変異株スクリーニングの実施状況」グラフ下に「変異株情報」ボタンを追加

## ⛏ 変更内容 / Details of Changes

- 「検査陽性者の状況」表の「死亡日別による死亡者数の推移はこちら」を参考に「L452R変異株スクリーニングの実施状況」グラフ下に「変異株情報」ボタンを追加
- Variantのチャートコンポーネント(`components/index/CardsReference/Variant/Chart.vue`)に名前付きスロット"additionalButton" を追加

## 📸 スクリーンショット / Screenshots

<img width="1434" alt="6680-add-henikabu-button-screenshot" src="https://user-images.githubusercontent.com/41494250/131231691-2e956984-2a6d-40c9-b1e8-56f85e649edd.png">
