### PR TITLE
陽性率グラフ表示の高速化

### DIFF
--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -437,18 +437,19 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       ]
     },
     tableData() {
+      const chartData = this.chartData;
       return this.labels
         .map((label, i) => {
           return Object.assign(
             { text: label },
             ...(this.dataLabels as string[]).map((_, j) => {
-              if (this.chartData[j][i] === null) {
+              if (chartData[j][i] === null) {
                 return {
                   [j]: '',
                 }
               }
               return {
-                [j]: this.getFormatter(j)(this.chartData[j][i]),
+                [j]: this.getFormatter(j)(chartData[j][i]),
               }
             })
           )
@@ -575,13 +576,14 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     scaledTicksYAxisMax() {
-      const max = Array.from(this.chartData[0].keys())
+      const chartData = this.chartData;
+      const max = Array.from(chartData[0].keys())
         .map(
           (i) =>
-            this.chartData[0][i] +
-            this.chartData[1][i] +
-            this.chartData[2][i] +
-            this.chartData[3][i]
+            chartData[0][i] +
+            chartData[1][i] +
+            chartData[2][i] +
+            chartData[3][i]
         )
         .reduce((a, b) => Math.max(a, b), 0)
       const digits = String(max).length

--- a/components/index/CardsMonitoring/PositiveRate/Chart.vue
+++ b/components/index/CardsMonitoring/PositiveRate/Chart.vue
@@ -437,7 +437,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       ]
     },
     tableData() {
-      const chartData = this.chartData;
+      const chartData = this.chartData
       return this.labels
         .map((label, i) => {
           return Object.assign(
@@ -576,7 +576,7 @@ const options: ThisTypedComponentOptionsWithRecordProps<
       return options
     },
     scaledTicksYAxisMax() {
-      const chartData = this.chartData;
+      const chartData = this.chartData
       const max = Array.from(chartData[0].keys())
         .map(
           (i) =>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues

- close #7411

## ⛏ 変更内容 / Details of Changes

`this.chartData` アクセスをループの手前に移動する。

## 📸 スクリーンショット / Screenshots

before:

![スクリーンショット 2022-08-08 20 46 55](https://user-images.githubusercontent.com/199592/183416073-b086d42d-b0a1-4be8-affa-c1a51cb0c67e.png)

tableData() に 1.9s かかってます

after:

![スクリーンショット 2022-08-08 20 47 50](https://user-images.githubusercontent.com/199592/183416154-cea68cc5-047d-47c0-8389-f2ecc9991776.png)

tableData() が 64ms になりました。