### PR TITLE
[hotfix]vaccinationのtableにフィルターがかかってしまう不具合を修正

### DIFF
--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -278,7 +278,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       ]
     },
     tableDataItems() {
-      return this.displayData.datasets[0].data
+      const datasets = this.dataLabels.map((_, i) => {
+        return this.chartData[i]
+      })
+      return datasets[0]
         .map((_, i) => {
           return Object.assign(
             { text: this.labels[i] },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #0
- close #0

## 📝 関連する issue / Related Issues
- #0
- #0

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- hotfixです。「ワクチン接種数（累計）」カードのテーブルの内容が日付フィルターと連動してしまっている不具合を修正しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
|before|after|
|---|---|
|![スクリーンショット 2022-02-14 13 01 19](https://user-images.githubusercontent.com/14883063/153798817-88c62cda-de5f-41c0-b984-c40f3528ae36.png)|![スクリーンショット 2022-02-14 13 00 45](https://user-images.githubusercontent.com/14883063/153798830-d75def8b-91de-4851-9a28-1757f7ef9b34.png)|
