### PR TITLE
`::v-deep` に関する警告が出力されないようにする

### DIFF
--- a/components/_shared/SideNavigation/MenuListContents.vue
+++ b/components/_shared/SideNavigation/MenuListContents.vue
@@ -135,7 +135,7 @@ export default Vue.extend({
   }
 }
 
-.MenuList ::v-deep .ExternalLinkIcon {
+.MenuList ::v-deep(.ExternalLinkIcon) {
   margin-left: 5px;
   color: $gray-3;
 

--- a/pages/sitemap.vue
+++ b/pages/sitemap.vue
@@ -182,7 +182,7 @@ export default Vue.extend<Data, Methods, Computed, Props>({
   display: flex;
   color: $green-1;
 
-  ::v-deep .v-icon {
+  ::v-deep(.v-icon) {
     color: $green-1;
   }
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #7478 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- `yarn dev` 時に出力される `v-deep` 関連の警告を修正しました。
- コンソール通りの修正（ `::deep` にする ）をするとissueでは書いたのですが、Vue2ではdeepを用いることが無理そうなので `v-deep` の状態で修正しました。

## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->

| 修正前 | 修正後 |
| :--: | :--:|
| <img width="822" alt="スクリーンショット 2022-09-10 17 01 38" src="https://user-images.githubusercontent.com/37988559/189474786-c2bcaa10-d2ec-4162-acee-4b5c399a3369.png"> | ![スクリーンショット 2022-09-19 20 31 26](https://user-images.githubusercontent.com/37988559/191008011-aba1cfd9-eed3-40d6-9c0d-be4303c53af6.png) |