### PR TITLE
このサイトから派生したサイト - 長崎県のサイトを stopcovid19.jp ドメインに変更

### DIFF
--- a/FORKED_SITES.md
+++ b/FORKED_SITES.md
@@ -64,7 +64,7 @@
 |[](40)福岡市|https://stopcovid19.codeforfukuoka.org/|Code for Fukuoka|[Code-for-Fukuoka/covid19](https://github.com/Code-for-Fukuoka/covid19)||
 |[](40)北九州市|https://stopcovid19-kitakyushu.jp/|Code for Kitakyushu|[covid19-kitakyushu/covid19](https://github.com/covid19-kitakyushu/covid19)||
 |[](41)佐賀県|https://stopcovid19.code4saga.org/|Code for Saga|[codeforsaga/covid19](https://github.com/codeforsaga/covid19)||
-|[](42)長崎県|https://stopcovid19-nagasaki.netlify.app/|Code for Nagasaki|[CodeForNagasaki/covid19](https://github.com/CodeForNagasaki/covid19)||
+|[](42)長崎県|https://nagasaki.stopcovid19.jp/|Code for Nagasaki|[CodeForNagasaki/covid19](https://github.com/CodeForNagasaki/covid19)||
 |[](43)熊本県|https://kumamoto.stopcovid19.jp/|Code for Kumamoto|[codeforkumamoto/covid19](https://github.com/codeforkumamoto/covid19)||
 |[](44)大分県|https://oita.stopcovid19.jp/|有志|[covid19-oita/covid19](https://github.com/covid19-oita/covid19)||
 |[](45)宮崎県|https://covid19-miyazaki.netlify.app/|有志|[covid19-miyazaki/covid19](https://github.com/covid19-miyazaki/covid19)||


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7030


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- このサイトから派生したサイト - 長崎県のサイトURLを`https://nagasaki.stopcovid19.jp/`へ変更


## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

### before
![スクリーンショット 2022-01-04 23 07 05](https://user-images.githubusercontent.com/1316886/148071091-5b299cef-be79-44ed-a7cd-93e0ffb5ac92.png)

### after
![スクリーンショット 2022-01-04 23 13 29](https://user-images.githubusercontent.com/1316886/148071930-040b5ea6-a256-46b9-be2e-e554fd6ee190.png)

