### PR TITLE
「検査実施件数」グラフ下に「検査情報」ボタンを追加・「ワクチン接種数（累計）」グラフ下に「ワクチン情報」ボタンを追加

### DIFF
--- a/components/index/CardsReference/TestedNumber/Card.vue
+++ b/components/index/CardsReference/TestedNumber/Card.vue
@@ -15,6 +15,19 @@
         :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000086'"
       >
         <!-- 件.tested = 検査数 -->
+        <template #additionalButton>
+          <app-link
+            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/kensa/index.html"
+            :class="$style.button"
+          >
+            <span :class="$style['button-inner']">
+              <v-icon size="1.1em" :class="$style['button-v-icon']">
+                {{ mdiClipboardText }}
+              </v-icon>
+              {{ $t('検査情報') }}
+            </span>
+          </app-link>
+        </template>
         <template #additionalDescription>
           <span>{{ $t('（注）') }}</span>
           <ul>
@@ -48,15 +61,18 @@
 </template>
 
 <script>
+import { mdiClipboardText } from '@mdi/js'
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 
+import AppLink from '@/components/_shared/AppLink.vue'
 import Chart from '@/components/index/CardsReference/TestedNumber/Chart.vue'
 import Data from '@/data/data.json'
 dayjs.extend(duration)
 
 export default {
   components: {
+    AppLink,
     Chart,
   },
   data() {
@@ -92,7 +108,29 @@ export default {
       inspectionsLabels,
       inspectionsDataLabels,
       inspectionsTableLabels,
+      mdiClipboardText,
     }
   },
 }
 </script>
+
+<style lang="scss" module>
+.button {
+  margin-top: 4px;
+  color: $green-1 !important;
+  text-decoration: none;
+  &:hover {
+    color: $white !important;
+  }
+  @include button-text('sm');
+  &-inner {
+    display: inline-flex;
+    align-items: center;
+  }
+  &-v-icon {
+    color: currentColor !important;
+    margin-right: 4px;
+    transition: none !important;
+  }
+}
+</style>

--- a/components/index/CardsReference/TestedNumber/Chart.vue
+++ b/components/index/CardsReference/TestedNumber/Chart.vue
@@ -58,6 +58,7 @@
         />
       </template>
     </scrollable-chart>
+    <slot name="additionalButton" />
     <template #dataTable>
       <client-only>
         <data-view-table :headers="tableHeaders" :items="tableData" />
@@ -84,7 +85,7 @@ import { ChartOptions, PluginServiceRegistrationOptions } from 'chart.js'
 import dayjs from 'dayjs'
 import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-import { TranslateResult } from 'vue-i18n'
+import { TranslateResult } from 'vue-i18n' // eslint-disable-line import/named
 
 import DataSelector from '@/components/index/_shared/DataSelector.vue'
 import DataView from '@/components/index/_shared/DataView.vue'

--- a/components/index/CardsReference/Vaccination/Card.vue
+++ b/components/index/CardsReference/Vaccination/Card.vue
@@ -18,6 +18,17 @@
         :labels="vaccinationData.labels"
         :data-labels="chartLabels"
       >
+        <template #additionalButton>
+          <app-link
+            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/coronavaccine/index.html"
+            :class="$style.button"
+          >
+            <span :class="$style['button-inner']">
+              <vaccine-icon :class="$style['button-icon']" aria-hidden="true" />
+              {{ $t('ワクチン情報') }}
+            </span>
+          </app-link>
+        </template>
         <template #additionalDescription>
           <span>{{ $t('（注）') }}</span>
           <ul>
@@ -44,11 +55,13 @@
 <script lang="ts">
 import Vue from 'vue'
 
+import AppLink from '@/components/_shared/AppLink.vue'
 import Chart from '@/components/index/CardsReference/Vaccination/Chart.vue'
 import {
   Dataset as IVaccinationDataset,
   VaccinationAll as IVaccination,
 } from '@/libraries/auto_generated/data_converter/convertVaccinationAll'
