### PR TITLE
【管理】開発・ステージング環境をFirebase Hostingにデプロイする

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,20 @@
+{
+  "projects": {
+    "default": "stopcovid19-tokyo"
+  },
+  "targets": {
+    "stopcovid19-tokyo": {
+      "hosting": {
+        "production": [
+          "stopcovid19-tokyo"
+        ],
+        "staging": [
+          "stopcovid19-tokyo-staging"
+        ],
+        "development": [
+          "stopcovid19-tokyo-development"
+        ]
+      }
+    }
+  }
+}

--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -1,0 +1,46 @@
+name: Deploy (development)
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: development
+          lfs: true
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.13.0'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn run test
+      - run: yarn run generate:dev
+      - run: "echo \"User-agent: *\nDisallow: /\" > ./dist/robots.txt"
+
+      - name: Deploy to Firebase
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STOPCOVID19_TOKYO }}'
+          channelId: live
+          projectId: stopcovid19-tokyo
+          target: development

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,4 +1,4 @@
-name: production deploy
+name: Deploy (production)
 
 on:
   push:
@@ -8,8 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-18.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -48,7 +46,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.WORKFLOW_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           publish_branch: production
 
@@ -59,6 +57,7 @@ jobs:
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STOPCOVID19_TOKYO }}'
           channelId: live
           projectId: stopcovid19-tokyo
+          target: production
 
       - name: Create GitHub release
         uses: rymndhng/release-on-push-action@master

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,4 +1,4 @@
-name: staging deploy
+name: Deploy (staging)
 
 on:
   push:
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: staging
+          lfs: true
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -33,8 +36,18 @@ jobs:
       - run: yarn run generate:dev
       - run: "echo \"User-agent: *\nDisallow: /\" > ./dist/robots.txt"
 
-      - name: deploy
+      - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          publish_branch: gh-pages
+
+      - name: Deploy to Firebase
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STOPCOVID19_TOKYO }}'
+          channelId: live
+          projectId: stopcovid19-tokyo
+          target: staging


### PR DESCRIPTION
下記のPRでFirebase Hostingの本番デプロイがうまくいったので、開発・ステージングもFirebase Hostingにデプロイする。
https://github.com/tokyo-metropolitan-gov/covid19/pull/7281
