### PR TITLE
陽性者の属性テーブルのセレクトボックスとページネーションをカスタムで作成

### DIFF
--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -85,11 +85,25 @@
                 }}
               </span>
               <div>
-                <v-icon v-model="page" :disabled="page <= 1" @click="page--">
+                <v-icon
+                  v-model="page"
+                  :aria-label="
+                    $t('前の{perPage}件', {
+                      perPage: itemsPerPage,
+                    })
+                  "
+                  :disabled="page <= 1"
+                  @click="page--"
+                >
                   {{ mdiChevronLeft }}
                 </v-icon>
                 <v-icon
                   v-model="page"
+                  :aria-label="
+                    $t('次の{perPage}件', {
+                      perPage: itemsPerPage,
+                    })
+                  "
                   :disabled="
                     props.pagination.itemsLength <= props.pagination.pageStop
                   "

--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -302,18 +302,8 @@ export default Vue.extend({
   padding-right: 8px;
 }
 .perPageSelectBox {
-  // select 要素のリセット
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: transparent;
-  // IEで矢印ボタンを消す
-  &::-ms-expand {
-    display: none;
-  }
-
+  appearance: auto;
   border: 1px solid $gray-4;
-  padding: 0 8px;
 
   &:focus {
     border: 1px dotted $gray-3;

--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -26,6 +26,7 @@
         :height="240"
         fixed-header
         :hide-default-header="true"
+        :hide-default-footer="true"
         :mobile-breakpoint="0"
         :footer-props="{
           'items-per-page-options': [15, 30, 50, 100, 200, 300, 500, 1000],
@@ -53,14 +54,54 @@
         <template #body="{ items, headers }">
           <slot name="tableBody" :items="items" :headers="headers" />
         </template>
-        <template slot="footer.page-text" slot-scope="props">
-          {{
-            $t('{itemsLength} 項目中 {pageStart} - {pageStop} ', {
-              itemsLength: props.itemsLength,
-              pageStart: props.pageStart,
-              pageStop: props.pageStop,
-            })
-          }}
+        <template #footer="{ attr, on, props }">
+          <div class="cardTableFooter">
+            <div class="cardTableFooterItem">
+              <label for="perPageSelector" class="cardTableFooterLabel">
+                {{ props.itemsPerPageText }}
+              </label>
+              <select
+                id="perPageSelector"
+                v-model="itemsPerPage"
+                v-bind="attr"
+                class="perPageSelectBox"
+                v-on="on"
+              >
+                <option
+                  v-for="(item, i) in props.itemsPerPageOptions"
+                  :key="i"
+                  :value="item"
+                >
+                  {{ item }}
+                </option>
+              </select>
+            </div>
+            <div class="cardTableFooterItem">
+              <span class="cardTableFooterLabel">
+                {{
+                  $t('{itemsLength} 項目中 {pageStart} - {pageStop} ', {
+                    itemsLength: props.pagination.itemsLength,
+                    pageStart: props.pagination.pageStart + 1,
+                    pageStop: props.pagination.pageStop,
+                  })
+                }}
+              </span>
+              <div>
+                <v-icon v-model="page" :disabled="page <= 1" @click="page--">
+                  {{ mdiChevronLeft }}
+                </v-icon>
+                <v-icon
+                  v-model="page"
+                  :disabled="
+                    props.pagination.itemsLength <= props.pagination.pageStop
+                  "
+                  @click="page++"
+                >
+                  {{ mdiChevronRight }}
+                </v-icon>
+              </div>
+            </div>
+          </div>
         </template>
       </v-data-table>
     </v-layout>
@@ -84,7 +125,7 @@
 </template>
 
 <script lang="ts">
-import { mdiAlert } from '@mdi/js'
+import { mdiAlert, mdiChevronLeft, mdiChevronRight } from '@mdi/js'
 import Vue from 'vue'
 import ScaleLoader from 'vue-spinner/src/ScaleLoader.vue'
 
@@ -137,6 +178,8 @@ export default Vue.extend({
       itemsPerPage: 15,
       page: 1,
       mdiAlert,
+      mdiChevronLeft,
+      mdiChevronRight,
     }
   },
   watch: {
@@ -244,5 +287,39 @@ export default Vue.extend({
 }
 .DataTable-header {
   white-space: nowrap;
+}
+.cardTableFooter {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin: 12px 0;
+  @include font-size(14);
+}
+.cardTableFooterItem {
+  display: flex;
+  align-items: center;
+  margin-left: 12px;
+}
+.cardTableFooterLabel {
+  padding-right: 8px;
+}
+.perPageSelectBox {
+  // select 要素のリセット
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  // IEで矢印ボタンを消す
+  &::-ms-expand {
+    display: none;
+  }
+
+  border: 1px solid $gray-4;
+  padding: 0 8px;
+
+  &:focus {
+    border: 1px dotted $gray-3;
+    outline: none;
+  }
 }
 </style>

--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -54,7 +54,7 @@
         <template #body="{ items, headers }">
           <slot name="tableBody" :items="items" :headers="headers" />
         </template>
-        <template #footer="{ attr, on, props }">
+        <template #footer="{ props }">
           <div class="cardTableFooter">
             <div class="cardTableFooterItem">
               <label for="perPageSelector" class="cardTableFooterLabel">
@@ -63,9 +63,7 @@
               <select
                 id="perPageSelector"
                 v-model="itemsPerPage"
-                v-bind="attr"
                 class="perPageSelectBox"
-                v-on="on"
               >
                 <option
                   v-for="(item, i) in props.itemsPerPageOptions"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6761 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 陽性者の属性テーブルのデフォルトfooterを非表示にし、カスタムでセレクトボックスとページネーションを作成しました

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2021-09-20 20 53 56](https://user-images.githubusercontent.com/14883063/133997919-bc326d0e-3c70-4268-9f2e-ef45625900be.png)

![スクリーンショット 2021-09-20 20 54 51](https://user-images.githubusercontent.com/14883063/133998015-5df8fbd1-d711-40a0-b415-1f820d334b1c.png)
