### PR TITLE
ワクチンカードのタイトル部分を３回目接種のみにする（１回目・２回目は注釈扱い）

### DIFF
--- a/assets/json/cardRoutesSettings.json
+++ b/assets/json/cardRoutesSettings.json
@@ -29,7 +29,7 @@
   },
   {
     "path": "/cards/vaccination",
-    "title": "ワクチン接種数（累計）",
+    "title": "ワクチン接種数及び接種率（都内全人口・累計）",
     "category": "注目の指標",
     "ogpWidth": 959,
     "ogpHeight": 730

--- a/components/index/CardsFeatured/Vaccination/Card.vue
+++ b/components/index/CardsFeatured/Vaccination/Card.vue
@@ -5,9 +5,9 @@
         :title="$t('ワクチン接種数及び接種率（都内全人口・累計）')"
         title-id="vaccination"
         :info-titles="[
-          $t('１回目接種数（接種率）'),
-          $t('２回目接種数（接種率）'),
           $t('３回目接種数（接種率）'),
+          $t('２回目接種数（接種率）'),
+          $t('１回目接種数（接種率）'),
         ]"
         chart-id="vaccination-chart"
         :chart-data="vaccinationData.chartData"

--- a/components/index/CardsFeatured/Vaccination/Card.vue
+++ b/components/index/CardsFeatured/Vaccination/Card.vue
@@ -5,9 +5,9 @@
         :title="$t('ワクチン接種数及び接種率（都内全人口・累計）')"
         title-id="vaccination"
         :info-titles="[
-          $t('３回目接種数（接種率）'),
-          $t('２回目接種数（接種率）'),
           $t('１回目接種数（接種率）'),
+          $t('２回目接種数（接種率）'),
+          $t('３回目接種数（接種率）'),
         ]"
         chart-id="vaccination-chart"
         :chart-data="vaccinationData.chartData"

--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -77,13 +77,23 @@
     </template>
     <template #dataSetPanel>
       <data-view-data-set-panel
-        v-for="(di, i) in displayInfo"
-        :key="i"
-        :title="infoTitles[i]"
+        v-for="(di, i) in displayInfoForTitle"
+        :key="`title-${i}`"
+        :title="infoTitles[di.index]"
         :l-text="di.lText"
         :s-text="di.sText"
         :is-single-card="isSingleCard"
       />
+    </template>
+    <template #description>
+      <ul>
+        <li
+          v-for="(di, i) in displayInfoForDescription"
+          :key="`description-${i}`"
+        >
+          {{ `${infoTitles[di.index]} ${di.lText}（${di.sText}）` }}
+        </li>
+      </ul>
     </template>
   </data-view>
 </template>
@@ -129,6 +139,8 @@ type Computed = {
   minDate: string
   maxDate: string
   displayInfo: DisplayInfo[]
+  displayInfoForTitle: DisplayInfo[]
+  displayInfoForDescription: DisplayInfo[]
   displayData: DisplayData
   displayOption: ChartOptions
   headTitle: string
@@ -260,17 +272,25 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         return dataset.slice(-1)[0]
       }
       const lastDay = this.labels.slice(-1)[0]
-      return this.chartData
-        .map((data, i) => {
-          return {
-            index: i,
-            lText: `${this.getFormatter(i * 2)(
-              lastData(this.tableData[i * 2])
-            )} (${this.getFormatter(i * 2 + 1)(lastData(data))}%)`,
-            sText: `${this.$d(new Date(lastDay), 'date')} ${this.$t('累計値')}`,
-          }
-        })
-        .sort((a, b) => (a.index > b.index ? -1 : 1))
+      return this.chartData.map((data, i) => {
+        return {
+          index: i,
+          lText: `${this.getFormatter(i * 2)(
+            lastData(this.tableData[i * 2])
+          )} (${this.getFormatter(i * 2 + 1)(lastData(data))}%)`,
+          sText: `${this.$d(new Date(lastDay), 'date')} ${this.$t('累計値')}`,
+        }
+      })
+    },
+    displayInfoForTitle() {
+      return this.displayInfo.filter((_, i) => {
+        return i === 2
+      })
+    },
+    displayInfoForDescription() {
+      return this.displayInfo.filter((_, i) => {
+        return i !== 2
+      })
     },
     displayData() {
       const datasets = this.dataLabels.map((_, i) => {
@@ -405,7 +425,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 suggestedMin: 0,
                 suggestedMax: 100,
                 fontColor: '#707070',
-                callback: (value) => {
+                callback: (value: number) => {
                   return `${value.toFixed(1)}%`
                 },
               },

--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -121,6 +121,7 @@ type Methods = {
   onClickLegend: (i: number) => void
 }
 type DisplayInfo = {
+  index: number
   lText: string
   sText: string
 }
@@ -259,14 +260,17 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         return dataset.slice(-1)[0]
       }
       const lastDay = this.labels.slice(-1)[0]
-      return this.chartData.map((data, i) => {
-        return {
-          lText: `${this.getFormatter(i * 2)(
-            lastData(this.tableData[i * 2])
-          )} (${this.getFormatter(i * 2 + 1)(lastData(data))}%)`,
-          sText: `${this.$d(new Date(lastDay), 'date')} ${this.$t('累計値')}`,
-        }
-      })
+      return this.chartData
+        .map((data, i) => {
+          return {
+            index: i,
+            lText: `${this.getFormatter(i * 2)(
+              lastData(this.tableData[i * 2])
+            )} (${this.getFormatter(i * 2 + 1)(lastData(data))}%)`,
+            sText: `${this.$d(new Date(lastDay), 'date')} ${this.$t('累計値')}`,
+          }
+        })
+        .sort((a, b) => (a.index > b.index ? -1 : 1))
     },
     displayData() {
       const datasets = this.dataLabels.map((_, i) => {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7143 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ~~ワクチンカードのタイトル部分の並び順を変更しました。~~ タイトル部は３回目接種のみ、１回目・２回目については注釈の位置に移動しました。
- ~~Chart.vue側でdisplayInfoを作っているところで降順にソートしました。~~
- ~~タイトルのテキストはわかりやすくするためCard.vue側で並び順を変えました。~~

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2022-03-08 11 24 29](https://user-images.githubusercontent.com/14883063/157153976-7c81698c-5dde-4469-a126-5dd12714a377.png)
