### PR TITLE
注釈の折り畳みボタンのアクセシビリティ改善

### DIFF
--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -45,6 +45,7 @@
       </div>
 
       <div
+        :id="titleId + '--description'"
         ref="Description"
         class="DataView-Description DataView-Description--Additional"
         :class="{
@@ -54,7 +55,7 @@
       >
         <slot name="additionalDescription" />
 
-        <div
+        <button
           v-if="
             $slots.additionalDescription &&
             !$route.params.card &&
@@ -64,6 +65,8 @@
             'DataView-Description DataView-Description--Toggle',
             isAdditionalDescriptionExpanded ? 'expand' : '',
           ]"
+          :aria-expanded="[isAdditionalDescriptionExpanded ? true : false]"
+          :aria-controls="titleId + '--description'"
           @click="toggleDescription"
         >
           <div class="DataView-Description--Toggle__Icon">
@@ -86,7 +89,7 @@
           <span v-else class="DataView-Description--Toggle__Text">
             {{ $t('注釈を全て表示') }}
           </span>
-        </div>
+        </button>
       </div>
 
       <expantion-panel v-if="$slots.dataTable" class="DataView-ExpantionPanel">

--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -301,6 +301,7 @@ export default Vue.extend({
   &-Description {
     position: relative;
     margin: 10px 0;
+    outline-offset: 4px;
     color: $gray-3;
     @include font-size(12);
 

--- a/components/index/_shared/DataView.vue
+++ b/components/index/_shared/DataView.vue
@@ -69,7 +69,7 @@
           :aria-controls="titleId + '--description'"
           @click="toggleDescription"
         >
-          <div class="DataView-Description--Toggle__Icon">
+          <span class="DataView-Description--Toggle__Icon">
             <v-icon
               :style="{
                 transform: isAdditionalDescriptionExpanded
@@ -79,7 +79,7 @@
               size="2.4rem"
               >{{ mdiChevronRight }}</v-icon
             >
-          </div>
+          </span>
           <span
             v-if="isAdditionalDescriptionExpanded"
             class="DataView-Description--Toggle__Text"


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6748 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 注釈の折り畳みボタンのアクセシビリティ改善
- div要素を用いて実装されていたボタンをbutton要素に変更
- `aria-expanded`属性および`aria-controls`属性を付与
- フォーカスリングに余白を設定

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/67552983/134095318-e72788f1-5f27-4752-b531-a99e6069421a.png)
