### PR TITLE
2軸グラフにて右軸メモリを表示期間に応じてオートスケール化

### DIFF
--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -559,6 +559,9 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 8,
                 fontColor: '#707070',
                 suggestedMin: 0,
+                callback: (value) => {
+                  return `${value}%`
+                },
               },
             },
           ],

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -152,7 +152,6 @@ type Computed = {
   displayData: DisplayData
   displayOption: ChartOptions
   scaledTicksYAxisMax: number
-  scaledTicksYAxisMaxRight: number
   tableHeaders: TableHeader[]
   tableData: TableItem[]
   startDateIndex: number
@@ -458,8 +457,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
         .reverse()
     },
     displayOption() {
-      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
-
       const options: ChartOptions = {
         tooltips: {
           intersect: false,
@@ -562,10 +559,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
                 maxTicksLimit: 8,
                 fontColor: '#707070',
                 suggestedMin: 0,
-                suggestedMax: scaledTicksYAxisMaxRight,
-                callback: (value) => {
-                  return `${value}%`
-                },
               },
             },
           ],
@@ -591,9 +584,6 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       const digits = String(max).length
       const base = 10 ** (digits - 1)
       return Math.ceil(max / base) * base
-    },
-    scaledTicksYAxisMaxRight() {
-      return this.chartData[5].reduce((a, b) => Math.max(a, b), 0)
     },
     startDateIndex() {
       const searchIndex = this.labels?.findIndex((item) => {

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -148,7 +148,6 @@ type Computed = {
   displayData: DisplayData
   displayOption: ChartOptions
   scaledTicksYAxisMax: number
-  scaledTicksYAxisMaxRight: number
   tableHeaders: TableHeader[]
   tableData: TableItem[]
   startDateIndex: number
@@ -407,7 +406,6 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     displayOption() {
       const unit = this.units[1]
-      const scaledTicksYAxisMaxRight = this.scaledTicksYAxisMaxRight
 
       const options: ChartOptions = {
         tooltips: {
@@ -514,10 +512,6 @@ export default Vue.extend<Data, Methods, Computed, Props>({
                 maxTicksLimit: 8,
                 fontColor: '#707070',
                 suggestedMin: 0,
-                suggestedMax: scaledTicksYAxisMaxRight,
-                callback: (value) => {
-                  return `${value}%`
-                },
               },
             },
           ],
@@ -538,9 +532,6 @@ export default Vue.extend<Data, Methods, Computed, Props>({
       const digits = String(maxTotal).length
       const base = 10 ** (digits - 1)
       return Math.ceil(max / base) * base
-    },
-    scaledTicksYAxisMaxRight() {
-      return this.chartData[3].reduce((a, b) => Math.max(a, b), 0)
     },
     startDateIndex() {
       const searchIndex = this.labels?.findIndex((item) => {

--- a/components/index/CardsMonitoring/UntrackedRate/Chart.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Chart.vue
@@ -512,6 +512,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
                 maxTicksLimit: 8,
                 fontColor: '#707070',
                 suggestedMin: 0,
+                callback: (value) => {
+                  return `${value}%`
+                },
               },
             },
           ],


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #7234 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 2軸グラフにて右軸メモリをオートスケール化させました．

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
| 変更前 | 変更後 |
| ---- | ---- |
| <img width="534" alt="スクリーンショット 2022-04-26 10 01 25" src="https://user-images.githubusercontent.com/37988559/165198290-b53f1313-5e58-4909-825c-95a4345d4573.png"> | <img width="535" alt="スクリーンショット 2022-04-26 10 14 04" src="https://user-images.githubusercontent.com/37988559/165199430-ccd4bf52-ffc0-4785-83ea-f11f3d533132.png"> |

| 変更前 | 変更後 |
| ---- | ---- |
| <img width="536" alt="スクリーンショット 2022-04-26 10 01 59" src="https://user-images.githubusercontent.com/37988559/165198343-fe4f3a60-613b-42e9-85da-b878da0a523f.png"> | <img width="531" alt="スクリーンショット 2022-04-26 10 15 02" src="https://user-images.githubusercontent.com/37988559/165199511-fdc697ba-cac5-4fda-bbf3-3026fd95d998.png"> |