### PR TITLE
【管理】本番環境をFirebase Hostingにデプロイする (再調整2)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.WORKFLOW_TOKEN }}
           publish_dir: ./dist
           publish_branch: production
           exclude_assets: ''


### PR DESCRIPTION
下記の再調整です。
https://github.com/tokyo-metropolitan-gov/covid19/pull/7274

GITHUB_TOKENのアカウントでは workflow 更新の権限がないため、新規のPATを作成して割り当てた。

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 下記の問題を解決するために本番環境をNetlifyからFirebase Hostingに変更する準備のコミット
  - レポジトリのサイズが巨大化したため、Netlifyの標準のデプロイフローで時間がかかるようになった
  - オープンデータに100MBを超えるファイルが出来、Netlifyデプロイ時のLFSとの相性問題が発生してデプロイがうまくいかない
  - Netlifyの本番環境のデプロイが発火しない状況が頻発するようになった
## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
