### PR TITLE
注釈の折りたたみをline-clampを使わない方法で修正

### DIFF
--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -316,7 +316,7 @@ export default Vue.extend({
         background: linear-gradient(
           to bottom,
           rgba(250, 252, 252, 0) 0%,
-          rgba(250, 252, 252, 0.95) 80%
+          rgba(255, 255, 255, 1) 80%
         );
       }
     }

--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -41,8 +41,42 @@
         <slot />
       </div>
 
-      <div class="DataView-Description DataView-Description--Additional">
+      <div
+        class="DataView-Description DataView-Description--Additional"
+        :class="{
+          'DataView-Description--Minimized-Additional':
+            !isAdditionalDescriptionExpanded,
+        }"
+      >
         <slot name="additionalDescription" />
+      </div>
+
+      <div
+        v-if="$slots.additionalDescription"
+        class="DataView-Description DataView-Description--Toggle"
+        @click="
+          isAdditionalDescriptionExpanded = !isAdditionalDescriptionExpanded
+        "
+      >
+        <div class="DataView-Description--Toggle__Icon">
+          <v-icon
+            :style="{
+              transform: isAdditionalDescriptionExpanded
+                ? 'rotate(-90deg)'
+                : 'none',
+            }"
+            size="2.4rem"
+            >{{ mdiChevronRight }}</v-icon
+          >
+        </div>
+        <span
+          v-if="isAdditionalDescriptionExpanded"
+          class="DataView-Description--Toggle__Text"
+          >注釈を折り畳む</span
+        >
+        <span v-else class="DataView-Description--Toggle__Text"
+          >注釈を全て表示</span
+        >
       </div>
 
       <expantion-panel v-if="$slots.dataTable" class="DataView-ExpantionPanel">
@@ -75,8 +109,9 @@
 </template>
 
 <script lang="ts">
+import { mdiChevronRight } from '@mdi/js'
 import Vue from 'vue'
-import { MetaInfo } from 'vue-meta'
+import { MetaInfo } from 'vue-meta' // eslint-disable-line import/named
 
 import AppLink from '@/components/_shared/AppLink.vue'
 import ExpantionPanel from '@/components/index/_shared/DataView/ExpantionPanel.vue'
@@ -102,6 +137,12 @@ export default Vue.extend({
       type: String,
       default: '',
     },
+  },
+  data() {
+    return {
+      mdiChevronRight,
+      isAdditionalDescriptionExpanded: false,
+    }
   },
   head(): MetaInfo {
     // カードの個別ページの場合は、タイトルと更新時刻を`page/cards/_card`に渡す
@@ -247,6 +288,36 @@ export default Vue.extend({
 
     &--Additional {
       margin-bottom: 10px;
+    }
+
+    &--Minimized-Additional {
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 4;
+      overflow: hidden;
+    }
+
+    &--Toggle {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 4px;
+      padding: 5px 8px;
+      background-color: $gray-3;
+      align-self: center;
+      cursor: pointer;
+      margin-bottom: 10px;
+
+      &__Icon {
+        margin-left: -5px;
+        .v-icon {
+          color: $white;
+        }
+      }
+
+      &__Text {
+        color: $white;
+        @include font-size(14);
+      }
     }
   }
 

--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -42,41 +42,50 @@
       </div>
 
       <div
+        ref="Description"
         class="DataView-Description DataView-Description--Additional"
         :class="{
           'DataView-Description--Minimized-Additional':
-            !isAdditionalDescriptionExpanded,
+            !isAdditionalDescriptionExpanded && !isAlreadyShowingDescription,
         }"
       >
         <slot name="additionalDescription" />
-      </div>
 
-      <div
-        v-if="$slots.additionalDescription"
-        class="DataView-Description DataView-Description--Toggle"
-        @click="
-          isAdditionalDescriptionExpanded = !isAdditionalDescriptionExpanded
-        "
-      >
-        <div class="DataView-Description--Toggle__Icon">
-          <v-icon
-            :style="{
-              transform: isAdditionalDescriptionExpanded
-                ? 'rotate(-90deg)'
-                : 'none',
-            }"
-            size="2.4rem"
-            >{{ mdiChevronRight }}</v-icon
+        <div
+          v-if="
+            $slots.additionalDescription &&
+            !$route.params.card &&
+            !isAlreadyShowingDescription
+          "
+          :class="[
+            'DataView-Description DataView-Description--Toggle',
+            isAdditionalDescriptionExpanded ? 'expand' : '',
+          ]"
+          @click="
+            isAdditionalDescriptionExpanded = !isAdditionalDescriptionExpanded
+          "
+        >
+          <div class="DataView-Description--Toggle__Icon">
+            <v-icon
+              :style="{
+                transform: isAdditionalDescriptionExpanded
+                  ? 'rotate(-90deg)'
+                  : 'none',
+              }"
+              size="2.4rem"
+              >{{ mdiChevronRight }}</v-icon
+            >
+          </div>
+          <span
+            v-if="isAdditionalDescriptionExpanded"
+            class="DataView-Description--Toggle__Text"
           >
