### PR TITLE
「L452R変異株スクリーニングの実施状況」カードを「更新を終了したグラフ」ブロック内へ移動

### DIFF
--- a/components/index/CardsReference.vue
+++ b/components/index/CardsReference.vue
@@ -59,9 +59,8 @@ export default Vue.extend({
     return {
       rows: [
         [ConfirmedCasesAttributesCard, ConfirmedCasesByMunicipalitiesCard],
-        [PositiveNumberOver65Card],
         [PositiveNumberByDevelopedDateCard, PositiveNumberByDiagnosedDateCard],
-        [DeathsByDeathDateCard],
+        [PositiveNumberOver65Card, DeathsByDeathDateCard],
         [MetroCard, AgencyCard],
       ],
       hideRows: [[VariantCard, MonitoringConsultationDeskReportsNumberCard]],

--- a/components/index/CardsReference.vue
+++ b/components/index/CardsReference.vue
@@ -61,10 +61,10 @@ export default Vue.extend({
         [ConfirmedCasesAttributesCard, ConfirmedCasesByMunicipalitiesCard],
         [PositiveNumberOver65Card],
         [PositiveNumberByDevelopedDateCard, PositiveNumberByDiagnosedDateCard],
-        [DeathsByDeathDateCard, VariantCard],
+        [DeathsByDeathDateCard],
         [MetroCard, AgencyCard],
       ],
-      hideRows: [[MonitoringConsultationDeskReportsNumberCard]],
+      hideRows: [[VariantCard, MonitoringConsultationDeskReportsNumberCard]],
     }
   },
 })


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #6978 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「L452R変異株スクリーニングの実施状況」を、その他参考指標タブの下のほう「更新を終了したグラフ」ブロック内の先頭へ移動しました。
- 移動することで元々グラフがあった位置が空いてしまうのですが、詰めるべきなのか空けたままにするべきなのかわからなかったのでとりあえず空けたままにしてます。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
<img width="1113" alt="スクリーンショット 2021-12-04 23 36 51" src="https://user-images.githubusercontent.com/65712721/144713403-41bb0290-560c-437e-8deb-ae598e59b480.png">

