### PR TITLE
(再再)【管理】外部レポジトリからのPRに対するプレビューデプロイが失敗する問題に対応

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          repository: '${{ github.event.pull_request.head.repo.full_name }}'
+          ref: '${{ github.event.pull_request.head.sha }}'
           lfs: true
 
       - name: Setup Node


### PR DESCRIPTION
プレビューデプロイなのにマージ先側のブランチがデプロイされてしまう問題の解消。

https://github.com/tokyo-metropolitan-gov/covid19/pull/7321