### PR TITLE
Fix 2964:英語のメニューリンクをホバーまたは押したときに文字幅が変わってしまう問題を修正

### DIFF
--- a/components/_shared/SideNavigation/MenuListContents.vue
+++ b/components/_shared/SideNavigation/MenuListContents.vue
@@ -89,15 +89,15 @@ export default Vue.extend({
   }
 
   &:hover {
-    font-weight: 600;
+    text-shadow: 0 0 1px $gray-1;
   }
 
   &:focus {
-    font-weight: 600;
+    text-shadow: 0 0 1px $gray-1;
   }
 
   &.nuxt-link-exact-active {
-    font-weight: 600;
+    text-shadow: 0 0 1px $gray-1;
 
     &:link,
     &:hover,

--- a/components/_shared/SideNavigation/MenuListContents.vue
+++ b/components/_shared/SideNavigation/MenuListContents.vue
@@ -97,7 +97,7 @@ export default Vue.extend({
   }
 
   &.nuxt-link-exact-active {
-    text-shadow: 0 0 1px $gray-1;
+    text-shadow: 0 0 1px $green-1;
 
     &:link,
     &:hover,


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #2964

## 📝 関連する issue / Related Issues


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- メニューリンクに以下のスタイルがあたっているときに、文字をtext-shadowで擬似的に太くする
  - `:hover`
  - `:active`
  - `.nuxt-link-exact-active`

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
### before
![covid19-menulink-hover-before](https://user-images.githubusercontent.com/30966790/148190569-c4ad42e8-963d-488a-ab47-3eb41aca241b.gif)

### after
![covid19-menulink-hover-after](https://user-images.githubusercontent.com/30966790/148190596-52211b14-f82b-4425-a2c4-3b4cab7afa4c.gif)

動作確認環境
- macOS BigSur
  - Safari バージョン15.2
  - Chrome 96.0.4664.110（Official Build）
