### PR TITLE
新規陽性者における接触歴等不明者数のデータは2022年9月26日まででフィルタリングする

### DIFF
--- a/components/index/CardsMonitoring/UntrackedRate/Card.vue
+++ b/components/index/CardsMonitoring/UntrackedRate/Card.vue
@@ -98,6 +98,7 @@ type Computed = {
 type Props = {}
 
 const firstDiagnosedDate = new Date('2020-03-27')
+const lastDiagnosedDate = new Date('2022-09-26')
 
 export default Vue.extend<Data, Methods, Computed, Props>({
   components: {
@@ -165,7 +166,9 @@ export default Vue.extend<Data, Methods, Computed, Props>({
     },
     filteredDailyPositiveDetailData() {
       return this.dailyPositiveDetail.data.filter(
-        (d) => new Date(d.diagnosedDate) >= firstDiagnosedDate
+        (d) =>
+          new Date(d.diagnosedDate) >= firstDiagnosedDate &&
+          new Date(d.diagnosedDate) <= lastDiagnosedDate
       )
     },
     dailyPositiveDetail() {


### PR DESCRIPTION
## 📝 関連する issue / Related Issues

- #7510 
- #7517 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 現「モニタリング項目(3)」は `data/daily_positive_detail.json` を「報告日陽性者数」「モニタリング項目(1)」と共有しているが、「モニタリング項目(3)」だけは2022年9月26日でストップさせたいので、日付をフィルタリングしました。

## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
