### PR TITLE
fix: flicker on switching tabs

### DIFF
--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -8,25 +8,9 @@ export default function (to, from, savedPosition) {
     return { selector: to.hash }
   }
 
-  if (!to.meta.tabs) {
-    return { x: 0, y: 0 }
+  if (from.meta.tabs && to.meta.tabs) {
+    return
   }
 
-  const element = document.querySelector('[id^="cardTab"]')
-  if (!element) {
-    return { x: 0, y: 0 }
-  }
-
-  const elementTop = element.getBoundingClientRect().top + window.pageYOffset
-
-  if (!window.$nuxt.context.$vuetify.breakpoint.xsOnly) {
-    return { x: 0, y: elementTop }
-  }
-
-  const naviContainer = document.querySelector('.naviContainer')
-  if (!naviContainer) {
-    return { x: 0, y: elementTop }
-  }
-
-  return { x: 0, y: elementTop - naviContainer.scrollHeight }
+  return { x: 0, y: 0 }
 }

--- a/app/router.scrollBehavior.js
+++ b/app/router.scrollBehavior.js
@@ -8,13 +8,25 @@ export default function (to, from, savedPosition) {
     return { selector: to.hash }
   }
 
-  if (to.meta.tabs) {
-    const element = document.querySelector('[id^="cardTab"]')
-    if (element) {
-      const y = element.getBoundingClientRect().top + window.pageYOffset
-      return { x: 0, y }
-    }
+  if (!to.meta.tabs) {
+    return { x: 0, y: 0 }
   }
 
-  return { x: 0, y: 0 }
+  const element = document.querySelector('[id^="cardTab"]')
+  if (!element) {
+    return { x: 0, y: 0 }
+  }
+
+  const elementTop = element.getBoundingClientRect().top + window.pageYOffset
+
+  if (!window.$nuxt.context.$vuetify.breakpoint.xsOnly) {
+    return { x: 0, y: elementTop }
+  }
+
+  const naviContainer = document.querySelector('.naviContainer')
+  if (!naviContainer) {
+    return { x: 0, y: elementTop }
+  }
+
+  return { x: 0, y: elementTop - naviContainer.scrollHeight }
 }

--- a/components/index/CardsTab.vue
+++ b/components/index/CardsTab.vue
@@ -78,6 +78,10 @@ export default Vue.extend({
   background: $gray-5;
 }
 
+.v-tabs {
+  min-height: 100vh;
+}
+
 .v-tab {
   top: 1px;
   margin: 0 8px;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     "types": [
       "@types/node",
       "@nuxt/types",
-      "@nuxtjs/i18n"
+      "@nuxtjs/i18n",
+      "@nuxtjs/vuetify"
     ]
   },
   "exclude": [


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6683 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- タブを切り替えた際のガタつきをなくし、#6666 の対応通り、タブの位置までスクロールするよう修正
- スマホでのスクロール位置がナビゲーションの分だけずれていた問題を修正

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

デスクトップ

https://user-images.githubusercontent.com/24248467/133935560-4f384edf-82e2-4cbc-87c1-5f37959a9885.mp4

スマホ

https://user-images.githubusercontent.com/24248467/133935568-45d55b71-abc4-4c3a-9aef-02426bb62870.mp4

---

ガタつきの原因は再描画によるものではなく、ページ遷移時のスクロールによるものでした。
具体的には以下のフローです。

1. タブクリック
2. ページ遷移
3. `app/router.scrollBehavior.js` によってタブの位置までスクロール
4. `cards-tab` のコンテンツが一瞬無くなり、タブの位置までスクロールできるだけのheightが存在しないことでスクロール位置が上に戻る
5. `cards-tab` のコンテンツを表示

`min-height: 100vh` によって4.の問題を発生させないようにしました。