### PR TITLE
HTMLの文法違反を修正

### DIFF
--- a/components/_shared/SideNavigation.vue
+++ b/components/_shared/SideNavigation.vue
@@ -18,11 +18,11 @@
             height="28"
             :alt="$t('東京都')"
           />
-          <div class="SideNavigation-HeaderText">
+          <span class="SideNavigation-HeaderText">
             {{ $t('menu/新型コロナウイルス感染症') }}<br />{{
               $t('menu/対策サイト')
             }}
-          </div>
+          </span>
         </app-link>
       </h1>
     </header>
@@ -520,6 +520,7 @@ export default Vue.extend({
 }
 
 .SideNavigation-HeaderText {
+  display: block;
   margin: 10px 0 0 0;
   @include lessThan($small) {
     margin: 0 0 0 10px;

--- a/components/_shared/SideNavigation/MenuList.vue
+++ b/components/_shared/SideNavigation/MenuList.vue
@@ -11,9 +11,9 @@
             :hide-actions="true"
             :style="{ transition: 'none' }"
           >
-            <div class="v-expansion-panel-header__icon">
+            <span class="v-expansion-panel-header__icon">
               <v-icon left size="2.4rem">{{ mdiChevronRight }}</v-icon>
-            </div>
+            </span>
             <span class="MenuTitle">{{ setMenuTitle(slug) }}</span>
           </v-expansion-panel-header>
           <v-expansion-panel-content>

--- a/components/index/CardsFeatured/TestedNumber/Chart.vue
+++ b/components/index/CardsFeatured/TestedNumber/Chart.vue
@@ -16,7 +16,8 @@
     >
       <li v-for="(item, i) in items" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -616,7 +617,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
+++ b/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
@@ -13,16 +13,18 @@
         @click="onClickLegend(i)"
       >
         <button>
-          <div
+          <span
             v-if="i === 2"
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -540,7 +542,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -15,7 +15,8 @@
         @click="onClickLegend(i)"
       >
         <button>
-          <div
+          <span
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -487,7 +488,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -11,16 +11,18 @@
     >
       <li v-for="(item, i) in dataLabels" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
             v-if="i === 1"
+            :class="$style.area"
             :style="{
               background: colors[i].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -527,7 +529,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -15,24 +15,27 @@
         @click="onClickLegend(i)"
       >
         <button>
-          <div
+          <span
             v-if="i === 4"
+            :class="$style.area"
             :style="{
               background: `repeating-linear-gradient(90deg, ${colors[i].fillColor}, ${colors[i].fillColor} 2px, #fff 2px, #fff 4px)`,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else-if="i === 5"
+            :class="$style.area"
             :style="{
               backgroundColor: colors[4].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -717,7 +720,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -18,24 +18,27 @@
         @click="onClickLegend(i)"
       >
         <button>
-          <div
+          <span
             v-if="i === 2"
+            :class="$style.area"
             :style="{
               background: `repeating-linear-gradient(90deg, ${colors[i].fillColor}, ${colors[i].fillColor} 2px, #fff 2px, #fff 4px)`,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else-if="i === 3"
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -672,7 +675,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsReference/Agency/Chart.vue
+++ b/components/index/CardsReference/Agency/Chart.vue
@@ -6,7 +6,8 @@
     >
       <li v-for="(item, i) in items" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -412,7 +413,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -9,7 +9,7 @@
     >
       <scale-loader color="#00A040" />
     </v-overlay>
-    <v-overlay v-if="error" absolute justify-center align-center>
+    <v-overlay v-if="error" absolute>
       <v-alert color="#AD2121">
         <v-icon>
           {{ mdiAlert }}

--- a/components/index/CardsReference/Metro/Chart.vue
+++ b/components/index/CardsReference/Metro/Chart.vue
@@ -6,7 +6,8 @@
     >
       <li v-for="(item, i) in items" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               border: 0,
@@ -445,7 +446,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsReference/MonitoringConsultationDeskReportsNumber/Chart.vue
+++ b/components/index/CardsReference/MonitoringConsultationDeskReportsNumber/Chart.vue
@@ -6,16 +6,18 @@
     >
       <li v-for="(item, i) in dataLabels" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
             v-if="i === 1"
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -496,7 +498,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/CardsReference/Variant/Chart.vue
+++ b/components/index/CardsReference/Variant/Chart.vue
@@ -15,7 +15,8 @@
         @click="onClickLegend(i)"
       >
         <button>
-          <div
+          <span
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -648,7 +649,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/components/index/_shared/CardsLazyRow.vue
+++ b/components/index/_shared/CardsLazyRow.vue
@@ -22,9 +22,9 @@
           :hide-actions="true"
           :style="{ transition: 'none' }"
         >
-          <div class="v-expansion-panel-header__icon">
+          <span class="v-expansion-panel-header__icon">
             <v-icon left size="2.4rem">{{ mdiChevronRight }}</v-icon>
-          </div>
+          </span>
           <span class="expansion-panel-text">{{
             $t('更新を終了したグラフ')
           }}</span>

--- a/components/index/_shared/DataView/ExpantionPanel.vue
+++ b/components/index/_shared/DataView/ExpantionPanel.vue
@@ -7,9 +7,9 @@
           :style="{ transition: 'none' }"
           @click="toggleDetails"
         >
-          <div class="v-expansion-panel-header__icon">
+          <span class="v-expansion-panel-header__icon">
             <v-icon left size="2.4rem">{{ mdiChevronRight }}</v-icon>
-          </div>
+          </span>
           <span class="expansion-panel-text">{{ $t('テーブルを表示') }}</span>
         </v-expansion-panel-header>
         <v-expansion-panel-content>

--- a/components/index/_shared/MixedBarAndLineChart.vue
+++ b/components/index/_shared/MixedBarAndLineChart.vue
@@ -11,16 +11,18 @@
     >
       <li v-for="(item, i) in dataLabels" :key="i" @click="onClickLegend(i)">
         <button>
-          <div
+          <span
             v-if="i === 1"
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               border: 0,
               height: '3px',
             }"
           />
-          <div
+          <span
             v-else
+            :class="$style.area"
             :style="{
               backgroundColor: colors[i].fillColor,
               borderColor: colors[i].strokeColor,
@@ -521,7 +523,7 @@ export default Vue.extend(options)
     li {
       display: inline-block;
       margin: 0 3px;
-      div {
+      .area {
         height: 12px;
         margin: 2px 4px;
         width: 40px;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,6 @@ const config: NuxtConfig = {
       prefix: 'og: http://ogp.me/ns#',
     },
     meta: [
-      { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
       { hid: 'og:type', property: 'og:type', content: 'website' },
       {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- #6750 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- [x] 対応済み
  > A document must not include more than one meta element with a charset attribute.
  > `<meta data-n-head="ssr" charset="utf-8">`
  > `<meta data-n-head="ssr" data-hid="charset" charset="utf-8">`
  > meta charsetが複数ある
 
- [x] 対応済み
  > Element div not allowed as child of element a in this context. (Suppressing further errors from this subtree.)
  > `<div class="SideNavigation-HeaderText" data-v-32e6c11e="">`
  > h1 > a > divになっていて入れ子ルール違反
 
- [x] 対応済み
  > Element div not allowed as child of element button in this context. (Suppressing further errors from this subtree.)
  > `<div class="v-expansion-panel-header__icon">`
  > button > divになっていて入れ子ルール違反
 
- [x] 対応せず（ https://github.com/tokyo-metropolitan-gov/covid19/pull/6770#issuecomment-923358942 ）
  > Element style not allowed as child of element div in this context. (Suppressing further errors from this subtree.)
  > noscript内部のstyle要素が入れ子ルール違反
 
- [ ] 未対応*2
  > Element div is missing one or more of the following attributes: role.
  > `<div aria-expanded="false" class="v-expansion-panel">`
  > aria-expandedはroleがない要素には指定できない（aria-expandedはbutton側だけにつける）
 
- [x] 対応済み
  > Element div not allowed as child of element button in this context. (Suppressing further errors from this subtree.)
  > `<button><div style="background-color: rgb(XXX); border-color: rgb(XXX);">`
  > グラフの凡例。button > divになっていて入れ子ルール違反
 
- [x] 対応せず（ https://github.com/tokyo-metropolitan-gov/covid19/pull/6770#issuecomment-922909538 ）
  > The role attribute must not be used on a th element which has a table ancestor with no role attribute, or with a role attribute whose value is table, grid, or treegrid.
  > `<th role="columnheader" scope="col" aria-label="地域" class="text-start">`
  > role="columnheader" があるとルール違反（親要素が普通のtableのときには使えない）
 
- [x] 対応済み
  > Attribute justify-center not allowed on element div at this point.Attribute align-center not allowed on element div at this point.
  > `<div class="v-overlay v-overlay--absolute theme--dark" justify-center="" align-center="" style="z-index: 5;">`
  > 陽性者の属性のテーブル送り周り。謎の属性がある
 
- [x] 対応済み（ #6773 ）
  > The element input must not appear as a descendant of an element with the attribute role=button.
  > `<input aria-label="1ページ当たり" id="input-918" readonly="readonly" type="text" autocomplete="off">`
  > 陽性者の属性のテーブル送り周り。role=button > input になっていて入れ子ルール違反

-----

- 未対応*1は、解決方法がわからずです。
- 未対応*2は、Vuetifyの内部実装なので保留にしています。

@magi1125 さん、アドバイスお願いします！ 🙏 
