### PR TITLE
日付スライダーのthumb付近に実際の日付を表示する

### DIFF
--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -154,10 +154,10 @@ const options: ThisTypedComponentOptionsWithRecordProps<
     },
   },
   methods: {
-    getDateFormat(seconds: number) {
+    getDateFormat(seconds: number): string {
       return dayjs.unix(seconds).format('YYYY-MM-DD')
     },
-    getDisplayDate(seconds: number) {
+    getDisplayDate(seconds: number): string {
       const date = this.getDateFormat(seconds)
       return this.$d(dayjs(date).toDate(), 'date')
     },

--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -3,7 +3,15 @@
     <span id="date-range" class="range-slider-title">{{ $t('表示期間') }}</span>
     <div class="range-slider-container">
       <div class="range-slider-inner">
-        <label class="sr-only" :for="`start-${id}`">{{ $t('開始') }}</label>
+        <label
+          :for="`start-${id}`"
+          :style="{
+            transform: `translateX(${((start - min) / (max - min)) * 100}%)`,
+          }"
+          class="range-slider-inner-label label-start"
+        >
+          {{ getDateFormat(start) }}
+        </label>
         <input
           :id="`start-${id}`"
           v-model="start"
@@ -14,7 +22,15 @@
           :aria-valuetext="$t(`{date}から`, { date: getDisplayDate(start) })"
           @change="$emit('start-date', getDateFormat($event.target.value))"
         />
-        <label class="sr-only" :for="`end-${id}`">{{ $t('終了') }}</label>
+        <label
+          :for="`end-${id}`"
+          :style="{
+            transform: `translateX(${((end - min) / (max - min)) * 100}%)`,
+          }"
+          class="range-slider-inner-label label-end"
+        >
+          {{ getDateFormat(end) }}
+        </label>
         <input
           :id="`end-${id}`"
           v-model="end"
@@ -211,7 +227,7 @@ input[type='range'] {
 }
 
 .range-slider-title {
-  margin: 6px 12px 0 0;
+  margin: 23px 12px 0 0;
 
   @include font-size(14);
 }
@@ -227,7 +243,29 @@ input[type='range'] {
   position: relative;
   margin: 1em auto;
   width: 100%;
-  background: linear-gradient(0deg, $gray-4 $h, transparent 0);
+  background-image: linear-gradient(
+    0deg,
+    transparent 33%,
+    $gray-4 33%,
+    $gray-4 66%,
+    transparent 66%
+  );
+}
+
+.range-slider-inner-label {
+  position: relative;
+  grid-column: 1;
+  left: -5em;
+
+  @include font-size(12);
+
+  &.label-start {
+    grid-row: 1;
+  }
+
+  &.label-end {
+    grid-row: 3;
+  }
 }
 
 .range-slider-label {

--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -170,11 +170,6 @@ $h: 1.2rem;
   outline: 2px solid $focus;
 }
 
-.sr-only {
-  position: absolute;
-  clip-path: inset(50%);
-}
-
 input[type='range'] {
   &::-webkit-slider-runnable-track,
   &::-webkit-slider-thumb,

--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -62,14 +62,6 @@
           @change="$emit('end-date', getDateFormat($event.target.value))"
         />
       </div>
-      <div class="range-slider-label">
-        <output :for="`start-${id}`">
-          {{ $t(`{date}から`, { date: getDisplayDate(start) }) }}
-        </output>
-        <output :for="`end-${id}`">
-          {{ $t(`{date}まで`, { date: getDisplayDate(end) }) }}
-        </output>
-      </div>
     </div>
   </div>
 </template>
@@ -316,13 +308,5 @@ input[type='range'] {
   &.label-value-end {
     grid-row: 3;
   }
-}
-
-.range-slider-label {
-  display: flex;
-  justify-content: space-between;
-  margin: 10px 0;
-
-  @include font-size(14);
 }
 </style>

--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -10,8 +10,17 @@
           }"
           class="range-slider-inner-label label-start"
         >
-          {{ getDateFormat(start) }}
+          <span role="img" :aria-label="$t('開始日')">▶</span>
         </label>
+        <span
+          aria-hidden="true"
+          :style="{
+            transform: `translateX(${((start - min) / (max - min)) * 100}%)`,
+          }"
+          class="range-slider-inner-label-value label-value-start"
+        >
+          {{ getDisplayDate(start) }}
+        </span>
         <input
           :id="`start-${id}`"
           v-model="start"
