### PR TITLE
[bugfix]isBetweenの第３引数を'day'にする

### DIFF
--- a/components/index/CardsFeatured/TestedNumber/Chart.vue
+++ b/components/index/CardsFeatured/TestedNumber/Chart.vue
@@ -273,7 +273,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const graphSeries = getGraphSeriesStyle(this.chartData.length)
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
       if (this.dataKind === 'transition') {
         return {

--- a/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
+++ b/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
@@ -275,7 +275,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -258,7 +258,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
+++ b/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
@@ -362,7 +362,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const values = this.chartData
         .filter((item) => {
           const date = dayjs(item.label)
-          return date.isBetween(this.startDate, this.endDate, null, '[]')
+          return date.isBetween(this.startDate, this.endDate, 'day', '[]')
         })
         .map((d) => d.transition)
       const max = Math.max(...values) + this.addedValue

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -246,7 +246,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       displayLegends: [true, true],
       colors,
       startDate: '2020-01-01',
-      endDate: dayjs().format('YYYY-MM-DD'),
+      endDate: dayjs().format('YYYY-MM-DDT00:00:00+09:00'),
     }
   },
   computed: {
@@ -314,7 +314,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
 
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -335,7 +335,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayData() {
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/CardsMonitoring/SevereCase/Chart.vue
+++ b/components/index/CardsMonitoring/SevereCase/Chart.vue
@@ -304,7 +304,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const values = this.chartData
         .filter((item) => {
           const date = dayjs(item.label)
-          return date.isBetween(this.startDate, this.endDate, null, '[]')
+          return date.isBetween(this.startDate, this.endDate, 'day', '[]')
         })
         .map((d) => d.transition)
       const max = Math.max(...values)

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -308,7 +308,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     displayData() {
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/_shared/MixedBarAndLineChart.vue
+++ b/components/index/_shared/MixedBarAndLineChart.vue
@@ -279,7 +279,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayData() {
       const rangeDate = this.labels.filter((item) => {
         const date = dayjs(item)
-        return date.isBetween(this.startDate, this.endDate, null, '[]')
+        return date.isBetween(this.startDate, this.endDate, 'day', '[]')
       })
 
       return {

--- a/components/index/_shared/TimeBarChart.vue
+++ b/components/index/_shared/TimeBarChart.vue
@@ -393,7 +393,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const values = this.chartData
         .filter((item) => {
           const date = dayjs(item.label)
-          return date.isBetween(this.startDate, this.endDate, null, '[]')
+          return date.isBetween(this.startDate, this.endDate, 'day', '[]')
         })
         .map((d) => d[dataKind])
       const max = Math.max(...values)


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7110 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- isBetweenのoption不備で `Uncaught RangeError: Invalid time value` になっていました。
- isBetweenの第３引数を `null` から `'day'` に修正しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
**Before**
![スクリーンショット 2022-02-18 23 15 56](https://user-images.githubusercontent.com/14883063/154699392-e302ce31-9e72-4432-9bfa-6b04ef54cbe1.png)

**After**
![スクリーンショット 2022-02-18 23 13 38](https://user-images.githubusercontent.com/14883063/154699468-5f7cd142-9569-4084-9db3-e36dbea7b7cf.png)
