### PR TITLE
GitHub Actionsのパスを統一する

### DIFF
--- a/.github/workflows/audit-staging.yml
+++ b/.github/workflows/audit-staging.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v1
         with:
-          path: ~/.npm
+          path: ${{ github.workspace }}/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-

--- a/.github/workflows/check-statuses-of-forked-sites.yml
+++ b/.github/workflows/check-statuses-of-forked-sites.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run scripts
         run: |
-          python ./audit-forked-sites/check_status.py
+          python ${{ github.workspace }}/audit-forked-sites/check_status.py
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,9 @@ jobs:
       - run: yarn run test
       - name: generate
         run: |
-          echo "GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}" >> .env.production
-          echo "GTM_CONTAINER_ID=${GTM_CONTAINER_ID}" >> .env.production
-          cat .env.production
+          echo "GOOGLE_ANALYTICS_ID=${GOOGLE_ANALYTICS_ID}" >> ${{ github.workspace }}/.env.production
+          echo "GTM_CONTAINER_ID=${GTM_CONTAINER_ID}" >> ${{ github.workspace }}/.env.production
+          cat ${{ github.workspace }}/.env.production
           yarn run generate:deploy
         env:
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
@@ -48,7 +48,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ${{ github.workspace }}/dist
           publish_branch: production
 
       - name: Create GitHub release
@@ -58,8 +58,8 @@ jobs:
 
       - name: run delete_fbcache.sh
         run: |
-          echo "FB_ACCESS_TOKEN=${FACEBOOK_ACCESS_TOKEN}" > .env
-          cd ui-test
+          echo "FB_ACCESS_TOKEN=${FACEBOOK_ACCESS_TOKEN}" > ${{ github.workspace }}/.env
+          cd ${{ github.workspace }}/ui-test
           ./delete_fbcache.sh
         env:
           FACEBOOK_ACCESS_TOKEN: ${{ secrets.FACEBOOK_ACCESS_TOKEN }}

--- a/.github/workflows/i18n_generator.yml
+++ b/.github/workflows/i18n_generator.yml
@@ -23,8 +23,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install BeautifulSoup4
       - name: Run script
+        # Since i18n_generator.py uses os.pardir, the cd command is used to move the directory.
         run: |
-          cd auto-i18n
+          cd ${{ github.workspace }}/auto-i18n
           python i18n_generator.py
           cd ..
       - name: Create Pull Request

--- a/.github/workflows/ogp_builder.yml
+++ b/.github/workflows/ogp_builder.yml
@@ -58,7 +58,7 @@ jobs:
           name: ogp
       - name: Commit files
         run: |
-          cp -rp ogp static/
+          cp -rp ${{ github.workspace }}/ogp ${{ github.workspace }}/static/
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add static

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - run: cp ui-test\dummy.json dist\data/\data.json
+      - run: cp ${{ github.workspace }}\ui-test\dummy.json ${{ github.workspace }}\dist\data/\data.json
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -31,10 +31,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run test
       - run: yarn run generate:dev
-      - run: "echo \"User-agent: *\nDisallow: /\" > ./dist/robots.txt"
+      - run: "echo \"User-agent: *\nDisallow: /\" > ${{ github.workspace }}/dist/robots.txt"
 
       - name: deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ${{ github.workspace }}/dist


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6921 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- GitHub `Actionsにてパスを入力している部分に${{ github.workspace }}`を書きました。
- シェルスクリプトやpythonを実行する際には、パスを環境変数で指定せずにそのまま`./~~`の形にしてあります。
  - https://github.com/Murayu0225/covid19-1/blob/897d0233c25da0ef19914bc66053ffe23cd89588/.github/workflows/deploy.yml#L63
  - https://github.com/Murayu0225/covid19-1/blob/897d0233c25da0ef19914bc66053ffe23cd89588/.github/workflows/ogp_builder.yml#L38
  - https://github.com/Murayu0225/covid19-1/blob/897d0233c25da0ef19914bc66053ffe23cd89588/.github/workflows/screenshot.yml#L36
- `i18n_generator.yml`では、`i18n_generator.py`にて`os.pardir`を[利用している](https://github.com/Murayu0225/covid19-1/blob/897d0233c25da0ef19914bc66053ffe23cd89588/auto-i18n/i18n_generator.py#L74) ためパス移動をしないといけないので、cdコマンドを利用して移動しています。
  - https://github.com/Murayu0225/covid19-1/blob/897d0233c25da0ef19914bc66053ffe23cd89588/.github/workflows/i18n_generator.yml#L28

### 動作チェック

- [ ] audit-staging.yml
- [ ] check-statuses-of-forked-sites.yml
- [ ] deploy.yml
- [ ] i18n_generator.yml
- [ ] ogp_builder.yml
- [ ] screenshot.yml
- [ ] staging.yml

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
CI関連なので表面的な変更はありません。