### PR TITLE
【管理】本番環境をFirebase Hostingにデプロイする (再調整)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: production
+          exclude_assets: ''
 
       - name: Create GitHub release
         uses: rymndhng/release-on-push-action@master


### PR DESCRIPTION
下記の再調整です。
https://github.com/tokyo-metropolitan-gov/covid19/pull/7269

actions-gh-pages アクションがデフォルトで .github が適用除外になっていったため、除外の解除を行いました。
https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-filter-publishing-assets-exclude_assets


## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 下記の問題を解決するために本番環境をNetlifyからFirebase Hostingに変更する準備のコミット
  - レポジトリのサイズが巨大化したため、Netlifyの標準のデプロイフローで時間がかかるようになった
  - オープンデータに100MBを超えるファイルが出来、Netlifyデプロイ時のLFSとの相性問題が発生してデプロイがうまくいかない
  - Netlifyの本番環境のデプロイが発火しない状況が頻発するようになった
