### PR TITLE
不要な `aria-label` を削除

### DIFF
--- a/components/index/CardsFeatured/ConfirmedCasesDetails/Card.vue
+++ b/components/index/CardsFeatured/ConfirmedCasesDetails/Card.vue
@@ -47,10 +47,7 @@
             </li>
           </ul>
         </template>
-        <confirmed-cases-details-table
-          :aria-label="$t('検査陽性者の状況')"
-          v-bind="confirmedCases"
-        />
+        <confirmed-cases-details-table v-bind="confirmedCases" />
         <div>
           <app-link
             :class="$style.button"

--- a/components/index/CardsFeatured/InfectionSummary/Card.vue
+++ b/components/index/CardsFeatured/InfectionSummary/Card.vue
@@ -10,7 +10,6 @@
       >
         <section :class="$style.section">
           <infection-status
-            :aria-label="$t('患者の発生状況等')"
             :items="statuses"
             :date="formatDate(statisticDate)"
           />

--- a/components/index/CardsFeatured/MedicalCareSummary/Card.vue
+++ b/components/index/CardsFeatured/MedicalCareSummary/Card.vue
@@ -8,7 +8,7 @@
         title-id="medical-care-summary"
         :date="date"
       >
-        <medical-system :aria-label="$t('病床使用率等')" :items="statuses" />
+        <medical-system :items="statuses" />
         <div :class="$style.link">
           <v-icon color="#D9D9D9">{{ mdiChevronRight }}</v-icon>
           <app-link


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #7469 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 不要な `aria-label` を削除しました．

issueでは，

- https://stopcovid19.metro.tokyo.lg.jp/cards/medical-care-summary/
- https://stopcovid19.metro.tokyo.lg.jp/cards/infection-summary/

を対象としていましたが，

- https://stopcovid19.metro.tokyo.lg.jp/cards/details-of-confirmed-cases/

も見出しですでに読まれており不要な `aria-label` があると思いますので削除しました．確認の方お願いします．
