### PR TITLE
[HOTFIX]i18n generatorが動かない問題を修正

### DIFF
--- a/auto-i18n/i18n_generator.py
+++ b/auto-i18n/i18n_generator.py
@@ -143,9 +143,9 @@ with open(os.path.join(os.pardir, OUTPUT_DIR, CHECK_RESULT), mode="a", encoding=
                         # ヘッダーを正規表現で取得し、textを抽出
                         headers = [eval(str_header + " }")[text] for str_header in header_pattern.findall(content)]
                         # translatable unitを正規表現で取得し、textを抽出
-                        translatable = [eval(str_unit + " }")[text] for str_unit in translatable_pattern.findall(content)]
+                        translatable_tags = [eval(str_unit + " }")[text] for str_unit in translatable_pattern.findall(content)]
                         # タグを統合し、重複分を取り除く
-                        all_tags = list(set(all_tags + headers + translatable))
+                        all_tags = list(set(all_tags + headers + translatable_tags))
         elif "auto-i18n/csv" in cdir:
             # すべてのcsvファイルを検索
             csv_files = glob.glob(cdir + os.sep + "**" + os.sep + "*.csv", recursive=True)


### PR DESCRIPTION
## 📝 関連する issue / Related Issues
- #6811 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- またまたIssueなしにすみません... #6811 で行ったtranslatable unit検出で、コード上のミスにより、GitHub Actionsが停止する事象が発生したので、それの修正です。

### 事象詳細
- 私の制作したスクリプトでは、pythonでJSのobjectを辞書型として扱うために、`eval`を用いてobjectの文字列を辞書として認識させています。
- また、例えばJSの`{ text: "abcdefg" }`の`text`の部分は、`eval`を用いると変数としてみなされるので、別の場所で変数に一度代入しています。
- #6811 では、`eval`のために用意している変数をglobal scopeに移動させ(複数個所で使うため)、`translatable`を認識するために、同様に`translatable`変数を用意しました。
- しかし、`translatable`という変数名を別の箇所(今回の変更箇所)でも使っており、`translatable`変数に`[]`(空のリスト)を代入してしまって書き換えてしまうことがあり、エラーを引き起こしていました。
- 残念ながら、以前まで正しく動いていた原因は究明できませんでした。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