@@ -20,7 +29,7 @@
           :min="min"
           :max="max"
           :step="step"
-          :aria-valuetext="$t(`{date}から`, { date: getDisplayDate(start) })"
+          :aria-valuetext="getDisplayDate(start)"
           @change="$emit('start-date', getDateFormat($event.target.value))"
         />
         <label
@@ -30,8 +39,17 @@
           }"
           class="range-slider-inner-label label-end"
         >
-          {{ getDateFormat(end) }}
+          <span role="img" :aria-label="$t('終了日')">◀</span>
         </label>
+        <span
+          aria-hidden="true"
+          :style="{
+            transform: `translateX(${((end - min) / (max - min)) * 100}%)`,
+          }"
+          class="range-slider-inner-label-value label-value-end"
+        >
+          {{ getDisplayDate(end) }}
+        </span>
         <input
           :id="`end-${id}`"
           v-model="end"
@@ -40,7 +58,7 @@
           :min="min"
           :max="max"
           :step="step"
-          :aria-valuetext="$t(`{date}まで`, { date: getDisplayDate(end) })"
+          :aria-valuetext="getDisplayDate(end)"
           @change="$emit('end-date', getDateFormat($event.target.value))"
         />
       </div>
@@ -269,17 +287,33 @@ input[type='range'] {
 }
 
 .range-slider-inner-label {
-  position: relative;
-  grid-column: 1;
-  left: -5em;
+  position: absolute;
+  width: 100%;
+  left: -7em;
 
   @include font-size(12);
 
   &.label-start {
-    grid-row: 1;
+    top: 0;
   }
 
   &.label-end {
+    bottom: 0;
+  }
+}
+
+.range-slider-inner-label-value {
+  position: relative;
+  grid-column: 1;
+  left: -6em;
+
+  @include font-size(12);
+
+  &.label-value-start {
+    grid-row: 1;
+  }
+
+  &.label-value-end {
     grid-row: 3;
   }
 }

--- a/components/index/_shared/DateRangeSlider.vue
+++ b/components/index/_shared/DateRangeSlider.vue
@@ -15,6 +15,7 @@
         <input
           :id="`start-${id}`"
           v-model="start"
+          class="input-range-start"
           type="range"
           :min="min"
           :max="max"
@@ -35,6 +36,7 @@
           :id="`end-${id}`"
           v-model="end"
           type="range"
+          class="input-range-end"
           :min="min"
           :max="max"
           :step="step"
@@ -181,14 +183,33 @@ input[type='range'] {
     outline: none;
   }
 
+  position: relative;
   grid-column: 1;
   grid-row: 2;
   margin: 0;
   background: none;
   color: $gray-1;
   font: inherit;
+  cursor: pointer;
   pointer-events: none;
   width: 100%;
+
+  &::after {
+    position: absolute;
+    display: block;
+    width: 100%;
+    height: 15px;
+    content: '';
+    pointer-events: auto;
+  }
+
+  &.input-range-start::after {
+    top: -15px;
+  }
+
+  &.input-range-end::after {
+    bottom: -15px;
+  }
 
   &::-webkit-slider-runnable-track {
     @include track;


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #7467 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 日付スライダーのthumb付近に実際の日付を表示するようにしました。
- thumbが近づいた時も重ならないように、ラベルを上下にふりました（とはいえやっぱり見た目厳しいですね...）。
- スライダーの両端に来た時にもはみ出ないようにしたので、ラベルの位置が少し左寄りになっています。

## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

![スクリーンショット 2022-09-11 10 29 29](https://user-images.githubusercontent.com/14883063/189507808-5de482de-f214-469c-b2af-2d0252d6cc81.png)

