### PR TITLE
Revert "style: show outline on focus"

### DIFF
--- a/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
+++ b/components/index/CardsReference/ConfirmedCasesAttributes/DataTable.vue
@@ -206,7 +206,7 @@ export default Vue.extend({
   mounted() {
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el
-    const tables = vTableElement.querySelectorAll('.v-data-table__wrapper')
+    const tables = vTableElement.querySelectorAll('table')
     // NodeListをIE11でforEachするためのワークアラウンド
     const nodes = Array.prototype.slice.call(tables, 0)
     nodes.forEach((table: HTMLElement) => {

--- a/components/index/CardsReference/ConfirmedCasesByMunicipalities/Table.vue
+++ b/components/index/CardsReference/ConfirmedCasesByMunicipalities/Table.vue
@@ -66,7 +66,7 @@ export default Vue.extend({
   mounted() {
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el
-    const tables = vTableElement.querySelectorAll('.v-data-table__wrapper')
+    const tables = vTableElement.querySelectorAll('table')
     // NodeListをIE11でforEachするためのワークアラウンド
     const nodes = Array.prototype.slice.call(tables, 0)
     nodes.forEach((table: HTMLElement) => {

--- a/components/index/_shared/DataViewTable.vue
+++ b/components/index/_shared/DataViewTable.vue
@@ -88,7 +88,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
   mounted() {
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el
-    const tables = vTableElement.querySelectorAll('.v-data-table__wrapper')
+    const tables = vTableElement.querySelectorAll('table')
     // NodeListをIE11でforEachするためのワークアラウンド
     const nodes = Array.prototype.slice.call(tables, 0)
     nodes.forEach((table: HTMLElement) => {

--- a/components/index/_shared/ScrollableChart.vue
+++ b/components/index/_shared/ScrollableChart.vue
@@ -1,7 +1,9 @@
 <template>
-  <div ref="chartContainer" class="LegendStickyChart" tabindex="0">
-    <div :style="{ width: `${chartWidth}px` }">
-      <slot name="chart" :chart-width="chartWidth" />
+  <div ref="chartContainer" class="LegendStickyChart">
+    <div ref="scrollable" class="scrollable" tabindex="0">
+      <div :style="{ width: `${chartWidth}px` }">
+        <slot name="chart" :chart-width="chartWidth" />
+      </div>
     </div>
     <slot name="sticky-chart" />
   </div>
@@ -84,9 +86,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return Math.max(calcWidth, containerWidth)
     },
     scrollRightSide() {
-      const container = this.$refs.chartContainer as HTMLElement
-      if (!container) return
-      container.scrollLeft = this.chartWidth
+      const scrollable = this.$refs.scrollable as HTMLElement
+      if (!scrollable) return
+      scrollable.scrollLeft = this.chartWidth
     },
     handleResize() {
       clearTimeout(this.timerId)
@@ -113,8 +115,11 @@ export default options
 .LegendStickyChart {
   margin: 16px 0;
   position: relative;
-  overflow-x: scroll;
-  overflow-y: hidden;
+  overflow: hidden;
+
+  .scrollable {
+    overflow-x: scroll;
+  }
 
   .sticky-legend {
     position: absolute;


### PR DESCRIPTION
Reverts tokyo-metropolitan-gov/covid19#6774

現在、デフォルトでY軸が表示されなくなっているので、一旦リバートします。