### PR TITLE
【管理】本番環境をFirebase Hostingにデプロイする

### DIFF
--- a/static/.github/workflows/firebase-hosting-merge.yml
+++ b/static/.github/workflows/firebase-hosting-merge.yml
@@ -1,0 +1,19 @@
+name: Deploy to Firebase Hosting on merge
+'on':
+  push:
+    branches:
+      - production
+    workflow_dispatch:
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STOPCOVID19_TOKYO }}'
+          channelId: live
+          projectId: stopcovid19-tokyo

--- a/static/firebase.json
+++ b/static/firebase.json
@@ -1,0 +1,25 @@
+{
+  "functions": {
+    "source": "functions",
+    "predeploy": "npm --prefix \"$RESOURCE_DIR\" run build"
+  },
+  "hosting": {
+    "public": "/",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "**/.git/**"
+    ],
+    "rewrites": [
+      {
+        "source": "/g-mark",
+        "function": "gMark"
+      },
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
productionブランチにコミットする下記のやり方がうまくいかなかったので、development経由で適用する方法を再トライします。
https://github.com/tokyo-metropolitan-gov/covid19/pull/7267

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 下記の問題を解決するために本番環境をNetlifyからFirebase Hostingに変更する準備のコミット
  - レポジトリのサイズが巨大化したため、Netlifyの標準のデプロイフローで時間がかかるようになった
  - オープンデータに100MBを超えるファイルが出来、Netlifyデプロイ時のLFSとの相性問題が発生してデプロイがうまくいかない
  - Netlifyの本番環境のデプロイが発火しない状況が頻発するようになった

