### PR TITLE
都外からの持込検体の文言修正

### DIFF
--- a/components/index/CardsFeatured/InfectionSummary/Table/InfectionStatus.vue
+++ b/components/index/CardsFeatured/InfectionSummary/Table/InfectionStatus.vue
@@ -34,7 +34,9 @@
     </li>
     <li :class="[$style.box]">
       <div :class="$style.content">
-        <span>{{ $t('都外からの持込検体による陽性数') }}</span>
+        <span>{{
+          $t('都外からの持込検体・他県陽性者登録センターによる陽性数')
+        }}</span>
         <value-with-translatable-unit
           :value="items['都外からの持込検体による陽性数'].toLocaleString()"
           :unit="{


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #7433 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 【都外からの持込検体による陽性数】の項目名を【都外からの持込検体・他県陽性者登録センターによる陽性数】に変更しました。

## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2022-08-17 14 46 40](https://user-images.githubusercontent.com/14883063/185043837-647c6399-819e-4c59-890d-07c232fb0ba2.png)
