### PR TITLE
[hotfix]remove opendata 130001_tokyo_covid19_patients.csv

### DIFF
--- a/static/data/130001_tokyo_covid19_patients.csv
+++ b/static/data/130001_tokyo_covid19_patients.csv
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d729737675837d4d12a775b115efc66ee066b301aa535141aa1f4e37acc2ba17
-size 266797099


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

オープンデータの患者情報全期間分のファイル名変更に伴い、従来のファイルを削除します。
- 旧URL
    - https://github.com/tokyo-metropolitan-gov/covid19/blob/development/static/data/130001_tokyo_covid19_patients.csv

- 新URL 
    - https://stopcovid19.metro.tokyo.lg.jp/data/130001_tokyo_covid19_patients_9e4b6290e76826a41c5e34ac575ec04f.csv


新ファイルは既に用意されているため、旧ファイルを削除するだけの対応になります。
