### PR TITLE
モニタリング項目(1)新規陽性者数のscaledTicksYAxisMaxを修正

### DIFF
--- a/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
+++ b/components/index/CardsMonitoring/MonitoringConfirmedCasesNumber/Chart.vue
@@ -455,7 +455,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
           ),
         0
       )
-      const digits = String(max).length
+      const digits = String(Math.ceil(max)).length
       const base = 10 ** (digits - 1)
       return Math.ceil(max / base) * base
     },


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7217 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- `scaledTicksYAxisMax()` で、digitsを算出するのに使用している値が小数点以下第１位になっているのが原因でした。
- maxの値を整数に切り上げました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2022-04-21 10 58 26](https://user-images.githubusercontent.com/14883063/164356415-3500ac27-1779-4f7f-9219-6e086aa836a4.png)
