### PR TITLE
年代別新規陽性者数のオープンデータリンク先URL追加

### DIFF
--- a/components/index/CardsFeatured/PositiveNumberByAge/Card.vue
+++ b/components/index/CardsFeatured/PositiveNumberByAge/Card.vue
@@ -18,7 +18,7 @@
         :table-labels="labels"
         :date-labels="dateLabels"
         :display-values="displayValues"
-        :url="''"
+        :url="'https://catalog.data.metro.tokyo.lg.jp/dataset/t000010d0000000103'"
         :day-period="isSingleCard ? 120 : 60"
         :is-single-card="isSingleCard"
       >


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues

- close #7617 

## ⛏ 変更内容 / Details of Changes

<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- 年代別新規陽性者数のカードにオープンデータリンク先URLを追加しました。

## 📸 スクリーンショット / Screenshots

<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![スクリーンショット 2022-10-31 13 28 35](https://user-images.githubusercontent.com/37988559/198931216-18944a5e-0b98-442d-81c1-75ca496d2c9b.png)