+import VaccineIcon from '@/static/vaccine.svg'
 import { getNumberToLocaleStringFunction } from '@/utils/monitoringStatusValueFormatters'
 
 type Data = {
@@ -72,7 +85,9 @@ type Props = {}
 
 export default Vue.extend<Data, Methods, Computed, Props>({
   components: {
+    AppLink,
     Chart,
+    VaccineIcon,
   },
   data() {
     const chartLabels = [
@@ -148,3 +163,24 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   },
 })
 </script>
+
+<style lang="scss" module>
+.button {
+  margin-top: 4px;
+  color: $green-1 !important;
+  text-decoration: none;
+  &:hover {
+    color: $white !important;
+  }
+  @include button-text('sm');
+  &-inner {
+    display: inline-flex;
+    align-items: center;
+  }
+  &-icon {
+    width: 1em;
+    height: 1em;
+    margin-right: 4px;
+  }
+}
+</style>

--- a/components/index/CardsReference/Vaccination/Chart.vue
+++ b/components/index/CardsReference/Vaccination/Chart.vue
@@ -61,6 +61,7 @@
         />
       </template>
     </scrollable-chart>
+    <slot name="additionalButton" />
     <template #additionalDescription>
       <slot name="additionalDescription" />
     </template>
@@ -86,7 +87,7 @@ import { ChartOptions, PluginServiceRegistrationOptions } from 'chart.js'
 import dayjs from 'dayjs'
 import Vue from 'vue'
 import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
-import { TranslateResult } from 'vue-i18n'
+import { TranslateResult } from 'vue-i18n' // eslint-disable-line import/named
 
 import DataView from '@/components/index/_shared/DataView.vue'
 import DataViewDataSetPanel from '@/components/index/_shared/DataViewDataSetPanel.vue'

--- a/components/index/SiteTopUpper/WhatsNew.vue
+++ b/components/index/SiteTopUpper/WhatsNew.vue
@@ -35,19 +35,6 @@
             </span>
           </app-link>
         </li>
-        <li>
-          <app-link
-            class="WhatsNew-linkButton"
-            to="https://www.fukushihoken.metro.tokyo.lg.jp/iryo/kansen/kensa/index.html"
-          >
-            <span class="WhatsNew-linkButton-inner">
-              <v-icon size="1.1em" class="WhatsNew-linkButton-v-icon">
-                {{ mdiClipboardText }}
-              </v-icon>
-              {{ $t('検査情報') }}
-            </span>
-          </app-link>
-        </li>
       </ul>
     </div>
     <ul class="WhatsNew-list">
@@ -68,7 +55,7 @@
 </template>
 
 <script lang="ts">
-import { mdiClipboardText, mdiHomeAccount, mdiInformation } from '@mdi/js'
+import { mdiHomeAccount, mdiInformation } from '@mdi/js'
 import Vue from 'vue'
 
 import AppLink from '@/components/_shared/AppLink.vue'
@@ -88,7 +75,6 @@ export default Vue.extend({
   },
   data() {
     return {
-      mdiClipboardText,
       mdiHomeAccount,
       mdiInformation,
     }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6678 
- close #6679 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「検査実施件数」グラフ下に「検査情報」ボタンを追加しました
- 「ワクチン接種数（累計）」グラフ下に「ワクチン情報」ボタンを追加しました
- 最新のお知らせから「検査情報」ボタンを削除しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-08-29 17 38 31](https://user-images.githubusercontent.com/14883063/131244290-36a23220-c3e7-49ab-8560-7aa20fc5d4d2.png)

![スクリーンショット 2021-08-29 17 38 47](https://user-images.githubusercontent.com/14883063/131244295-314e94ca-97ed-4c49-b9d9-c45d7680f7bb.png)

![スクリーンショット 2021-08-29 17 39 07](https://user-images.githubusercontent.com/14883063/131244301-6e1b3cd6-0c53-4852-9ed7-2625d4bb67c1.png)
