### PR TITLE
MonitoringCommentCard の h3 「感染状況・医療提供体制の分析」 の翻訳もれを修正

### DIFF
--- a/components/index/CardsFeatured/MonitoringComment/Card.vue
+++ b/components/index/CardsFeatured/MonitoringComment/Card.vue
@@ -2,7 +2,7 @@
   <v-col cols="12" md="6" class="DataCard MonitoringCommentCard">
     <client-only>
       <data-view
-        :title="'感染状況・医療提供体制の分析'"
+        :title="$t('感染状況・医療提供体制の分析')"
         title-id="monitoring-comment"
         :date="date"
         is-set-title-row


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #6840 

## 📝 関連する issue / Related Issues
- https://github.com/tokyo-metropolitan-gov/covid19/pull/6685

## ⛏ 変更内容 / Details of Changes
- MonitoringCommentCard の h3 「感染状況・医療提供体制の分析」 を $t() で翻訳する
