### PR TITLE
マウスのx座標に応じてグラフのツールチップを表示する

### DIFF
--- a/components/index/CardsFeatured/TestedNumber/Chart.vue
+++ b/components/index/CardsFeatured/TestedNumber/Chart.vue
@@ -364,6 +364,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
+++ b/components/index/CardsFeatured/TokyoFeverConsultationCenterReportsNumber/Chart.vue
@@ -355,6 +355,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayOption() {
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsFeatured/Vaccination/Chart.vue
+++ b/components/index/CardsFeatured/Vaccination/Chart.vue
@@ -353,6 +353,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayOption() {
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             title: (tooltipItem, data) => {

--- a/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
+++ b/components/index/CardsMonitoring/HospitalizedNumber/Chart.vue
@@ -272,6 +272,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           filter(tooltipItem) {
             return tooltipItem.datasetIndex !== 1

--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -327,6 +327,8 @@ export default Vue.extend<Data, Methods, Computed, Props>({
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -462,6 +462,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsMonitoring/SevereCase/Chart.vue
+++ b/components/index/CardsMonitoring/SevereCase/Chart.vue
@@ -214,6 +214,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -411,6 +411,8 @@ export default Vue.extend<Data, Methods, Computed, Props>({
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/CardsReference/Agency/Chart.vue
+++ b/components/index/CardsReference/Agency/Chart.vue
@@ -195,6 +195,8 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       const options: ChartOptions = {
         maintainAspectRatio: false,
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             title: (tooltipItems: ChartTooltipItem[]) => {

--- a/components/index/CardsReference/DeathsByDeathDate/Card.vue
+++ b/components/index/CardsReference/DeathsByDeathDate/Card.vue
@@ -60,7 +60,6 @@ export default {
         displayInfo() {
           const { lastDay, lastDayData } = calcDayBeforeRatio({
             displayData: this.displayData,
-            dataIndex: 1,
           })
           const formattedLastDay = this.$d(lastDay, 'date')
           if (this.dataKind === 'transition') {

--- a/components/index/CardsReference/Metro/Chart.vue
+++ b/components/index/CardsReference/Metro/Chart.vue
@@ -350,6 +350,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
           ],
         },
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             title: this.tooltipsTitle,

--- a/components/index/CardsReference/PositiveNumberByDevelopedDate/Card.vue
+++ b/components/index/CardsReference/PositiveNumberByDevelopedDate/Card.vue
@@ -71,7 +71,6 @@ export default {
         displayInfo() {
           const { lastDay, lastDayData } = calcDayBeforeRatio({
             displayData: this.displayData,
-            dataIndex: 1,
           })
           const formattedLastDay = this.$d(lastDay, 'date')
           if (this.dataKind === 'transition') {

--- a/components/index/CardsReference/PositiveNumberByDiagnosedDate/Card.vue
+++ b/components/index/CardsReference/PositiveNumberByDiagnosedDate/Card.vue
@@ -55,7 +55,6 @@ export default {
         displayInfo() {
           const { lastDay, lastDayData } = calcDayBeforeRatio({
             displayData: this.displayData,
-            dataIndex: 1,
           })
           const formattedLastDay = this.$d(lastDay, 'date')
           if (this.dataKind === 'transition') {

--- a/components/index/_shared/MixedBarAndLineChart.vue
+++ b/components/index/_shared/MixedBarAndLineChart.vue
@@ -350,6 +350,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {

--- a/components/index/_shared/TimeBarChart.vue
+++ b/components/index/_shared/TimeBarChart.vue
@@ -199,7 +199,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     displayInfo() {
       const { lastDay, lastDayData, dayBeforeRatio } = calcDayBeforeRatio({
         displayData: this.displayData,
-        dataIndex: 1,
+        dataIndex: 0,
       })
       const formattedLastDay = this.$d(lastDay, 'date')
       if (this.dataKind === 'transition' && this.byDate) {
@@ -229,8 +229,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
     displayData() {
       const style = getGraphSeriesStyle(1)[0]
-      const zeroMouseOverHeight = 5
-      const transparentWhite = 'rgba(255,255,255,0)'
 
       if (this.dataKind === 'transition') {
         return {
@@ -238,21 +236,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
             return d.label
           }),
           datasets: [
-            {
-              label: this.dataKind,
-              data: this.chartData.map((_d) => {
-                return 0
-              }),
-              backgroundColor: transparentWhite,
-              borderColor: transparentWhite,
-              borderWidth: 0,
-              minBarLength: this.chartData.map((d) => {
-                if (d.transition <= 0) {
-                  return zeroMouseOverHeight
-                }
-                return 0
-              }),
-            },
             {
               label: this.dataKind,
               data: this.chartData.map((d) => {
@@ -268,21 +251,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return {
         labels: this.chartData.map((d) => d.label),
         datasets: [
-          {
-            label: this.dataKind,
-            data: this.chartData.map((_d) => {
-              return 0
-            }),
-            backgroundColor: transparentWhite,
-            borderColor: transparentWhite,
-            borderWidth: 0,
-            minBarLength: this.chartData.map((d) => {
-              if (d.cumulative <= 0) {
-                return zeroMouseOverHeight
-              }
-              return 0
-            }),
-          },
           {
             label: this.dataKind,
             data: this.chartData.map((d) => {

--- a/components/index/_shared/TimeBarChart.vue
+++ b/components/index/_shared/TimeBarChart.vue
@@ -300,6 +300,8 @@ const options: ThisTypedComponentOptionsWithRecordProps<
 
       const options: ChartOptions = {
         tooltips: {
+          intersect: false,
+          mode: 'index',
           displayColors: false,
           callbacks: {
             label: (tooltipItem) => {


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #5062

## 📝 関連する issue / Related Issues
- #4512

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
1. マウスのx座標に応じてツールチップを表示する設定追加 cd77258802b0b7ef82aac70034c023c931bab66f
2. #4512 のPRで追加されたツールチップ用のダミーデータ削除 54be893726e397467255061dd007195721a41557

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

`変更内容`の1のみだと以下のようにダミーデータも表示されてしまいます。\
これは#4512　で追加されたツールチップ用のダミーデータによるものです。2の変更をすることで防ぐことができます。
<img width="650" alt="dummies_on_tooltip" src="https://user-images.githubusercontent.com/44665462/160272840-f19ba978-9176-4936-af17-9e9ba4fe09f2.png">



### 変更前:
https://user-images.githubusercontent.com/44665462/160273416-328699cc-bfa1-4864-bc58-af247bfedaef.mp4

### 変更後:
https://user-images.githubusercontent.com/44665462/160273441-af6cef41-f00e-41e5-aa6d-807eeb3eb601.mp4