+            {{ $t('注釈を折り畳む') }}
+          </span>
+          <span v-else class="DataView-Description--Toggle__Text">
+            {{ $t('注釈を全て表示') }}
+          </span>
         </div>
-        <span
-          v-if="isAdditionalDescriptionExpanded"
-          class="DataView-Description--Toggle__Text"
-          >注釈を折り畳む</span
-        >
-        <span v-else class="DataView-Description--Toggle__Text"
-          >注釈を全て表示</span
-        >
       </div>
 
       <expantion-panel v-if="$slots.dataTable" class="DataView-ExpantionPanel">
@@ -141,7 +150,8 @@ export default Vue.extend({
   data() {
     return {
       mdiChevronRight,
-      isAdditionalDescriptionExpanded: false,
+      isAdditionalDescriptionExpanded: !!this.$route.params.card,
+      isAlreadyShowingDescription: true,
     }
   },
   head(): MetaInfo {
@@ -180,6 +190,10 @@ export default Vue.extend({
       const permalink = `/cards/${this.titleId}`
       return this.localePath(permalink)
     },
+  },
+  mounted() {
+    const $Description = this.$refs.Description as HTMLElement
+    this.isAlreadyShowingDescription = $Description.clientHeight <= 70
   },
 })
 </script>
@@ -261,7 +275,8 @@ export default Vue.extend({
   }
 
   &-Description {
-    margin-top: 10px;
+    position: relative;
+    margin: 10px 0;
     color: $gray-3;
     @include font-size(12);
 
@@ -286,18 +301,32 @@ export default Vue.extend({
       }
     }
 
-    &--Additional {
-      margin-bottom: 10px;
-    }
-
     &--Minimized-Additional {
-      display: -webkit-box;
-      -webkit-box-orient: vertical;
-      -webkit-line-clamp: 4;
+      position: relative;
+      height: 100px;
       overflow: hidden;
+      &::after {
+        position: absolute;
+        z-index: 1;
+        bottom: 0;
+        content: '';
+        display: block;
+        width: 100%;
+        height: 70px;
+        background: linear-gradient(
+          to bottom,
+          rgba(250, 252, 252, 0) 0%,
+          rgba(250, 252, 252, 0.95) 80%
+        );
+      }
     }
 
     &--Toggle {
+      position: absolute;
+      z-index: 2;
+      bottom: 0;
+      left: 50%;
+      transform: translateX(-50%);
       display: inline-flex;
       align-items: center;
       border-radius: 4px;
@@ -305,7 +334,10 @@ export default Vue.extend({
       background-color: $gray-3;
       align-self: center;
       cursor: pointer;
-      margin-bottom: 10px;
+
+      &.expand {
+        position: relative;
+      }
 
       &__Icon {
         margin-left: -5px;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6677 

## 📝 関連する issue / Related Issues
- #6690 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- @knknk98 さんのPRを修正しました（ @knknk98 さんありがとうございます！）
- `line-clamp` は将来的なことを鑑みると使わないほうがよさそうなので、別の方法にしました→ [参考](https://copypet.jp/codedescription/499/)
- 個別カードページでは注釈は全表示にしました
- 注釈が短い場合はトグルを出さないようにしました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-08-30 12 56 57](https://user-images.githubusercontent.com/14883063/131283266-a3a52767-6961-4401-bdad-78a9ea799aeb.png)
