### PR TITLE
rspec のテストコードをリニューアル後の挙動に追いつく

### DIFF
--- a/spec/feature/index_CardsFeatured_h3_spec.rb
+++ b/spec/feature/index_CardsFeatured_h3_spec.rb
@@ -17,7 +17,8 @@ describe 'page [/]', type: :feature do
           end
 
           it 'has h3' do
-            expect(find('.DataCard.InfectionMedicalCareSummaryCard > div > div > div.DataView-Header > h3').text).to match /#{t(lang, '{date}の状況').gsub('{date}', '')}/
+            expect(find('.DataCard.MedicalCareSummaryCard > div > div > div.DataView-Header > h3').text).to match /#{t(lang, '{date}の病床使用率等').gsub('{date}', '')}/
+            expect(find('.DataCard.InfectionSummaryCard > div > div > div.DataView-Header > h3').text).to match /#{t(lang, '{date}の患者の発生状況等').gsub('{date}', '')}/
             expect(find('.DataCard.ConfirmedCasesDetailsCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '検査陽性者の状況')
             expect(find('.DataCard.MonitoringItemsOverviewCard > div > div > div.DataView-Header > h3').text).to eq t(lang, 'モニタリング項目')
             expect(find('.DataCard.MonitoringCommentCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '感染状況・医療提供体制の分析')

--- a/spec/feature/index_CardsFeatured_h3_spec.rb
+++ b/spec/feature/index_CardsFeatured_h3_spec.rb
@@ -21,7 +21,7 @@ describe 'page [/]', type: :feature do
             expect(find('.DataCard.ConfirmedCasesDetailsCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '検査陽性者の状況')
             expect(find('.DataCard.MonitoringItemsOverviewCard > div > div > div.DataView-Header > h3').text).to eq t(lang, 'モニタリング項目')
             expect(find('.DataCard.MonitoringCommentCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '感染状況・医療提供体制の分析')
-            expect(find('.DataCard.VaccinationCard > div > div > div.DataView-Header > h3').text).to eq t(lang, 'ワクチン接種数（累計）')
+            expect(find('.DataCard.VaccinationCard > div > div > div.DataView-Header > h3').text).to eq t(lang, 'ワクチン接種数及び接種率（都内全人口・累計）')
             expect(find('.DataCard.ConfirmedCasesNumberCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '報告日別による陽性者数の推移')
             expect(find('.DataCard.TestedNumberCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '検査実施件数')
             expect(find('.DataCard.TokyoFeverConsultationCenterReportsNumberCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '東京都発熱相談センターにおける相談件数')

--- a/spec/feature/index_CardsReference_DataViewExpantionPanel_spec.rb
+++ b/spec/feature/index_CardsReference_DataViewExpantionPanel_spec.rb
@@ -7,7 +7,6 @@ card_classes = [
   '.DataCard.PositiveNumberByDevelopedDateCard',
   '.DataCard.PositiveNumberByDiagnosedDateCard',
   '.DataCard.DeathsByDeathDateCard',
-  '.DataCard.VariantCard',
   '.DataCard.MetroCard',
   '.DataCard.AgencyCard',
 ]

--- a/spec/feature/index_CardsReference_DataViewExpantionPanel_spec.rb
+++ b/spec/feature/index_CardsReference_DataViewExpantionPanel_spec.rb
@@ -3,9 +3,9 @@
 require 'spec_helper'
 
 card_classes = [
-  '.DataCard.PositiveNumberOver65Card',
   '.DataCard.PositiveNumberByDevelopedDateCard',
   '.DataCard.PositiveNumberByDiagnosedDateCard',
+  '.DataCard.PositiveNumberOver65Card',
   '.DataCard.DeathsByDeathDateCard',
   '.DataCard.MetroCard',
   '.DataCard.AgencyCard',

--- a/spec/feature/index_CardsReference_h3_spec.rb
+++ b/spec/feature/index_CardsReference_h3_spec.rb
@@ -19,9 +19,9 @@ describe 'page [/]', type: :feature do
           it 'has h3' do
             expect(find('.DataCard.ConfirmedCasesAttributesCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '陽性者の属性')
             expect(find('.DataCard.ConfirmedCasesByMunicipalitiesCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '陽性者数（区市町村別）')
-            expect(find('.DataCard.PositiveNumberOver65Card > div > div > div.DataView-Header > h3').text).to eq t(lang, '報告日別による陽性者数（65歳以上）の推移')
             expect(find('.DataCard.PositiveNumberByDevelopedDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '発症日別による陽性者数の推移')
             expect(find('.DataCard.PositiveNumberByDiagnosedDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '確定日別による陽性者数の推移')
+            expect(find('.DataCard.PositiveNumberOver65Card > div > div > div.DataView-Header > h3').text).to eq t(lang, '報告日別による陽性者数（65歳以上）の推移').strip
             expect(find('.DataCard.DeathsByDeathDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '死亡日別による死亡者数の推移')
             expect(find('.DataCard.MetroCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '都営地下鉄の利用者数の推移')
             expect(find('.DataCard.AgencyCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '都庁来庁者数の推移')

--- a/spec/feature/index_CardsReference_h3_spec.rb
+++ b/spec/feature/index_CardsReference_h3_spec.rb
@@ -23,7 +23,6 @@ describe 'page [/]', type: :feature do
             expect(find('.DataCard.PositiveNumberByDevelopedDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '発症日別による陽性者数の推移')
             expect(find('.DataCard.PositiveNumberByDiagnosedDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '確定日別による陽性者数の推移')
             expect(find('.DataCard.DeathsByDeathDateCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '死亡日別による死亡者数の推移')
-            expect(find('.DataCard.VariantCard > div > div > div.DataView-Header > h3').text).to eq t(lang, 'L452R変異株スクリーニングの実施状況')
             expect(find('.DataCard.MetroCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '都営地下鉄の利用者数の推移')
             expect(find('.DataCard.AgencyCard > div > div > div.DataView-Header > h3').text).to eq t(lang, '都庁来庁者数の推移')
           end

--- a/spec/feature/index_SiteTopUpper_h3_spec.rb
+++ b/spec/feature/index_SiteTopUpper_h3_spec.rb
@@ -14,7 +14,7 @@ describe 'page [/]', type: :feature do
         context 'SiteTopUpper' do
           it 'has h3' do
             expect(find('.WhatsNew h3.WhatsNew-title').text).to eq t(lang, '最新のお知らせ')
-            expect(find('.StayingPopulation h3.StayingPopulation-heading').text).to eq t(lang, '都内の滞在人口の増減状況（毎週月曜日更新）')
+            expect(find('.StayingPopulation h3.StayingPopulation-heading').text).to eq t(lang, '都内の滞在人口の増減状況（毎週月曜日更新）').strip
             expect(find('.ConsultationWrap h3.StaticInfo-Text').text).to eq t(lang, 'ワクチン情報・変異株情報・検査情報等の新型コロナ関連情報はこちら')
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ Capybara.register_driver :emulated_chrome_ios do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument('--headless')
   options.add_argument('--disable-gpu')
-  options.add_emulation(device_name: 'iPhone 6/7/8')
+  options.add_emulation(device_name: 'iPhone SE')
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
                                  options: options)


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #7489 

## ⛏ 変更内容 / Details of Changes
- https://github.com/tokyo-metropolitan-gov/covid19/pull/7057 に対応するrspec内容に修正
- `L452R変異株スクリーニングの実施状況` のテストを削除
- `本日のサマリ2カード化` に対応するテストを追加
- `ワクチン接種数及び接種率のh3変更` に対応するテストを追加
